### PR TITLE
Re-enable PHPCompatibility sniffs.

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -57,10 +57,8 @@
 	</rule>
 
 	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->
-	<!-- Currently disabled because it does not play nice with Composer.
-	     This is being worked on in https://github.com/wimg/PHPCompatibility/issues/102 -->
-	<!--<config name="testVersion" value="5.2-99.0"/>-->
-	<!--<rule ref="PHPCompatibility"/>-->
+	<config name="testVersion" value="5.2-99.0"/>
+	<rule ref="PHPCompatibility"/>
 
 	<rule ref="Squiz.ControlStructures">
 		<!-- Prevent errors for Spaces after closing braces, as we want a newline -->

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 	"require": {
 		"squizlabs/php_codesniffer": "~2.8.1",
 		"wp-coding-standards/wpcs": "~0.10.0",
+		"wimg/php-compatibility": "^8.0.0",
 		"phpmd/phpmd": "^2.2.3"
 	},
 	"suggest" : {
@@ -28,7 +29,7 @@
 	},
 	"scripts": {
 		"config-set" : [
-			"\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../../vendor/wp-coding-standards/wpcs",
+			"\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../../vendor/wp-coding-standards/wpcs,../../../vendor/wimg/php-compatibility",
 			"\"vendor/bin/phpcs\" --config-set default_standard Yoast"
 		],
 		"post-install-cmd": "composer config-set",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "681003d6ae7b87ffdc48f9246ca05a08",
+    "content-hash": "2356e06e55615278f1744bbd48d76279",
     "packages": [
         {
             "name": "pdepend/pdepend",
@@ -357,6 +357,58 @@
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
             "time": "2017-03-06T19:30:27+00:00"
+        },
+        {
+            "name": "wimg/php-compatibility",
+            "version": "8.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wimg/PHPCompatibility.git",
+                "reference": "4c4385fb891dff0501009670f988d4fe36785249"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4c4385fb891dff0501009670f988d4fe36785249",
+                "reference": "4c4385fb891dff0501009670f988d4fe36785249",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.2 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "PHPCompatibility\\": "PHPCompatibility/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-08-07T19:39:05+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",


### PR DESCRIPTION
Rationale:
* PHPCompatibility now runs on PHPCS 2.x without problems (and has been doing so for quite a long time).
* PHPCompatibility issues with Composer have been solved with the release of v 8.0.0.
* PHPCompatibility 8.0.0 also brings cross-version compatibility with PHPCS 3.x so won't hold YoastCS back when it wants to upgrade.

Additionally:
* Set `testVersion` to receive any messages relevant for PHP 5.2+.
* The `DealerDirect` composer plugin which has previously been added as a suggestion for projects including YoastCS should sort out the `installed_paths` config setting for PHPCS instead of doing this via a script in projects using YoastCS.

Fixes issue #15

- [x] Run `composer install` and refresh `composer.lock` file