### PR TITLE
Introduce Required Parameter Sniff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 /phpunit.xml export-ignore
 /phpunit.xml.dist export-ignore
 /Yoast/Tests export-ignore
+/Tests export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,17 +24,18 @@ php:
     - nightly
 
 env:
-  # Test against the highest supported PHPCS version.
-  - PHPCS_BRANCH="dev-master" PHPLINT=1
-  # Test against the lowest supported PHPCS version.
-  - PHPCS_BRANCH="3.3.1"
+  # Test against the highest and lowest supported PHPCS and WPCS versions.
+  - PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-develop" PHPLINT=1
+  - PHPCS_BRANCH="3.3.2" WPCS_BRANCH="dev-develop"
+  - PHPCS_BRANCH="dev-master" WPCS_BRANCH="1.2.0"
+  - PHPCS_BRANCH="3.3.2" WPCS_BRANCH="1.2.0"
 
 matrix:
   fast_finish: true
   include:
     # Extra build to check for XML codestyle.
     - php: 7.1
-      env: PHPCS_BRANCH="dev-master" SNIFF=1
+      env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-master" SNIFF=1
       addons:
           apt:
               packages:
@@ -54,14 +55,16 @@ before_install:
     - export PHPCS_BIN=$(pwd)/vendor/bin/phpcs
     # Set the PHPCS version to test against.
     - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --no-update --no-suggest --no-scripts
+    # Set the WPCS version to test against.
+    - composer require wp-coding-standards/wpcs:${WPCS_BRANCH} --no-update --no-suggest --no-scripts
     - |
       if [[ "$SNIFF" == "1" ]]; then
           composer install --dev --no-suggest
           # The post-install-cmd script takes care of the installed_paths.
       else
           # For testing the YoastCS native sniffs, the rest of the packages aren't needed.
-          composer remove wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp phpmd/phpmd --no-update
-          # This will now only install the version of PHPCS to test against.
+          composer remove phpcompatibility/phpcompatibility-wp phpmd/phpmd --no-update
+          # This will now only install the versions of PHPCS and WPCS to test against.
           composer install --no-dev --no-suggest --no-scripts
           # Set the installed_paths for the test environment.
           $PHPCS_BIN --config-set installed_paths $(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_install:
 
 script:
     - if [[ "$PHPLINT" == "1" ]]; then if find . -path ./vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
-    - phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
+    - phpunit --filter Yoast $PHPCS_DIR/tests/AllTests.php
     # Check the codestyle of the files within YoastCS.
     - if [[ "$SNIFF" == "1" ]]; then composer check-cs; fi
     # Validate the xml files.

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Bootstrap file for running the tests.
+ *
+ * Load the PHPCS autoloader and the WPCS PHPCS cross-version helpers.
+ *
+ * Code has been based on the phpcs3-bootstrap.php used in the WordPress Coding Standards project
+ *
+ * @link: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ *
+ * @package Yoast\YoastCS
+ * @link    https://github.com/Yoast/yoastcs
+ * @license https://opensource.org/licenses/MIT MIT
+ * @since   1.1.0
+ */
+
+if ( ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
+	define( 'PHP_CODESNIFFER_IN_TESTS', true );
+}
+
+/**
+ * Builds the directory path for the given parts.
+ *
+ * @param array $parts Parts to convert to a path.
+ *
+ * @return string The path usable for the current system.
+ */
+function yoastcs_test_bootstrap_get_path( $parts ) {
+	return implode( DIRECTORY_SEPARATOR, $parts );
+}
+
+$ds              = DIRECTORY_SEPARATOR;
+$baseComposerDir = dirname( __DIR__ );
+
+// Get the PHPCS dir from an environment variable.
+$phpcsDir         = getenv( 'PHPCS_DIR' );
+$phpcsComposerDir = yoastcs_test_bootstrap_get_path(
+	array( $baseComposerDir, 'vendor', 'squizlabs', 'php_codesniffer' )
+);
+
+// This may be a Composer install.
+if ( false === $phpcsDir && is_dir( $phpcsComposerDir ) ) {
+	$phpcsDir = $phpcsComposerDir;
+}
+elseif ( false !== $phpcsDir ) {
+	$phpcsDir = realpath( $phpcsDir );
+}
+
+// Try and load the PHPCS autoloader.
+if ( false !== $phpcsDir && file_exists( yoastcs_test_bootstrap_get_path( array( $phpcsDir, 'autoload.php' ) ) ) ) {
+	require_once yoastcs_test_bootstrap_get_path( array( $phpcsDir, 'autoload.php' ) );
+
+	/*
+	 * As of PHPCS 3.1, PHPCS support PHPUnit 6.x, but needs a bootstrap, so
+	 * load it if it's available.
+	 */
+	if ( file_exists( yoastcs_test_bootstrap_get_path( array( $phpcsDir, 'tests', 'bootstrap.php' ) ) ) ) {
+		require_once yoastcs_test_bootstrap_get_path( array( $phpcsDir, 'tests', 'bootstrap.php' ) );
+	}
+}
+else {
+	echo 'Uh oh... can\'t find PHPCS.
+
+If you use Composer, please run `composer install`.
+Otherwise, make sure you set a `PHPCS_DIR` environment variable in your phpunit.xml file
+pointing to the PHPCS directory.
+';
+
+	die( 1 );
+}
+
+// Get the WPCS dir from an environment variable.
+$wpcsDir         = getenv( 'WPCS_DIR' );
+$wpcsComposerDir = yoastcs_test_bootstrap_get_path( array( $baseComposerDir, 'vendor', 'wp-coding-standards', 'wpcs' ) );
+
+// This may be a Composer install.
+if ( false === $wpcsDir && is_dir( $wpcsComposerDir ) ) {
+	$wpcsDir = $wpcsComposerDir;
+}
+elseif ( false !== $wpcsDir ) {
+	$wpcsDir = realpath( $wpcsDir );
+}
+
+// Try and load the WPCS class aliases file.
+$wpcsAliasFilename = yoastcs_test_bootstrap_get_path( array( $wpcsDir, 'WordPress', 'PHPCSAliases.php' ) );
+if ( file_exists( $wpcsAliasFilename ) ) {
+	require_once $wpcsAliasFilename;
+}
+else {
+	echo 'Uh oh... can\'t find WPCS.
+
+If you use Composer, please run `composer install`.
+Otherwise, make sure you set a `WPCS_DIR` environment variable in your phpunit.xml file
+pointing to the WPCS directory.
+';
+
+	die( 1 );
+}
+
+unset( $ds, $baseComposerDir, $phpcsDir, $phpcsComposerDir, $wpcsDir, $wpcsComposerDir, $wpcsAliasFilename );

--- a/Yoast/Sniffs/WP/RequiredOptionalParametersSniff.php
+++ b/Yoast/Sniffs/WP/RequiredOptionalParametersSniff.php
@@ -73,7 +73,7 @@ class RequiredOptionalParametersSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
-			// Check that number of parameters defined is not less than the position to check.
+			// Check that a valid parameter value is being passed.
 			if ( $this->has_valid_parameter( $parameters, $position, $parameter_args ) ) {
 				continue;
 			}

--- a/Yoast/Sniffs/WP/RequiredOptionalParametersSniff.php
+++ b/Yoast/Sniffs/WP/RequiredOptionalParametersSniff.php
@@ -12,8 +12,8 @@ namespace YoastCS\Yoast\Sniffs\WP;
 use WordPress\AbstractFunctionParameterSniff;
 
 /**
- * Sniff that ensures the optional parameter for update_option and set_option
- * are defined because we want developers to be conscious about what is needed.
+ * Sniff that ensures the optional parameter for update_option() and add_option()
+ * are passed because we want developers to be conscious about what is needed.
  *
  * @package Yoast\YoastCS
  * @author  Jip Moors
@@ -38,7 +38,7 @@ class RequiredOptionalParametersSniff extends AbstractFunctionParameterSniff {
 	 *            (int) Target parameter position, 1-based. => array(
 	 *                'name'       => (string)  The name of the argument that should be set.
 	 *                'enforce'    => (boolean) If this should trigger an error or warning.
-	 *                'allow_null' => (boolean) If `null` is seen as setting the optional value, defaults to False.
+	 *                'allow_null' => (boolean) Whether `null` is seen as setting the optional value. Defaults to false.
 	 *            )
 	 *         )
 	 *    );

--- a/Yoast/Sniffs/WP/RequiredOptionalParametersSniff.php
+++ b/Yoast/Sniffs/WP/RequiredOptionalParametersSniff.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * YoastCS\Yoast\Sniffs\WP\RequiredOptionalParameters.
+ *
+ * @package Yoast\YoastCS
+ * @author  Jip Moors
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace YoastCS\Yoast\Sniffs\WP;
+
+use WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * Sniff that ensures the optional parameter for update_option and set_option
+ * are defined because we want developers to be conscious about what is needed.
+ *
+ * @package Yoast\YoastCS
+ * @author  Jip Moors
+ *
+ * @since   1.1.0
+ */
+class RequiredOptionalParametersSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'wp_required_parameters';
+
+	/**
+	 * Functions this sniff is looking for.
+	 *
+	 * @var array Multidimensional array with parameter details.
+	 *    $target_functions = array(
+	 *        (string) Function name. => array(
+	 *            (int) Target parameter position, 1-based. => array(
+	 *                'name'       => (string)  The name of the argument that should be set.
+	 *                'enforce'    => (boolean) If this should trigger an error or warning.
+	 *                'allow_null' => (boolean) If `null` is seen as setting the optional value, defaults to False.
+	 *            )
+	 *         )
+	 *    );
+	 */
+	protected $target_functions = array(
+		'update_option' => array(
+			3 => array(
+				'name'       => 'autoload',
+				'enforce'    => false,
+				'allow_null' => false,
+			),
+		),
+		'add_option'    => array(
+			4 => array(
+				'name'       => 'autoload',
+				'enforce'    => true,
+				'allow_null' => false,
+			),
+		),
+	);
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
+			// Check that number of parameters defined is not less than the position to check.
+			if ( $this->has_valid_parameter( $parameters, $position, $parameter_args ) ) {
+				continue;
+			}
+
+			$message = '%s() is %s to be called with the "%s" argument at position %d%s.';
+
+			$error_type = ( $parameter_args['enforce'] === true ) ? 'Required' : 'Optional';
+			$error_null = $this->is_null_allowed( $parameter_args ) ? '' : 'NullDisallowed';
+
+			$error_string = $matched_content . $error_type . 'Param' . ucfirst( $parameter_args['name'] ) . 'Missing' . $error_null;
+
+			$code = $this->string_to_errorcode( $error_string );
+
+			$data = array(
+				$matched_content,
+				( $parameter_args['enforce'] === true ) ? 'required' : 'expected',
+				$parameter_args['name'],
+				$position,
+				( $this->is_null_allowed( $parameter_args ) ) ? '' : ', which cannot be "null"',
+			);
+
+			$is_error = $parameter_args['enforce'];
+			if ( ! $is_error && ! $parameter_args['allow_null'] ) {
+				$is_error = ( isset( $parameters[ $position ] ) && $parameters[ $position ]['raw'] === 'null' );
+			}
+
+			$this->addMessage( $message, $stackPtr, $is_error, $code, $data );
+		}
+	}
+
+	/**
+	 * Determines if a valid parameter has been provided.
+	 *
+	 * @param array $parameters     The parameters used to call the function.
+	 * @param int   $position       The position of the parameter to check.
+	 * @param array $parameter_args The configuration of the function check.
+	 *
+	 * @return bool True if a valid parameter has been given, False otherwise.
+	 */
+	protected function has_valid_parameter( $parameters, $position, $parameter_args ) {
+		if ( ! isset( $parameters[ $position ] ) ) {
+			return false;
+		}
+
+		if ( ! $this->is_null_allowed( $parameter_args ) ) {
+			return false === $this->phpcsFile->findNext(
+				\T_NULL,
+				$parameters[ $position ]['start'],
+				( $parameters[ $position ]['end'] + 1 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Determines if null is allowed for the specific function argument.
+	 *
+	 * @param array $parameter_args The arguments of the parameter supplied to the function.
+	 *
+	 * @return bool True if null is allowed, False otherwise.
+	 */
+	protected function is_null_allowed( $parameter_args ) {
+		if ( ! isset( $parameter_args['allow_null'] ) ) {
+			return false;
+		}
+
+		return $parameter_args['allow_null'];
+	}
+}

--- a/Yoast/Tests/WP/RequiredOptionalParametersUnitTest.inc
+++ b/Yoast/Tests/WP/RequiredOptionalParametersUnitTest.inc
@@ -1,0 +1,30 @@
+<?php
+
+// Missing autoload option.
+update_option( 'a', 'b' );
+
+// Ok.
+update_option( 'a', 'b', true );
+
+// Null triggers an error, as it is not explicit.
+update_option( 'a', 'b', null );
+
+// Missing autoload option.
+add_option( 'a', 'b' );
+
+// Missing autoload option.
+add_option( 'a', 'b', '' );
+
+// Ok.
+add_option( 'a', 'b', '', 'yes' );
+
+// Null triggers an errors, as it is not explicit.
+add_option( 'a', 'b', '', null );
+
+add_option(
+	'a',
+	'b',
+	'',
+	// Testing comments.
+	null // phpcs:ignore Standard.Cat.SniffName -- testing comment ignoring
+);

--- a/Yoast/Tests/WP/RequiredOptionalParametersUnitTest.php
+++ b/Yoast/Tests/WP/RequiredOptionalParametersUnitTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Unit test class for the Yoast Coding Standard.
+ *
+ * @package Yoast\YoastCS
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace YoastCS\Yoast\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the RequiredOptionalParameters sniff.
+ *
+ * @package Yoast\YoastCS
+ *
+ * @since   1.1.0
+ */
+class RequiredOptionalParametersUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			10 => 1,
+			13 => 1,
+			16 => 1,
+			22 => 1,
+			24 => 1,
+		);
+	} // end getErrorList()
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getWarningList() {
+		return array(
+			4  => 1,
+		);
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
 	backupGlobals="true"
+	bootstrap="Tests/bootstrap.php"
 	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true">
 


### PR DESCRIPTION
Initially only checking `update_option` for the `autoload` parameter to be set.
This is an optional parameter, but we want to make sure it is set with intent.

As this class is based upon the `AbstractFunctionParameterSniff`-class from WPCS, some class-aliases need to be loaded to make it work.
These are being provided in the autoload-bootstrap.php file.

To make sure the tests also know where to find them, a test bootstrap file had to be added as well.

@jrfnl do I need to give props for the inspirational files and extended class and if so, how?

Fixes #74 