### PR TITLE
CS: Remove `// end` comments

### DIFF
--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -36,7 +36,7 @@ class IfElseDeclarationSniff implements Sniff {
 			T_ELSEIF,
 		);
 
-	}//end register()
+	}
 
 
 	/**
@@ -97,6 +97,6 @@ class IfElseDeclarationSniff implements Sniff {
 			$phpcsFile->addError( $error, $stackPtr, 'StatementFound', $data );
 		}
 
-	}//end process()
+	}
 
-}//end class
+}

--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -297,4 +297,4 @@ class FileNameSniff implements Sniff {
 		return ltrim( strtr( $path, '\\', '/' ), '/' );
 	}
 
-} // End class.
+}

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -38,7 +38,7 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 			84 => 2,
 		);
 
-	} // end getErrorList()
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -50,4 +50,4 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 
 	}
 
-} // End class.
+}

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -114,7 +114,7 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 
 		return array( $testFileBase . '.inc' );
 
-	} // End getTestFiles().
+	}
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -151,4 +151,4 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		return array();
 	}
 
-} // End class.
+}


### PR DESCRIPTION
These are no longer required by WPCS and have also been removed from the WPCS code itself, so we may as well follow suit.