### PR TITLE
Exclude the PHP linting sniff

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -6,6 +6,10 @@
 	<rule ref="WordPress">
 		<exclude name="Generic.Files.LineEndings.InvalidEOLChar" />
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" />
+
+		<!-- No need for this sniff as every Yoast travis script includes linting all files. -->
+		<exclude name="Generic.PHP.Syntax" />
+
 		<!-- Some calls just too quirky and complicated for this. -->
 		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
 


### PR DESCRIPTION
I was running some tests and noticed this sniff making the PHPCS run very slow.
This sniff is newly included as it is contained in the `WordPress-Extra` ruleset which wasn't included previously.

As all Yoast repos contain a travis script which does linting on all PHP versions anyway, there is no need to have this sniff active, so excluding it.
