### PR TITLE
Travis: fix build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ dist: trusty
 
 cache:
     apt: true
+    directories:
+      - tmp/phpunit
+
 
 php:
     - 5.4
@@ -48,6 +51,7 @@ before_install:
     - export PHPCS_BIN=$PHPCS_DIR/bin/phpcs
     - export WPCS_DIR=/tmp/wpcs
     - export PHPCOMPAT_DIR=/tmp/phpcompatibility
+    - export PHPUNIT_DIR=/tmp/phpunit
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - $PHPCS_BIN --config-set installed_paths $(pwd)
     # Install WordPress Coding Standards.
@@ -58,10 +62,22 @@ before_install:
     - if [[ "$SNIFF" == "1" ]]; then $PHPCS_BIN --config-set installed_paths $(pwd),$WPCS_DIR,$PHPCOMPAT_DIR; fi
     # After CodeSniffer install you should refresh your path.
     - phpenv rehash
+    # Download PHPUnit 6.x for builds on PHP 7.2 and nightly in combination with PHPCS 3.2.0
+    # as the PHPCS test suite in PHPCS 3.2.0 is not compatible with PHPUnit 7.x.
+    - if [[ "$TRAVIS_PHP_VERSION" == "7.2" || "$TRAVIS_PHP_VERSION" == "nightly" ]] && [[ "$PHPCS_BRANCH" != "master" ]]; then
+        wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-6.5.7.phar && chmod +x $PHPUNIT_DIR/phpunit-6.5.7.phar;
+      fi
+
 
 script:
     - if [[ "$PHPLINT" == "1" ]]; then if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
-    - phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
+    # Run the unit tests.
+    - if [[ "$TRAVIS_PHP_VERSION" == "7.2" || "$TRAVIS_PHP_VERSION" == "nightly" ]] && [[ "$PHPCS_BRANCH" != "master" ]]; then
+        php $PHPUNIT_DIR/phpunit-6.5.7.phar  --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php;
+      else
+        phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php;
+      fi
+
     # Check the codestyle of the files within YoastCS.
     - if [[ "$SNIFF" == "1" ]]; then $PHPCS_BIN --runtime-set ignore_warnings_on_exit 1; fi
     # Validate the xml files.


### PR DESCRIPTION
The current PHP 7.2/nightly images on Travis come by default with PHPUnit 7.x.

Unfortunately, the lowest PHPCS version supported by YoastCS (`3.2.0`), did not yet have full support for PHPUnit 7.x. This has since been fixed, which is why the builds against PHPCS `master` are passing fine.

To still be able to test the sniffs in YoastCS fully, we need to use PHPUnit 6.x for the PHP 7.2/nightly builds in combination with PHPCS 3.2.0, so that's what this PR sorts out.