### PR TITLE
Remove a redundant exclusion.

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -97,8 +97,6 @@
 	<rule ref="WordPress-Docs">
 		<!-- Catches way too many things, like vars and file headers. -->
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
-		<!-- PHP 7 -->
-		<exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing" />
 	</rule>
 
 	<!-- exclude the 'empty' index files from some documentation checks -->


### PR DESCRIPTION
This error message has already been excluded upstream in WPCS 0.10.0 and as the minimum WPCS requirement for Yoast CS is WPCS 0.10.0, the exclusion in the proprietary ruleset can be removed.

Ref upstream: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/552