### PR TITLE
Update YoastCS native custom ruleset & build for PHPCS 3.3.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -24,16 +24,6 @@
 
 		<!-- Conflicts with variable names coming from PHPCS itself. -->
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
-
-		<!-- As the YoastCS ruleset is loaded *after* this ruleset, it overrules the
-			 PHPCompatibility testVersion set here, so we have to resort to excluding
-			 some error messages.... -->
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_traitFound"/>
-		<exclude name="PHPCompatibility.PHP.NewKeywords.t_dirFound"/>
-		<exclude name="PHPCompatibility.PHP.NewKeywords.t_namespaceFound"/>
-		<exclude name="PHPCompatibility.PHP.NewKeywords.t_useFound"/>
-		<exclude name="PHPCompatibility.PHP.NewLanguageConstructs.t_ns_separatorFound"/>
-
 	</rule>
 
 	<!-- Enforce PSR1 compatible namespaces. -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
     - if [[ "$PHPLINT" == "1" ]]; then if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
     - phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
     # Check the codestyle of the files within YoastCS.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_BIN --runtime-set ignore_warnings_on_exit 1; fi
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_BIN --runtime-set ignore_warnings_on_exit 1 --runtime-set testVersion 5.4-; fi
     # Validate the xml files.
     # @link http://xmlsoft.org/xmllint.html
     - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./Yoast/ruleset.xml; fi

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
 			"\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../../vendor/wp-coding-standards/wpcs,../../../vendor/wimg/php-compatibility",
 			"\"vendor/bin/phpcs\" --config-set default_standard Yoast"
 		],
+		"check-cs": [
+			"\"vendor/bin/phpcs\" --runtime-set testVersion 5.4-"
+		],
 		"post-install-cmd": "composer config-set",
 		"post-update-cmd": "composer config-set"
 	},


### PR DESCRIPTION
As of PHPCS 3.3.0, a configuration directive set in a custom ruleset, can be overruled from the command-line.

This allows us to get rid of the excludes in the YoastCS own ruleset which were needed as the minimum PHP requirement for YoastCS 0.5+ is PHP 5.4, while WP has a minimum requirement of PHP 5.2.4.

This also adds a `check-cs` script to the composer file to make it easier for people to run phpcs locally with the right command-line arguments.