### PR TITLE
FileNameSniff: remove debug code

### DIFF
--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -102,7 +102,6 @@ class FileNameSniff implements Sniff {
 		$file = preg_replace( '`^([\'"])(.*)\1$`Ds', '$2', $phpcsFile->getFileName() );
 
 		if ( 'STDIN' === $file ) {
-			$this->echo_status( $phpcsFile, 'STDIN', '', '' );
 			return;
 		}
 


### PR DESCRIPTION
This snippet is calling a function which doesn't exist.

Or rather - a function which only exists in a local branch which I use to generate the file rename lists :sunglasses: 

Considering nobody reported this, I can only presume that it is not very common for the team to use YoastCS with STDIN. All the same, it should be fixed.

--------------

Note: the build failure is related to PHPUnit 7.x having been rolled out for the Travis PHP 7.2 images.
PHPCS 3.2 was not compatible with PHPUnit 7.x yet. PHPCS `master` has been fixed, as can been seen by the second PHP 7.2 build passing.

There are a couple of options to "fix" this:
* Drop the PHP 7.2 / PHPCS 3.2.0 build.
* Install PHPUnit 6.x when PHPUnit 7.x is detected for builds not run against PHPCS `master`.
* Switch over to using Composer to install the dependencies and limit PHPUnit in it (even though it's not a dependency of YoastCS, but rather of PHPCS).
* and I bet there are even more alternatives we could come up with....

I'll be happy to send in a separate PR implementing whichever "fix" is preferred.