### PR TITLE
Composer: update PHPCS dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.1.1",
+		"squizlabs/php_codesniffer": "^3.2.0",
 		"wp-coding-standards/wpcs": "~0.14.0",
 		"wimg/php-compatibility": "^8.1.0",
 		"phpmd/phpmd": "^2.2.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2a96958dbb64a1d12dc80dcb5451ad7",
+    "content-hash": "2cb94ac9f8ad6db580fa354fb8b0dfd3",
     "packages": [
         {
             "name": "pdepend/pdepend",
@@ -114,16 +114,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.1.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d667e245d5dcd4d7bf80f26f2c947d476b66213e"
+                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d667e245d5dcd4d7bf80f26f2c947d476b66213e",
-                "reference": "d667e245d5dcd4d7bf80f26f2c947d476b66213e",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
+                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
                 "shasum": ""
             },
             "require": {
@@ -161,7 +161,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-10-16T22:40:25+00:00"
+            "time": "2017-12-19T21:44:46+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
PHPCS has [released version 3.2.2](https://github.com/squizlabs/PHP_CodeSniffer/releases) by now.

Quite apart from the new versions containing  quite some bugfixes, the main advantage of using PHPCS 3.2+ is that the new "ignore" comment syntax can be used, which will allow to make it far more descriptive why certain parts of code should be ignored by PHPCS as well as allowing to selectively ignore code only for particular sniffs/error codes.

See:
https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.2.0
https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file

Once plugins start using YoastCS 0.5, "old style" ignore comments as well as the WPCS native whitelist flags can be replaced by the new syntax.