### PR TITLE
PHPCS Ruleset: Remove exclusion of rule which code should try to comply with

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -9,9 +9,6 @@
 		<!-- No need for this sniff as every Yoast travis script includes linting all files. -->
 		<exclude name="Generic.PHP.Syntax"/>
 
-		<!-- Some calls just too quirky and complicated for this. -->
-		<exclude name="PEAR.Functions.FunctionCallSignature.Indent"/>
-
 		<!-- Excluded in favour of the YoastCS native Filename sniff. -->
 		<exclude name="WordPress.Files.FileName"/>
 


### PR DESCRIPTION
Most of the code already complies with this anyway. The exclusion causes issues when running the auto-fixer, so may as well be removed.

FYI: In the future, it is expected that WPCS will create a WP native function call signature sniff which will be more lenient than the PEAR one.