### PR TITLE
PHPCS Ruleset: Remove extra rules which now largely covered by WPCS

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -12,6 +12,9 @@
 		<!-- Some calls just too quirky and complicated for this. -->
 		<exclude name="PEAR.Functions.FunctionCallSignature.Indent"/>
 
+		<!-- Excluded in favour of the YoastCS native "else on new line" sniff. -->
+		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
+
 		<!-- Excluded in favour of the YoastCS native Filename sniff. -->
 		<exclude name="WordPress.Files.FileName"/>
 
@@ -64,31 +67,6 @@
 	<rule ref="PHPCompatibility.PHP.RemovedExtensions">
 		<properties>
 			<property name="functionWhitelist" type="array" value="mysql_to_rfc3339"/>
-		</properties>
-	</rule>
-
-	<rule ref="Squiz.ControlStructures">
-		<!-- Prevent errors for Spaces after closing braces, as we want a newline -->
-		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
-		<!-- elseif is fine by WP -->
-		<exclude name="Squiz.ControlStructures.ElseIfDeclaration"/>
-		<!-- WP got nothing about switch -->
-		<exclude name="Squiz.ControlStructures.SwitchDeclaration"/>
-	</rule>
-
-	<!-- ##### Some miscellanous other sniffs ##### -->
-	<!-- Added for lowercase keywords check -->
-	<rule ref="Squiz.ControlStructures.ForEachLoopDeclaration">
-		<properties>
-			<property name="requiredSpacesAfterOpen" value="1"/>
-			<property name="requiredSpacesBeforeClose" value="1"/>
-		</properties>
-	</rule>
-
-	<rule ref="Squiz.ControlStructures.ForLoopDeclaration">
-		<properties>
-			<property name="requiredSpacesAfterOpen" value="1"/>
-			<property name="requiredSpacesBeforeClose" value="1"/>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
As previously discussed: these are some outdated additional rules which were included in YoastCS when WPCS was still in its infancy.
By now, WPCS contains rules for most of these things anyway and/or includes some of these rules natively.

Unless there is a strong argument to be stricter than WPCS already is, there is no reason to keep these rules active.

Includes moving one existing exclusion up from the custom rules to the WP rules inclusion, as that particular error code conflicts with the YoastCS native "else on new line" sniff.