### PR TITLE
Ruleset: add new sniff to standardize whitespace at the end of functions

### DIFF
--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -34,7 +34,6 @@ class IfElseDeclarationSniff implements Sniff {
 			T_ELSE,
 			T_ELSEIF,
 		);
-
 	}
 
 	/**
@@ -94,6 +93,5 @@ class IfElseDeclarationSniff implements Sniff {
 			);
 			$phpcsFile->addError( $error, $stackPtr, 'StatementFound', $data );
 		}
-
 	}
 }

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -37,7 +37,6 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 			76 => 1,
 			84 => 2,
 		);
-
 	}
 
 	/**
@@ -47,6 +46,5 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 }

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -112,7 +112,6 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		}
 
 		return array( $testFileBase . '.inc' );
-
 	}
 
 	/**

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -83,6 +83,9 @@
 		</properties>
 	</rule>
 
+	<!-- CS: no blank line between the content of a function and a function close brace.-->
+	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
+
 	<!-- ##### Documentation Sniffs vs empty index files ##### -->
 
 	<!-- Exclude the 'empty' index files from some documentation checks -->


### PR DESCRIPTION
This sniff ensures that there are no blank lines between the body of a function and the close brace.

In a second commit any violations against this rule within the YoastCS codebase are fixed.

