### PR TITLE
Set the type for Composer to `phpcodesniffer-standard`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 			"homepage": "https://yoast.com"
 		}
 	],
+	"type" : "phpcodesniffer-standard",
 	"support": {
 		"issues": "https://github.com/Yoast/yoastcs/issues"
 	},


### PR DESCRIPTION
This provides compatibility with several Composer plugins which can sort out the PHPCS `installed_paths` config.

Ref:
* https://github.com/DealerDirect/phpcodesniffer-composer-installer/wiki/Change-%60composer.json%60-%22type%22-to-%60phpcodesniffer-standard%60