### PR TITLE
Update YoastCS to use WPCS 1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	"require": {
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.3.1",
-		"wp-coding-standards/wpcs": "^1.0.0",
+		"wp-coding-standards/wpcs": "^1.1.0",
 		"phpcompatibility/phpcompatibility-wp": "^1.0.0",
 		"phpmd/phpmd": "^2.2.3"
 	},


### PR DESCRIPTION
WPCS 1.1.0 was released yesterday: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0

No changes are needed in the ruleset file, nor in the YoastCS code base itself, though I expect that the change which was made in WPCS 1.1.0 regarding the `PEAR.Functions.FunctionCallSignature` sniff will warrant changes in the code bases of the individual plugin when they upgrade.