### PR TITLE
 	Lint the XML files as part of the build testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language:
 
 dist: trusty
 
+cache:
+    apt: true
+
 php:
     - 5.4
     - 5.5
@@ -32,7 +35,11 @@ matrix:
       env: PHPCS_BRANCH=2.8.1
     - php: 5.3
       dist: precise
-      env: PHPCS_BRANCH=2.9
+      env: PHPCS_BRANCH=2.9 SNIFF=1
+      addons:
+          apt:
+              packages:
+                - libxml2-utils
     - php: 5.3
       dist: precise
       env: PHPCS_BRANCH=2.8.1
@@ -47,6 +54,7 @@ matrix:
     - php: nightly
 
 before_install:
+    - export XMLLINT_INDENT="	"
     - export PHPCS_DIR=/tmp/phpcs
     - export PHPUNIT_DIR=/tmp/phpunit
     - export PHPCS_BIN=$(if [[ ${PHPCS_BRANCH:0:2} != "2." ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
@@ -60,3 +68,10 @@ script:
     - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
     - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then phpunit --filter Yoast /tmp/phpcs/tests/AllTests.php; fi
     - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then php $PHPUNIT_DIR/phpunit-5.7.phar --filter Yoast /tmp/phpcs/tests/AllTests.php; fi
+    # Validate the xml files.
+    # @link http://xmlsoft.org/xmllint.html
+    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./Yoast/ruleset.xml; fi
+    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./phpmd.xml; fi
+    # Check the code-style consistency of the xml files.
+    - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./Yoast/ruleset.xml <(xmllint --format "./Yoast/ruleset.xml"); fi
+    - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./phpmd.xml <(xmllint --format "./phpmd.xml"); fi

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -2,23 +2,24 @@
 <ruleset name="WordPress Yoast">
 	<description>Yoast Coding Standards</description>
 
-    <!-- ##### WordPress sniffs #####-->
+	<!-- ##### WordPress sniffs #####-->
 	<rule ref="WordPress">
-		<exclude name="Generic.Files.LineEndings.InvalidEOLChar" />
-		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" />
+		<exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
+		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>
 
 		<!-- No need for this sniff as every Yoast travis script includes linting all files. -->
-		<exclude name="Generic.PHP.Syntax" />
+		<exclude name="Generic.PHP.Syntax"/>
 
 		<!-- Some calls just too quirky and complicated for this. -->
-		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.Indent"/>
 
 		<!-- WP VIP rules which are very restrictive and not all that applicable as WPSEO is not on VIP -->
-		<exclude name="WordPress.VIP.DirectDatabaseQuery" />
+		<exclude name="WordPress.VIP.DirectDatabaseQuery"/>
 		<exclude name="WordPress.VIP.FileSystemWritesDisallow"/>
 
 		<!-- We should probably want to turn the below rules on, but these give issues with the current code base. -->
-		<exclude name="WordPress.XSS.EscapeOutput" /><!-- This sniff also has known & reported bugs -->
+		<!-- This sniff also has known & reported bugs -->
+		<exclude name="WordPress.XSS.EscapeOutput"/>
 
 		<!-- Demanding Yoda conditions is stupid. -->
 		<exclude name="WordPress.PHP.YodaConditions"/>
@@ -28,29 +29,30 @@
 
 		<!-- Turned off because of known & reported bugs in the Sniffs, should be turned on once the bugs are fixed. -->
 		<!-- Exclusion can be removed once the WPCS 0.11.0 has been released - in which the bugs have been fixed -
-		     and the the minimum WPCS version required by Yoast CS has been upped to 0.11.0. -->
-		<exclude name="WordPress.Variables.GlobalVariables"/><!-- WPCS #300 -->
+		     and the minimum WPCS version required by Yoast CS has been upped to 0.11.0. -->
+		<!-- WPCS #300 -->
+		<exclude name="WordPress.Variables.GlobalVariables"/>
 
 		<!-- Catches way too many things, like vars and file headers. -->
-		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
 	</rule>
 
 	<!-- Adjust some WP VIP rules which are very restrictive and not all that applicable as WPSEO is not on VIP -->
 	<rule ref="WordPress.VIP.RestrictedFunctions">
 		<properties>
-			<property name="exclude" value="user_meta,switch_to_blog,wp_remote_get,file_get_contents,curl,get_term_link,get_term_by,count_user_posts,get_pages,error_log,runtime_configuration,prevent_path_disclosure,url_to_postid" />
+			<property name="exclude" value="user_meta,switch_to_blog,wp_remote_get,file_get_contents,curl,get_term_link,get_term_by,count_user_posts,get_pages,error_log,runtime_configuration,prevent_path_disclosure,url_to_postid"/>
 		</properties>
 	</rule>
 
 	<rule ref="WordPress.VIP.RestrictedVariables">
 		<properties>
-			<property name="exclude" value="user_meta,cache_constraints" />
+			<property name="exclude" value="user_meta,cache_constraints"/>
 		</properties>
 	</rule>
 
 	<rule ref="WordPress.VIP.PostsPerPage">
 		<properties>
-			<property name="exclude" value="posts_per_page" />
+			<property name="exclude" value="posts_per_page"/>
 		</properties>
 	</rule>
 
@@ -88,15 +90,15 @@
 	<!-- Application memory use! -->
 	<rule ref="Generic.Strings.UnnecessaryStringConcat">
 		<properties>
-			<property name="allowMultiline" value="true" />
+			<property name="allowMultiline" value="true"/>
 		</properties>
 	</rule>
 
 	<!-- Error prevention: Make sure the condition in a inline if declaration is bracketed -->
-	<rule ref="Squiz.ControlStructures.InlineIfDeclaration" />
+	<rule ref="Squiz.ControlStructures.InlineIfDeclaration"/>
 
 	<!-- Error prevention: Make sure arithmetics are bracketed -->
-	<rule ref="Squiz.Formatting.OperatorBracket.MissingBrackets" />
+	<rule ref="Squiz.Formatting.OperatorBracket.MissingBrackets"/>
 
 	<!-- Should be turned on, but gives issue with current codebase -->
 	<!--<rule ref="Generic.CodeAnalysis.EmptyStatement" />-->

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,40 +1,37 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Yoast"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+<ruleset xmlns="http://pmd.sf.net/ruleset/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Yoast" xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd" xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+
 	<description>Yoast Standards</description>
 
 	<rule ref="rulesets/cleancode.xml">
 
 		<!-- used all over -->
-		<exclude name="BooleanArgumentFlag" />
+		<exclude name="BooleanArgumentFlag"/>
 
 		<!-- in lack of real namespacing -->
-		<exclude name="StaticAccess" />
+		<exclude name="StaticAccess"/>
 	</rule>
 
-	<rule ref="rulesets/codesize.xml" />
+	<rule ref="rulesets/codesize.xml"/>
 
 	<rule ref="rulesets/design.xml">
 
 		<!-- normal in WP for redirects, etc -->
-		<exclude name="ExitExpression" />
+		<exclude name="ExitExpression"/>
 	</rule>
 
 	<rule ref="rulesets/naming.xml/ShortVariable">
 		<properties>
 
 			<!-- common in WP -->
-			<property name="exceptions" value="id,wp" />
+			<property name="exceptions" value="id,wp"/>
 		</properties>
 	</rule>
 
-	<rule ref="rulesets/naming.xml/LongVariable" />
-	<rule ref="rulesets/naming.xml/ShortMethodName" />
-	<rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass" />
-	<rule ref="rulesets/naming.xml/ConstantNamingConventions" />
-	<rule ref="rulesets/naming.xml/BooleanGetMethodName" />
+	<rule ref="rulesets/naming.xml/LongVariable"/>
+	<rule ref="rulesets/naming.xml/ShortMethodName"/>
+	<rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/>
+	<rule ref="rulesets/naming.xml/ConstantNamingConventions"/>
+	<rule ref="rulesets/naming.xml/BooleanGetMethodName"/>
 
 </ruleset>


### PR DESCRIPTION
Checks the syntax of XML files + the layout.
In line with WP, tabs are specified to be used for indentation, not spaces.

I've chosen to run this during one of the PHP 5.3 builds so as not to have to split off another PHP version from the main matrix. The PHP version should have no effect on the results anyhow, so this should be fine.

Includes fixing existing layout issues in the XML files.