### PR TITLE
Ruleset: add new sniff to standardize whitespace between functions

### DIFF
--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -24,7 +24,6 @@ use PHP_CodeSniffer\Util\Tokens;
  */
 class IfElseDeclarationSniff implements Sniff {
 
-
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -37,7 +36,6 @@ class IfElseDeclarationSniff implements Sniff {
 		);
 
 	}
-
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -98,5 +96,4 @@ class IfElseDeclarationSniff implements Sniff {
 		}
 
 	}
-
 }

--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -76,7 +76,6 @@ class FileNameSniff implements Sniff {
 		T_TRAIT,
 	);
 
-
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -85,7 +84,6 @@ class FileNameSniff implements Sniff {
 	public function register() {
 		return array( T_OPEN_TAG );
 	}
-
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -204,7 +202,6 @@ class FileNameSniff implements Sniff {
 		return ( $phpcsFile->numTokens + 1 );
 	}
 
-
 	/**
 	 * Check if the file is on the exclude list.
 	 *
@@ -245,7 +242,6 @@ class FileNameSniff implements Sniff {
 		return false;
 	}
 
-
 	/**
 	 * Clean a custom array property received from a ruleset.
 	 *
@@ -285,7 +281,6 @@ class FileNameSniff implements Sniff {
 		return $property;
 	}
 
-
 	/**
 	 * Normalize all directory separators to be a forward slash and remove prefixed slash.
 	 *
@@ -296,5 +291,4 @@ class FileNameSniff implements Sniff {
 	private function normalize_directory_separators( $path ) {
 		return ltrim( strtr( $path, '\\', '/' ), '/' );
 	}
-
 }

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -49,5 +49,4 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 		return array();
 
 	}
-
 }

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -80,7 +80,6 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		'FileNameUnitTest.inc'            => 1,
 	);
 
-
 	/**
 	 * Set CLI values before the file is tested.
 	 *
@@ -150,5 +149,4 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 
 		return array();
 	}
-
 }

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -71,6 +71,18 @@
 	<rule ref="Generic.PHP.LowerCaseType"/>
 	<rule ref="PSR12.Keywords.ShortFormTypeKeywords"/>
 
+	<!-- CS: standardize the number of blank lines between functions. -->
+	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
+		<properties>
+			<!-- In a class, there should be 1 blank line between functions ... -->
+			<property name="spacing" value="1"/>
+			<!-- and one blank line before the first function ... -->
+			<property name="spacingBeforeFirst" value="1"/>
+			<!-- and no blank line between the last function and the class closing brace. -->
+			<property name="spacingAfterLast" value="0"/>
+		</properties>
+	</rule>
+
 	<!-- ##### Documentation Sniffs vs empty index files ##### -->
 
 	<!-- Exclude the 'empty' index files from some documentation checks -->


### PR DESCRIPTION
As discussed with @moorscode, the Yoast plugins should have:
- 1 blank line between functions
- 1 blank line before the first function in a class
- no blank lines between the last function in a class and the class closing brace.

This sniff with the configuration as set, will take care of checking this and can auto-fix this for codebases.

In a second commit any violations against this rule in the YoastCS codebase are fixed.

