### PR TITLE
Composer: Update DealerDirect Composer plugin and move to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,12 @@
 		"squizlabs/php_codesniffer": "^3.3.2",
 		"wp-coding-standards/wpcs": "^1.1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
-		"phpmd/phpmd": "^2.2.3"
+		"phpmd/phpmd": "^2.2.3",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0.0",
-		"roave/security-advisories": "dev-master",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
-	},
-	"suggest" : {
-		"dealerdirect/phpcodesniffer-composer-installer": "This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+		"roave/security-advisories": "dev-master"
 	},
 	"scripts": {
 		"config-yoastcs" : [


### PR DESCRIPTION
The [DealerDirect Composer plugin](https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases) has released version 0.5.0.

I've also done some testing to see if when the plugin is in the YoastCS `require` section, it will work, even if the individual projects which have YoastCS as a dependency do *not* explicitly require the DealerDirect plugin and have found this to work smoothly in most cases.

With that in mind, I've moved the dependency from the `require-dev` section to the `require` section and have removed  the `suggests` section.

This means that - in most cases - projects which `require(-dev)` YoastCS, will no longer need to have the plugin in their own `composer.json`.

Note:
Normally an external PHPCS standard should not include a Composer PHPCS plugin as an project installing the standard may already use a Composer PHPCS plugin, however as this is a company specific external PHPCS standard, we can take the liberty to include it.


----

When testing it worked in most cases, but not for the ACF plugin. I will, at a later point in time, run some more tests with that plugin to try & figure out what is go on there, but that shouldn't stop us simplifying the composer setup for the other plugins in the mean time.