### PR TITLE
Remove exclusion of the ValidVariableName Sniff.

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -42,11 +42,6 @@
 		</properties>
 	</rule>
 
-	<rule ref="WordPress.NamingConventions">
-		<!-- complains about core cat_ID -->
-		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
-	</rule>
-
 	<!-- Rules from WP-Extra which are not in WP-VIP -->
 	<rule ref="WordPress.PHP.DiscouragedFunctions"/>
 	<rule ref="WordPress.WP.EnqueuedResources" />


### PR DESCRIPTION
This sniff was excluded because it complained about the WP core `$cat_ID` variable. This was however fixed in WPCS 0.10.0.

See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/551