### PR TITLE
PHPCS Ruleset: remove a number of exclusions and one individual sniff inclusion

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -4,7 +4,6 @@
 
 	<!-- ##### WordPress sniffs #####-->
 	<rule ref="WordPress">
-		<exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>
 
 		<!-- No need for this sniff as every Yoast travis script includes linting all files. -->

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -64,9 +64,6 @@
 	<!-- Error prevention: Make sure arithmetics are bracketed -->
 	<rule ref="Squiz.Formatting.OperatorBracket.MissingBrackets"/>
 
-	<!-- Should be turned on, but gives issue with current codebase -->
-	<!--<rule ref="Generic.CodeAnalysis.EmptyStatement" />-->
-
 	<!-- ##### Documentation Sniffs vs empty index files ##### -->
 
 	<!-- exclude the 'empty' index files from some documentation checks -->

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -13,47 +13,14 @@
 		<!-- Some calls just too quirky and complicated for this. -->
 		<exclude name="PEAR.Functions.FunctionCallSignature.Indent"/>
 
-		<!-- WP VIP rules which are very restrictive and not all that applicable as WPSEO is not on VIP -->
-		<exclude name="WordPress.VIP.DirectDatabaseQuery"/>
-		<exclude name="WordPress.VIP.FileSystemWritesDisallow"/>
-
-		<!-- We should probably want to turn the below rules on, but these give issues with the current code base. -->
-		<!-- This sniff also has known & reported bugs -->
-		<exclude name="WordPress.XSS.EscapeOutput"/>
-
 		<!-- Demanding Yoda conditions is stupid. -->
 		<exclude name="WordPress.PHP.YodaConditions"/>
-
-		<!-- Turned off because of known & reported bugs in the Sniffs, should be turned on once the bugs are fixed. -->
-		<exclude name="WordPress.VIP.ValidatedSanitizedInput"/>
 
 		<!-- Turned off because of known & reported bugs in the Sniffs, should be turned on once the bugs are fixed. -->
 		<!-- Exclusion can be removed once the WPCS 0.11.0 has been released - in which the bugs have been fixed -
 		     and the minimum WPCS version required by Yoast CS has been upped to 0.11.0. -->
 		<!-- WPCS #300 -->
 		<exclude name="WordPress.Variables.GlobalVariables"/>
-
-		<!-- Catches way too many things, like vars and file headers. -->
-		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
-	</rule>
-
-	<!-- Adjust some WP VIP rules which are very restrictive and not all that applicable as WPSEO is not on VIP -->
-	<rule ref="WordPress.VIP.RestrictedFunctions">
-		<properties>
-			<property name="exclude" value="user_meta,switch_to_blog,wp_remote_get,file_get_contents,curl,get_term_link,get_term_by,count_user_posts,get_pages,error_log,runtime_configuration,prevent_path_disclosure,url_to_postid"/>
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.VIP.RestrictedVariables">
-		<properties>
-			<property name="exclude" value="user_meta,cache_constraints"/>
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.VIP.PostsPerPage">
-		<properties>
-			<property name="exclude" value="posts_per_page"/>
-		</properties>
 	</rule>
 
 	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->


### PR DESCRIPTION
These exclusions fall into two categories:
* Too specific for the YoastCS ruleset - should be set in the plugin specific rulesets instead.
* Shouldn't have been excluded in the first place.

Additional removing one sniff inclusion for a sniff which has been included in WPCS since 0.5.0 and therefore doesn't need to be double included.