### PR TITLE
Update YoastCS to PHPCS 3.x/WPCS 0.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,57 +18,36 @@ php:
     - nightly
 
 env:
-  # Test against the highest supported PHPCS version (2.x dev).
-  # This can be changed back to "master" once PHPCS 3.x is supported. See issue #36
-  - PHPCS_BRANCH=2.9
-  # Test against the lowest supported PHPCS 2.x version.
-  - PHPCS_BRANCH=2.8.1
+  # Test against the highest supported PHPCS version.
+  - PHPCS_BRANCH=master
+  # Test against the lowest supported PHPCS version.
+  - PHPCS_BRANCH=3.1.1
 
 matrix:
   fast_finish: true
   include:
-    # PHP 5.2/5.3 need precise.
-    - php: 5.2
-      dist: precise
-      env: PHPCS_BRANCH=2.9
-    - php: 5.2
-      dist: precise
-      env: PHPCS_BRANCH=2.8.1
-    - php: 5.3
-      dist: precise
-      env: PHPCS_BRANCH=2.9 SNIFF=1
+    # Extra build to check for XML codestyle.
+    - php: 7.1
+      env: PHPCS_BRANCH=master SNIFF=1
       addons:
           apt:
               packages:
                 - libxml2-utils
-    - php: 5.3
-      dist: precise
-      env: PHPCS_BRANCH=2.8.1
-
-    # Run against PHPCS 3.x. I just picked to run it against 5.6.
-    - php: 5.6
-      env: PHPCS_BRANCH=master
 
   allow_failures:
     # Allow failures for unstable builds.
-    - env: PHPCS_BRANCH=master
     - php: nightly
 
 before_install:
     - export XMLLINT_INDENT="	"
     - export PHPCS_DIR=/tmp/phpcs
-    - export PHPUNIT_DIR=/tmp/phpunit
-    - export PHPCS_BIN=$(if [[ ${PHPCS_BRANCH:0:2} != "2." ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
+    - export PHPCS_BIN=$PHPCS_DIR/bin/phpcs
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - $PHPCS_BIN --config-set installed_paths $(pwd)
-    # Download PHPUnit 5.x for builds on PHP 7 and nightly as
-    # PHPCS test suite is currently not compatible with PHPUnit 6.x.
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-5.7.phar && chmod +x $PHPUNIT_DIR/phpunit-5.7.phar; fi
 
 script:
     - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then phpunit --filter Yoast /tmp/phpcs/tests/AllTests.php; fi
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then php $PHPUNIT_DIR/phpunit-5.7.phar --filter Yoast /tmp/phpcs/tests/AllTests.php; fi
+    - phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
     # Validate the xml files.
     # @link http://xmlsoft.org/xmllint.html
     - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./Yoast/ruleset.xml; fi

--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -1,20 +1,27 @@
 <?php
 /**
- * Yoast_Sniffs_ControlStructures_WpseoIfElseDeclarationSniff.
+ * YoastCS\Yoast\Sniffs\ControlStructures\IfElseDeclarationSniff.
  *
- * PHP version 5
- *
- * @author    Juliette Reinders Folmer
+ * @package Yoast\YoastCS
+ * @author  Juliette Reinders Folmer
+ * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace YoastCS\Yoast\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
- * Yoast_Sniffs_ControlStructures_WpseoIfElseDeclarationSniff.
- *
  * Verifies that else statements are on a new line.
  *
- * @author    Juliette Reinders Folmer
+ * @package Yoast\YoastCS
+ * @author  Juliette Reinders Folmer
+ *
+ * @since   0.1
+ * @since   0.5 This class now uses namespaces and is no longer compatible with PHPCS 2.x.
  */
-class Yoast_Sniffs_ControlStructures_IfElseDeclarationSniff implements PHP_CodeSniffer_Sniff
+class IfElseDeclarationSniff implements Sniff
 {
 
 
@@ -36,13 +43,13 @@ class Yoast_Sniffs_ControlStructures_IfElseDeclarationSniff implements PHP_CodeS
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
+    public function process( File $phpcsFile, $stackPtr )
     {
         $tokens     = $phpcsFile->getTokens();
 		$has_errors = 0;

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -6,13 +6,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace YoastCS\Yoast\Tests\ControlStructures;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
- * Unit test class for the ControlStructureSpacing sniff.
+ * Unit test class for the IfElseDeclaration sniff.
  *
  * @package Yoast\YoastCS
- * @since   0.5
+ *
+ * @since   0.4.1
+ * @since   0.5   This class now uses namespaces and is no longer compatible with PHPCS 2.x.
  */
-class Yoast_Tests_ControlStructures_IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
+class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Yoast">
+<ruleset name="Yoast" namespace="YoastCS\Yoast">
 	<description>Yoast Coding Standards</description>
 
 	<!-- ##### WordPress sniffs #####-->

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,14 @@
 		"issues": "https://github.com/Yoast/yoastcs/issues"
 	},
 	"require": {
-		"squizlabs/php_codesniffer": "~2.8.1",
-		"wp-coding-standards/wpcs": "~0.10.0",
+		"php": ">=5.4",
+		"squizlabs/php_codesniffer": "^3.1.1",
+		"wp-coding-standards/wpcs": "~0.14.0",
 		"wimg/php-compatibility": "^8.0.0",
 		"phpmd/phpmd": "^2.2.3"
 	},
 	"suggest" : {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
 	},
 	"scripts": {
 		"config-set" : [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2356e06e55615278f1744bbd48d76279",
+    "content-hash": "0f9ccb3de939452afb5ade43a727bd5a",
     "packages": [
         {
             "name": "pdepend/pdepend",
@@ -114,63 +114,36 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.1",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
+                "reference": "d667e245d5dcd4d7bf80f26f2c947d476b66213e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d667e245d5dcd4d7bf80f26f2c947d476b66213e",
+                "reference": "d667e245d5dcd4d7bf80f26f2c947d476b66213e",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -188,7 +161,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01T22:17:45+00:00"
+            "time": "2017-10-16T22:40:25+00:00"
         },
         {
             "name": "symfony/config",
@@ -412,22 +385,26 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.10.0",
+            "version": "0.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "b39490465f6fd7375743a395019cd597e12119c9"
+                "reference": "8cadf48fa1c70b2381988e0a79e029e011a8f41c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/b39490465f6fd7375743a395019cd597e12119c9",
-                "reference": "b39490465f6fd7375743a395019cd597e12119c9",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/8cadf48fa1c70b2381988e0a79e029e011a8f41c",
+                "reference": "8cadf48fa1c70b2381988e0a79e029e011a8f41c",
                 "shasum": ""
             },
             "require": {
-                "squizlabs/php_codesniffer": "^2.6"
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
-            "type": "library",
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+            },
+            "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -444,7 +421,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2016-08-29T20:04:47+00:00"
+            "time": "2017-11-01T15:10:46+00:00"
         }
     ],
     "packages-dev": [],
@@ -453,6 +430,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.4"
+    },
     "platform-dev": []
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
+	backupGlobals="true"
+	beStrictAboutTestsThatDoNotTestAnything="false"
+	colors="true">
+</phpunit>


### PR DESCRIPTION
* Up the required version of PHPCS and WPCS
* Adjust the Travis script to allow for changes in PHPCS 3.x
* Adjust the YoastCS native script for compliance with PHPCS 3.x

See the individual commits for more details.

Fixes #36