### PR TITLE
.gitattributes: sync with files currently in the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,25 @@
 # https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
 # https://blog.madewithlove.be/post/gitattributes/
 #
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.phpcs.xml export-ignore
+/.phpcs.xml.dist export-ignore
 /.travis.yml export-ignore
+/phpcs.xml export-ignore
+/phpcs.xml.dist export-ignore
+/phpunit.xml export-ignore
+/phpunit.xml.dist export-ignore
 /Yoast/Tests export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text


### PR DESCRIPTION
The `export-ignore` directives in the `.gitattributes` file determine which files are excluded when the repository is packaged for distribution, like on tagging a release.

The file exclusion list was out of date.

Also added the `text=auto` directive to normalize line-endings.