### PR TITLE
IfElseDeclaration: Various improvements

### DIFF
--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -68,7 +68,7 @@ class IfElseDeclarationSniff implements Sniff {
 			return;
 		}
 
-		$previous = $phpcsFile->findPrevious( T_CLOSE_CURLY_BRACKET, $stackPtr, null, false );
+		$previous = $phpcsFile->findPrevious( T_CLOSE_CURLY_BRACKET, ( $stackPtr - 1 ) );
 
 		if ( $tokens[ $previous ]['line'] === $tokens[ $stackPtr ]['line'] ) {
 			$error = 'else(if) statement must be on a new line';

--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -11,6 +11,7 @@ namespace YoastCS\Yoast\Sniffs\ControlStructures;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Verifies that else statements are on a new line.
@@ -54,8 +55,12 @@ class IfElseDeclarationSniff implements Sniff {
 		if ( isset( $tokens[ $stackPtr ]['scope_opener'] ) ) {
 			$scope_open = $tokens[ $stackPtr ]['scope_opener'];
 		}
-		elseif ( $tokens[ ( $stackPtr + 2 ) ]['code'] === T_IF && isset( $tokens[ ( $stackPtr + 2 ) ]['scope_opener'] ) ) {
-			$scope_open = $tokens[ ( $stackPtr + 2 ) ]['scope_opener'];
+		else {
+			// Deal with "else if".
+			$next = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+			if ( $tokens[ $next ]['code'] === T_IF && isset( $tokens[ $next ]['scope_opener'] ) ) {
+				$scope_open = $tokens[ $next ]['scope_opener'];
+			}
 		}
 
 		if ( isset( $scope_open ) && $tokens[ $scope_open ]['code'] !== T_COLON ) { // Ignore alternative syntax.

--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -49,8 +49,7 @@ class IfElseDeclarationSniff implements Sniff {
 	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		$tokens     = $phpcsFile->getTokens();
-		$has_errors = 0;
+		$tokens = $phpcsFile->getTokens();
 
 		if ( isset( $tokens[ $stackPtr ]['scope_opener'] ) ) {
 			$scope_open = $tokens[ $stackPtr ]['scope_opener'];
@@ -77,7 +76,14 @@ class IfElseDeclarationSniff implements Sniff {
 				'NewLine',
 				array( ucfirst( $tokens[ $stackPtr ]['content'] ) )
 			);
-			$has_errors++;
+		}
+		elseif ( $tokens[ $previous ]['column'] !== $tokens[ $stackPtr ]['column'] ) {
+			$phpcsFile->addError(
+				'%s statement not aligned with previous part of the control structure',
+				$stackPtr,
+				'Alignment',
+				array( ucfirst( $tokens[ $stackPtr ]['content'] ) )
+			);
 		}
 
 		$start        = ( $previous + 1 );
@@ -100,20 +106,8 @@ class IfElseDeclarationSniff implements Sniff {
 				$phpcsFile->getTokensAsString( $other_start, $other_length ),
 			);
 			$phpcsFile->addError( $error, $stackPtr, 'StatementFound', $data );
-			$has_errors++;
 			unset( $error, $data, $other_start, $other_length );
 
-		}
-
-		if ( $has_errors === 0 ) {
-			if ( $tokens[ $previous ]['column'] !== $tokens[ $stackPtr ]['column'] ) {
-				$phpcsFile->addError(
-					'%s statement not aligned with previous part of the control structure',
-					$stackPtr,
-					'Alignment',
-					array( ucfirst( $tokens[ $stackPtr ]['content'] ) )
-				);
-			}
 		}
 
 	}//end process()

--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -72,9 +72,10 @@ class IfElseDeclarationSniff implements Sniff {
 
 		if ( $tokens[ $previous ]['line'] === $tokens[ $stackPtr ]['line'] ) {
 			$phpcsFile->addError(
-				'else(if) statement must be on a new line',
+				'%s statement must be on a new line',
 				$stackPtr,
-				'NewLine'
+				'NewLine',
+				array( ucfirst( $tokens[ $stackPtr ]['content'] ) )
 			);
 			$has_errors++;
 		}
@@ -93,8 +94,11 @@ class IfElseDeclarationSniff implements Sniff {
 		unset( $i );
 
 		if ( isset( $other_start, $other_length ) ) {
-			$error = 'Nothing but whitespace and comments allowed between closing bracket and else(if) statement, found "%s"';
-			$data  = $phpcsFile->getTokensAsString( $other_start, $other_length );
+			$error = 'Nothing but whitespace and comments allowed between closing bracket and %s statement, found "%s"';
+			$data  = array(
+				$tokens[ $stackPtr ]['content'],
+				$phpcsFile->getTokensAsString( $other_start, $other_length ),
+			);
 			$phpcsFile->addError( $error, $stackPtr, 'StatementFound', $data );
 			$has_errors++;
 			unset( $error, $data, $other_start, $other_length );
@@ -104,9 +108,10 @@ class IfElseDeclarationSniff implements Sniff {
 		if ( $has_errors === 0 ) {
 			if ( $tokens[ $previous ]['column'] !== $tokens[ $stackPtr ]['column'] ) {
 				$phpcsFile->addError(
-					'else(if) statement not aligned with previous part of the control structure',
+					'%s statement not aligned with previous part of the control structure',
 					$stackPtr,
-					'Alignment'
+					'Alignment',
+					array( ucfirst( $tokens[ $stackPtr ]['content'] ) )
 				);
 			}
 		}

--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -71,10 +71,12 @@ class IfElseDeclarationSniff implements Sniff {
 		$previous = $phpcsFile->findPrevious( T_CLOSE_CURLY_BRACKET, ( $stackPtr - 1 ) );
 
 		if ( $tokens[ $previous ]['line'] === $tokens[ $stackPtr ]['line'] ) {
-			$error = 'else(if) statement must be on a new line';
-			$phpcsFile->addError( $error, $stackPtr, 'NewLine' );
+			$phpcsFile->addError(
+				'else(if) statement must be on a new line',
+				$stackPtr,
+				'NewLine'
+			);
 			$has_errors++;
-			unset( $error );
 		}
 
 		$start        = ( $previous + 1 );
@@ -101,9 +103,11 @@ class IfElseDeclarationSniff implements Sniff {
 
 		if ( $has_errors === 0 ) {
 			if ( $tokens[ $previous ]['column'] !== $tokens[ $stackPtr ]['column'] ) {
-				$error = 'else(if) statement not aligned with previous part of the control structure';
-				$phpcsFile->addError( $error, $stackPtr, 'Alignment' );
-				unset( $error );
+				$phpcsFile->addError(
+					'else(if) statement not aligned with previous part of the control structure',
+					$stackPtr,
+					'Alignment'
+				);
 			}
 		}
 

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.inc
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.inc
@@ -8,12 +8,15 @@ else {
 	// ...
 }
 
+// Ok.
 if ( false ):
+elseif:
+else if:
+else /* comment */
+if:
 else:
 endif;
 
-
-// Bad.
 if ( true ) {
 	// code.
 } else { // Bad - else should be on the next line.
@@ -24,8 +27,13 @@ if ( true ) {
 	// code.
 } elseif( 1 ) { // Bad - elseif should be on the next line.
 	// ...
-} elseif( 2 ) { // Bad - elseif should be on the next line.
+} else if       (2 // Bad - else if should be on the next line.
+	|| 6
+) {
 	// ...
-} elseif( 3 ) { // Bad - elseif should be on the next line.
+} else // Bad - else if should be on the next line.
+if (2) {
+	// ...
+} else ( 3 ) { // Bad - else should be on the next line.
 	// ...
 }

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.inc
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.inc
@@ -37,3 +37,50 @@ if (2) {
 } else ( 3 ) { // Bad - else should be on the next line.
 	// ...
 }
+
+if ( true ) {
+	// code.
+}
+	else { // Bad - else not aligned with if.
+	// ...
+	}
+
+				if ( true ) {
+					// code.
+				}
+	else { // Bad - else not aligned with if.
+	// ...
+	}
+
+if ( true ) {
+	// code.
+}
+
+
+else { // OK - multiple blank lines between if/else are ignored, not the concern of this sniff.
+	// ...
+}
+
+if ( true ) {
+	// code.
+}
+// Some comment - this comment should be ignored.
+else {
+	// ...
+}
+
+if ( true ) {
+	// code.
+}
+	/* phpcs:ignore Standard.Category.Sniffname -- for reasons. */
+	else { // Bad - else not aligned with if.
+		// ...
+	}
+
+if ( true ) {
+	// code.
+}
+?> <!-- This would be a parse error anyway. --> <?php
+	else { // Bad.
+		// ...
+	}

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -27,10 +27,11 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			19 => 1,
-			25 => 1,
-			27 => 1,
-			29 => 1,
+			22 => 1,
+			28 => 1,
+			30 => 1,
+			34 => 1,
+			37 => 1,
 		);
 
 	} // end getErrorList()

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -32,6 +32,10 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 			30 => 1,
 			34 => 1,
 			37 => 1,
+			44 => 1,
+			51 => 1,
+			76 => 1,
+			84 => 2,
 		);
 
 	} // end getErrorList()


### PR DESCRIPTION
This PR addresses a number of issues with the `IfElseDeclaration` sniff.

I initially started reviewing the sniff to make sure it would deal correctly with the new PHPCS 3.2.0+ annotations.
It was cute to see what I did when I really didn't know much about writing sniffs yet :heart_eyes_cat: (This was the first sniff I ever wrote.)

Based on the review, I've made extensive changes to the sniff. Each change is isolated in an individual commit for easier review and traceable history.

Summary of the changes:
* Bug fix: the sniff would presume the WP code style. If code was not using the WP code style, the sniff would not correctly detect issues, effectively leading to "issues hiding behind other issues".
    This fix also sorts out the false positives which would be thrown for the PHPCS annotations.
* Bug fix: the same - issues hiding behind each other - was true for the various error messages this sniff could throw.
* Enhancement: minor improvement to the error message.
* Minor efficiency fixes.
* Tests: The unit tests didn't cover all possible error messages.
* Tests: The unit tests presumed the WP code style.
* Tests: New test to cover the new PHPCS annotations are handled correctly.

