### PR TITLE
Composer: add note about why the DealerDirect plugin is suggested

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"phpmd/phpmd": "^2.2.3"
 	},
 	"suggest" : {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+		"dealerdirect/phpcodesniffer-composer-installer": "This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"scripts": {
 		"config-set" : [


### PR DESCRIPTION
Just suggesting a package does not explain to a user why it would be interesting for them to install it.

The `suggest` entry in the `composer.json` file has a value which is not actually intended for version constraints, but to add a hint to the user about why they should install the package.

Ref: https://getcomposer.org/doc/04-schema.md#suggest