### PR TITLE
Remove `conflict` directive from `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,6 @@
 		"wp-coding-standards/wpcs": "~0.10.0",
 		"phpmd/phpmd": "^2.2.3"
 	},
-	"conflict": {
-		"squizlabs/php_codesniffer": "2.3.1"
-	},
 	"scripts": {
 		"config-set" : [
 			"\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../../vendor/wp-coding-standards/wpcs",


### PR DESCRIPTION
The minimum required PHPCS version > the conflict version, so this conflict will never happen.