### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for YoastCS using Composer, use `--prefer-source`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.travis.yml export-ignore
+/Yoast/Tests export-ignore


### PR DESCRIPTION
This PR adds a `.gitattributes` file to keep the archives GH creates of the repo clean of development related files.
People using Composer can still get these files in their setup if they really want to, by using `--prefer-source`.

Refs:
* [Reddit: I don't need your tests in my production](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production)
* [Blog: I don't need your tests in my production](https://blog.madewithlove.be/post/gitattributes/)