### PR TITLE
YoastCS: check YoastCS native files for codestyle compliance

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<ruleset name="Yoast Coding Standard">
+	<description>The Coding standard for the Yoast Coding Standard itself.</description>
+
+	<!-- Scan all files. -->
+	<file>.</file>
+
+	<!-- Exclude Composer vendor directory. -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Show progress, show the error codes for each message (source). -->
+	<arg value="sp"/>
+
+	<!-- YoastCS supports PHP 5.4 or higher. -->
+	<config name="testVersion" value="5.4-"/>
+
+	<rule ref="Yoast">
+
+		<!-- Conflicts with PHPCS autoloading of sniffs. -->
+		<exclude name="WordPress.Files.FileName"/>
+
+		<!-- Conflicts with variable names coming from PHPCS itself. -->
+		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+
+		<!-- As the YoastCS ruleset is loaded *after* this ruleset, it overrules the
+			 PHPCompatibility testVersion set here, so we have to resort to excluding
+			 some error messages.... -->
+		<exclude name="PHPCompatibility.PHP.NewKeywords.t_dirFound"/>
+		<exclude name="PHPCompatibility.PHP.NewKeywords.t_namespaceFound"/>
+		<exclude name="PHPCompatibility.PHP.NewKeywords.t_useFound"/>
+		<exclude name="PHPCompatibility.PHP.NewLanguageConstructs.t_ns_separatorFound"/>
+
+	</rule>
+
+	<!-- Enforce PSR1 compatible namespaces. -->
+	<rule ref="PSR1.Classes.ClassDeclaration"/>
+
+</ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,24 @@ before_install:
     - export XMLLINT_INDENT="	"
     - export PHPCS_DIR=/tmp/phpcs
     - export PHPCS_BIN=$PHPCS_DIR/bin/phpcs
+    - export WPCS_DIR=/tmp/wpcs
+    - export PHPCOMPAT_DIR=/tmp/phpcompatibility
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - $PHPCS_BIN --config-set installed_paths $(pwd)
+    # Install WordPress Coding Standards.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
+    # Install PHP Compatibility sniffs.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
+    # Set install path for PHPCS sniffs.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_BIN --config-set installed_paths $(pwd),$WPCS_DIR,$PHPCOMPAT_DIR; fi
+    # After CodeSniffer install you should refresh your path.
+    - phpenv rehash
 
 script:
     - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
     - phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
+    # Check the codestyle of the files within YoastCS.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_BIN --runtime-set ignore_warnings_on_exit 1; fi
     # Validate the xml files.
     # @link http://xmlsoft.org/xmllint.html
     - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./Yoast/ruleset.xml; fi

--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -21,47 +21,44 @@ use PHP_CodeSniffer\Files\File;
  * @since   0.1
  * @since   0.5 This class now uses namespaces and is no longer compatible with PHPCS 2.x.
  */
-class IfElseDeclarationSniff implements Sniff
-{
+class IfElseDeclarationSniff implements Sniff {
 
 
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array(
-                T_ELSE,
-                T_ELSEIF,
-               );
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_ELSE,
+			T_ELSEIF,
+		);
 
-    }//end register()
+	}//end register()
 
 
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current
-     *                                               in the stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process( File $phpcsFile, $stackPtr )
-    {
-        $tokens     = $phpcsFile->getTokens();
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens     = $phpcsFile->getTokens();
 		$has_errors = 0;
 
-		if( isset( $tokens[ $stackPtr ]['scope_opener'] ) ) {
+		if ( isset( $tokens[ $stackPtr ]['scope_opener'] ) ) {
 			$scope_open = $tokens[ $stackPtr ]['scope_opener'];
 		}
-		else if( $tokens[ ( $stackPtr + 2 ) ]['code'] === T_IF && isset( $tokens[ ( $stackPtr + 2 ) ]['scope_opener'] ) ) {
+		elseif ( $tokens[ ( $stackPtr + 2 ) ]['code'] === T_IF && isset( $tokens[ ( $stackPtr + 2 ) ]['scope_opener'] ) ) {
 			$scope_open = $tokens[ ( $stackPtr + 2 ) ]['scope_opener'];
 		}
 
-		if ( isset( $scope_open ) && $tokens[ $scope_open ]['code'] !== T_COLON ) { // Ignore alternative syntax
+		if ( isset( $scope_open ) && $tokens[ $scope_open ]['code'] !== T_COLON ) { // Ignore alternative syntax.
 
 			$previous = $phpcsFile->findPrevious( T_CLOSE_CURLY_BRACKET, $stackPtr, null, false );
 
@@ -76,8 +73,8 @@ class IfElseDeclarationSniff implements Sniff
 			$other_start  = null;
 			$other_length = 0;
 			for ( $i = $start; $i < $stackPtr; $i++ ) {
-				if( $tokens[ $i ]['code'] !== T_COMMENT && $tokens[ $i ]['code'] !== T_WHITESPACE) {
-					if( ! isset( $other_start ) ) {
+				if ( $tokens[ $i ]['code'] !== T_COMMENT && $tokens[ $i ]['code'] !== T_WHITESPACE ) {
+					if ( ! isset( $other_start ) ) {
 						$other_start = $i;
 					}
 					$other_length++;
@@ -85,9 +82,9 @@ class IfElseDeclarationSniff implements Sniff
 			}
 			unset( $i );
 
-			if( isset( $other_start, $other_length ) ) {
+			if ( isset( $other_start, $other_length ) ) {
 				$error = 'Nothing but whitespace and comments allowed between closing bracket and else(if) statement, found "%s"';
-				$data = $phpcsFile->getTokensAsString( $other_start, $other_length );
+				$data  = $phpcsFile->getTokensAsString( $other_start, $other_length );
 				$phpcsFile->addError( $error, $stackPtr, 'StatementFound', $data );
 				$has_errors++;
 				unset( $error, $data, $other_start, $other_length );
@@ -103,6 +100,6 @@ class IfElseDeclarationSniff implements Sniff
 			}
 		}
 
-    }//end process()
+	}//end process()
 
 }//end class

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,4 +5,8 @@
 	backupGlobals="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true">
+
+	<php>
+		<env name="PHPCS_IGNORE_TESTS" value="PHPCompatibility,WordPress,WordPress-Core,WordPress-Docs,WordPress-Extra,WordPress-VIP"/>
+	</php>
 </phpunit>


### PR DESCRIPTION
Includes addition of a fully documented `.phpcs.xml.dist` file specifically for YoastCS itself and fixes to the IfElseDeclaration sniff to comply.

