### PR TITLE
Update PHPCS and PHPCompatibility dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,21 +21,22 @@
 	},
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.3.1",
+		"squizlabs/php_codesniffer": "^3.3.2",
 		"wp-coding-standards/wpcs": "^1.1.0",
-		"phpcompatibility/phpcompatibility-wp": "^1.0.0",
+		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"phpmd/phpmd": "^2.2.3"
 	},
 	"require-dev": {
-		"phpcompatibility/php-compatibility": "^8.2.0",
-		"roave/security-advisories": "dev-master"
+		"phpcompatibility/php-compatibility": "^9.0.0",
+		"roave/security-advisories": "dev-master",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
 	},
 	"suggest" : {
 		"dealerdirect/phpcodesniffer-composer-installer": "This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"scripts": {
 		"config-set" : [
-			"\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../../vendor/wp-coding-standards/wpcs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-wp",
+			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
 			"\"vendor/bin/phpcs\" --config-set default_standard Yoast"
 		],
 		"check-cs": [


### PR DESCRIPTION
[PHPCompatibility 9.0.0](https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0) has just been released and renames all sniffs.
[PHPCompatibilityWP 2.0.0](https://github.com/PHPCompatibility/PHPCompatibilityWP/releases/tag/2.0.0) has been released alongside it.

Asides from that [PHP_CodeSniffer 3.3.2](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.3.2) has also been released with improved report layouts and a number of bugfixes.

The upgrade for this repo is simple as YoastCS currently doesn't use PHPCS inline annotations which reference PHPCompatibility sniffs, nor uses custom excludes.

As the PHPCompatibilityWP ruleset as of version 2.0 has an additional dependency, it is however opportune to let the DealerDirect plugin sort out the installed paths, at least for devs.

For the users of YoastCS, the DealerDirect plugin is advised anyway and for all repos which are already using a recent version of YoastCS, this has been implemented.