### PR TITLE
Update YoastCS to use WPCS 1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	"require": {
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.3.2",
-		"wp-coding-standards/wpcs": "^1.1.0",
+		"wp-coding-standards/wpcs": "^1.2.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"phpmd/phpmd": "^2.2.3"
 	},


### PR DESCRIPTION
WPCS 1.2.0 has been released: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.2.0