### PR TITLE
Travis: use the correct minimum PHPCS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   # Test against the highest supported PHPCS version.
   - PHPCS_BRANCH=master
   # Test against the lowest supported PHPCS version.
-  - PHPCS_BRANCH=3.1.1
+  - PHPCS_BRANCH=3.2.0
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
The builds are tested against the lowest and highest PHPCS version supported.

The minimum PHPCS version was updated to PHPCS `3.2.0` in PR #60, but the Travis script had not been updated to match.