### PR TITLE
Add more files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 vendor/
 composer.lock
+.phpcs.xml
+phpcs.xml
+phpunit.xml


### PR DESCRIPTION
These files are used locally by developers to override the `.dist` version of the same files as contained in this repo and should not be committed to the repo.