### PR TITLE
Composer: use PHPCS 3.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
   # Test against the highest supported PHPCS version.
   - PHPCS_BRANCH="dev-master" PHPLINT=1
   # Test against the lowest supported PHPCS version.
-  - PHPCS_BRANCH="3.3.0"
+  - PHPCS_BRANCH="3.3.1"
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.3.0",
+		"squizlabs/php_codesniffer": "^3.3.1",
 		"wp-coding-standards/wpcs": "^1.0.0",
 		"phpcompatibility/phpcompatibility-wp": "^1.0.0",
 		"phpmd/phpmd": "^2.2.3"


### PR DESCRIPTION
Aside from it being a new release with lots of bug fixes, there are also a few specific changes in PHPCS 3.3.1 which benefit YoastCS and necessitate updating the minimum version:

> * Generic.Commenting.DocComment no longer generates the SpacingBeforeTags error if tags are the first content in the docblock
>     - The sniff will still generate a MissingShort error if there is no short comment
>     -This allows the MissingShort error to be suppressed in a ruleset to make short descriptions optional

As a lot of plugins still have issues with missing short descriptions, the `SpacingBeforeTags` error was also being thrown and had to be forcibly excluded. These exclusions can now be removed.

> * Squiz.WhiteSpace.FunctionSpacing no longer checks spacing of functions at the top of an embedded PHP block
>     - Fixes a conflict between this sniff and the Squiz.PHP.EmbeddedPHP sniff

This bug was discovered via one of the Yoast plugins, so having this fix prevents needing a work-around.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.3.1