### PR TITLE
Build/Travis: Validate the PHPCS ruleset against XSD schema

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
-<ruleset name="Yoast Coding Standard">
-	<description>The Coding standard for the Yoast Coding Standard itself.</description>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    name="Yoast Coding Standard"
+    xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+	<description>The Coding standard for the YoastCS Coding Standard itself.</description>
 
 	<!-- Scan all files. -->
 	<file>.</file>

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
     - if [[ "$SNIFF" == "1" ]]; then composer check-cs; fi
     # Validate the xml files.
     # @link http://xmlsoft.org/xmllint.html
-    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./Yoast/ruleset.xml; fi
+    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./Yoast/ruleset.xml; fi
     - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./phpmd.xml; fi
     # Check the code-style consistency of the xml files.
     - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./Yoast/ruleset.xml <(xmllint --format "./Yoast/ruleset.xml"); fi

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="Yoast" namespace="YoastCS\Yoast">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Yoast" namespace="YoastCS\Yoast" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
 	<description>Yoast Coding Standards</description>
 
 	<!--


### PR DESCRIPTION
As of PHPCS 3.2.0, PHPCS includes an XSD schema for rulesets which defines what can be used in the XML ruleset file.

In PHPCS 3.3.0 a new array format for properties was introduced and as of PHPCS 3.3.2, the new array format is now also covered by this schema.

PR #99 updated the PHPCS requirement to PHPCS 3.3.2, so now we can actually use the XSD and validate against it.

This commit:
* Adds the schema tags to the `ruleset.xml` file as well as the native YoastCS `phpcs.xml.dist` file.
* Adds validation against the schema for the `ruleset.xml` file to the Travis build.

Fixes #91