### PR TITLE
:rocket: Minor travis script tweak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     # Allow failures for unstable builds.
     - env: PHPCS_BRANCH=3.0
 
-before_script:
+before_install:
     - export PHPCS_DIR=/tmp/phpcs
     - export PHPUNIT_DIR=/tmp/phpunit
     - export PHPCS_BIN=$(if [[ $PHPCS_BRANCH == 3.0 ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)


### PR DESCRIPTION
Run the setup in `before_install` instead of `before_script` to report failures in the setup as build `errored` instead of `failed`.

This is important as it determines there was an issue setting up your environment rather than the code you are testing against.