### PR TITLE
PHPCS Ruleset updates

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -17,6 +17,17 @@
 
 	</rule>
 
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<!-- No need to adjust alignment of large arrays when the item with the largest key is removed. -->
+			<property name="exact" value="false"/>
+			<!-- Don't align multi-line items if ALL items in the array are multi-line. -->
+			<property name="alignMultilineItems" value="!=100"/>
+			<!-- Array Assignment operator should always be on the same line as the array key. -->
+			<property name="ignoreNewlines" value="false"/>
+		</properties>
+	</rule>
+
 	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->
 	<config name="testVersion" value="5.2-99.0"/>
 	<rule ref="PHPCompatibility"/>

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -18,7 +18,9 @@
 		<!-- A while loop is the only valid control structure where an assignment can be justified. -->
 		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
 
-		<!-- If a conscious choice has been made for a non-strict comparison, that's ok. -->
+		<!-- If a conscious choice has been made for a non-strict comparison, that's ok.
+			 I.e. when `strict` has been explicitely set to `false` in an array comparison,
+			 it will be allowed. -->
 		<exclude name="WordPress.PHP.StrictInArray.FoundNonStrictFalse"/>
 	</rule>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -15,11 +15,6 @@
 		<!-- Demanding Yoda conditions is stupid. -->
 		<exclude name="WordPress.PHP.YodaConditions"/>
 
-		<!-- Turned off because of known & reported bugs in the Sniffs, should be turned on once the bugs are fixed. -->
-		<!-- Exclusion can be removed once the WPCS 0.11.0 has been released - in which the bugs have been fixed -
-		     and the minimum WPCS version required by Yoast CS has been upped to 0.11.0. -->
-		<!-- WPCS #300 -->
-		<exclude name="WordPress.Variables.GlobalVariables"/>
 	</rule>
 
 	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -15,6 +15,8 @@
 		<!-- Demanding Yoda conditions is stupid. -->
 		<exclude name="WordPress.PHP.YodaConditions"/>
 
+		<!-- If a conscious choice has been made for a non-strict comparison, that's ok. -->
+		<exclude name="WordPress.PHP.StrictInArray.FoundNonStrictFalse"/>
 	</rule>
 
 	<rule ref="WordPress.Arrays.MultipleStatementAlignment">

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -15,6 +15,9 @@
 		<!-- Demanding Yoda conditions is stupid. -->
 		<exclude name="WordPress.PHP.YodaConditions"/>
 
+		<!-- A while loop is the only valid control structure where an assignment can be justified. -->
+		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
+
 		<!-- If a conscious choice has been made for a non-strict comparison, that's ok. -->
 		<exclude name="WordPress.PHP.StrictInArray.FoundNonStrictFalse"/>
 	</rule>

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -46,13 +46,6 @@
 		</properties>
 	</rule>
 
-	<!-- Application memory use! -->
-	<rule ref="Generic.Strings.UnnecessaryStringConcat">
-		<properties>
-			<property name="allowMultiline" value="true"/>
-		</properties>
-	</rule>
-
 	<!-- Error prevention: Make sure the condition in a inline if declaration is bracketed -->
 	<rule ref="Squiz.ControlStructures.InlineIfDeclaration"/>
 


### PR DESCRIPTION
As WPCS `0.14.0` is now the target version, some changes to the ruleset can be made to:
* Remove rule duplication - for sniff(s) which are now included upstream
* Remove outdated exclusions - for sniff which used to be buggy, which has been fixed
* Add configuration for a new WPCS sniff
* Exclude warnings for two specific situations.

See the individual commits for more details.

Fixes #20
Fixes #35