### PR TITLE
:rocket: Up the minimum PHPCS version to 2.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ php:
 
 env:
   - PHPCS_BRANCH=master
-  - PHPCS_BRANCH=2.7.1
+  - PHPCS_BRANCH=2.8.1
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"issues": "https://github.com/Yoast/yoastcs/issues"
 	},
 	"require": {
-		"squizlabs/php_codesniffer": "~2.7.0",
+		"squizlabs/php_codesniffer": "~2.8.1",
 		"wp-coding-standards/wpcs": "~0.10.0",
 		"phpmd/phpmd": "^2.2.3"
 	},


### PR DESCRIPTION
PHPCS 2.8.1 has been released nearly three weeks ago and contains a fix for a security vulnerability.

The YoastCS library is technically not vulnerable as it currently uses the `WordPress-VIP` ruleset, not `WordPress-Extra` or `WordPress` (which both contain the `Generic.PHP.Syntax` sniff), though a user might select to use the `diff` report which opens them up to the vulnerability.


From the release notes:
> This release contains a fix for a security advisory related to the improper handling of shell commands
>     * Uses of shell_exec() and exec() were not escaping filenames and configuration settings in most cases
>     * A properly crafted filename or configuration option would allow for arbitrary code execution when using some features
>     * All users are encouraged to upgrade to this version, especially if you are checking 3rd-party code
>           * e.g., you run PHPCS over libraries that you did not write
>           * e.g., you provide a web service that runs PHPCS over user-uploaded files or 3rd-party repositories
>           * e.g., you allow external tool paths to be set by user-defined values
>     * If you are unable to upgrade but you check 3rd-party code, ensure you are not using the following features:
>           * The diff report
>           * The notify-send report
>           * The Generic.PHP.Syntax sniff
>           * The Generic.Debug.CSSLint sniff
>           * The Generic.Debug.ClosureLinter sniff
>           * The Generic.Debug.JSHint sniff
>           * The Squiz.Debug.JSLint sniff
>           * The Squiz.Debug.JavaScriptLint sniff
>           * The Zend.Debug.CodeAnalyzer sniff
>     * Thanks to Klaus Purer for the report