### PR TITLE
:rocket: Fix travis unit test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,15 @@ matrix:
 
 before_script:
     - export PHPCS_DIR=/tmp/phpcs
+    - export PHPUNIT_DIR=/tmp/phpunit
     - export PHPCS_BIN=$(if [[ $PHPCS_BRANCH == 3.0 ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - $PHPCS_BIN --config-set installed_paths $(pwd)
+    # Download PHPUnit 5.x for builds on PHP 7 and nightly as
+    # PHPCS test suite is currently not compatible with PHPUnit 6.x.
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-5.7.phar && chmod +x $PHPUNIT_DIR/phpunit-5.7.phar; fi
 
 script:
     - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
-    - phpunit --filter Yoast /tmp/phpcs/tests/AllTests.php
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then phpunit --filter Yoast /tmp/phpcs/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then php $PHPUNIT_DIR/phpunit-5.7.phar --filter Yoast /tmp/phpcs/tests/AllTests.php; fi


### PR DESCRIPTION
The Travis PHP images for PHP 7+ have started to use PHPUnit 6, while the PHPCS testsuite is not yet compatible with that.

This commit is intended (fingers crossed) as a temporary solution to be reverted once the testsuite for PHPCS is cross-version compatible with PHPUnit. See https://github.com/squizlabs/PHP_CodeSniffer/pull/1384

I've chosen to only download PHPUnit when a different version is needed than the one installed by default in the Travis images to keep the build time down.