### PR TITLE
Update PHPCompatibility min requirement to v 8.1.0

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -51,6 +51,9 @@
 		<exclude name="PHPCompatibility.PHP.NewClasses.errorFound"/>
 		<exclude name="PHPCompatibility.PHP.NewClasses.typeerrorFound"/>
 
+		<exclude name="PHPCompatibility.PHP.NewConstants.json_pretty_printFound"/>
+		<exclude name="PHPCompatibility.PHP.NewConstants.php_version_idFound"/>
+
 		<exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound"/>
 		<exclude name="PHPCompatibility.PHP.NewFunctions.json_last_error_msgFound"/>
 		<exclude name="PHPCompatibility.PHP.NewFunctions.random_intFound"/>

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.1.1",
 		"wp-coding-standards/wpcs": "~0.14.0",
-		"wimg/php-compatibility": "^8.0.0",
+		"wimg/php-compatibility": "^8.1.0",
 		"phpmd/phpmd": "^2.2.3"
 	},
 	"suggest" : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f9ccb3de939452afb5ade43a727bd5a",
+    "content-hash": "b2a96958dbb64a1d12dc80dcb5451ad7",
     "packages": [
         {
             "name": "pdepend/pdepend",
@@ -333,16 +333,16 @@
         },
         {
             "name": "wimg/php-compatibility",
-            "version": "8.0.1",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wimg/PHPCompatibility.git",
-                "reference": "4c4385fb891dff0501009670f988d4fe36785249"
+                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4c4385fb891dff0501009670f988d4fe36785249",
-                "reference": "4c4385fb891dff0501009670f988d4fe36785249",
+                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
+                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
                 "shasum": ""
             },
             "require": {
@@ -356,7 +356,7 @@
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -381,7 +381,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-08-07T19:39:05+00:00"
+            "time": "2017-12-27T21:58:38+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",


### PR DESCRIPTION
[PHPCompatibility has just released version 8.1.0](https://github.com/wimg/PHPCompatibility/releases/tag/8.1.0).

This version contains a lot of new checks for PHP 7.2 related issues, as well as a massive new sniff which will inform about usage of PHP constants which were not always available.

This PR:
* Updates the Composer config & lock file to use PHPCompatibility `^8.1.0`.
* Updates the WP back-fills whitelist in the PHPCS ruleset for constants which are being back-filled by WP.