### PR TITLE
Composer: sync script name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,14 +35,14 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"scripts": {
-		"config-set" : [
+		"config-yoastcs" : [
 			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
 			"\"vendor/bin/phpcs\" --config-set default_standard Yoast"
 		],
 		"check-cs": [
 			"\"vendor/bin/phpcs\" --runtime-set testVersion 5.4-"
 		],
-		"post-install-cmd": "composer config-set",
-		"post-update-cmd": "composer config-set"
+		"post-install-cmd": "composer config-yoastcs",
+		"post-update-cmd": "composer config-yoastcs"
 	}
 }


### PR DESCRIPTION
Even though the script isn't really needed, what with the DealerDirect plugin doing things automatically anyway, if it does exist, it makes more sense to have it named the same as the equivalent script in the Yoast plugin projects to make it more intuitive to use for devs.

Alternative, we could choose to just remove it.