### PR TITLE
Enable rule which was previously turned off

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -82,8 +82,11 @@
 	</rule>
 
 	<!-- Application memory use! -->
-    <!-- Temporarily disabled to discuss, see https://github.com/Yoast/yoastcs/issues/4 R. -->
-	<!--<rule ref="Generic.Strings.UnnecessaryStringConcat" />-->
+	<rule ref="Generic.Strings.UnnecessaryStringConcat">
+		<properties>
+			<property name="allowMultiline" value="true" />
+		</properties>
+	</rule>
 
 	<!-- Error prevention: Make sure the condition in a inline if declaration is bracketed -->
 	<rule ref="Squiz.ControlStructures.InlineIfDeclaration" />


### PR DESCRIPTION
~~The `Generic.Strings.UnnecessaryStringConcat` sniff was mentioned in the ruleset file already as "not turned on" with a reason.~~
~~As this sniff is included in the `WordPress-Extra` ruleset, it was now accidentally turned on anyway.~~

~~This fixes that.~~

The reason the rule was turned off was that it gave problems with concatenation across multiple lines.
Turns out there is a property which can be set to selectively turn the rule off when the string is multiline.

Problem solved ;-)
