### PR TITLE
TestDoubles: various improvements, including allowing multiple dirs

### DIFF
--- a/Yoast/Sniffs/Files/TestDoublesSniff.php
+++ b/Yoast/Sniffs/Files/TestDoublesSniff.php
@@ -93,7 +93,7 @@ class TestDoublesSniff implements Sniff {
 
 		if ( ! isset( $this->target_path ) || defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
 			$target_path  = $base_path;
-			$target_path .= ltrim( $this->normalize_directory_separators( $this->doubles_path ), '/' );
+			$target_path .= trim( $this->normalize_directory_separators( $this->doubles_path ), '/' ) . '/';
 
 			$this->target_path = false;
 			if ( file_exists( $target_path ) && is_dir( $target_path ) ) {
@@ -114,14 +114,9 @@ class TestDoublesSniff implements Sniff {
 			);
 		}
 
-		$path_info = pathinfo( $file );
-		if ( empty( $path_info['dirname'] ) ) {
-			return;
-		}
-
-		$tokens  = $phpcsFile->getTokens();
-		$dirname = $this->normalize_directory_separators( $path_info['dirname'] );
-		if ( false === $this->target_path || stripos( $dirname, $this->target_path ) === false ) {
+		$tokens       = $phpcsFile->getTokens();
+		$path_to_file = $this->normalize_directory_separators( $file );
+		if ( false === $this->target_path || stripos( $path_to_file, $this->target_path ) === false ) {
 			$phpcsFile->addError(
 				'Double/Mock test helper classes should be placed in the "%s" sub-directory. Found %s: %s',
 				$stackPtr,

--- a/Yoast/Sniffs/Files/TestDoublesSniff.php
+++ b/Yoast/Sniffs/Files/TestDoublesSniff.php
@@ -133,15 +133,23 @@ class TestDoublesSniff implements Sniff {
 		}
 
 		$more_objects_in_file = $phpcsFile->findNext( $this->register(), ( $stackPtr + 1 ) );
-		if ( false !== $more_objects_in_file ) {
+		if ( $more_objects_in_file === false ) {
+			$more_objects_in_file = $phpcsFile->findPrevious( $this->register(), ( $stackPtr - 1 ) );
+		}
+
+		if ( $more_objects_in_file !== false ) {
+			$data = array(
+				$tokens[ $stackPtr ]['content'],
+				$object_name,
+				$tokens[ $more_objects_in_file ]['content'],
+				$phpcsFile->getDeclarationName( $more_objects_in_file ),
+			);
+
 			$phpcsFile->addError(
-				'Double/Mock test helper classes should be in their own file. Found %s: %s',
+				'Double/Mock test helper classes should be in their own file. Found %1$s: %2$s and %3$s: %4$s',
 				$stackPtr,
 				'OneObjectPerFile',
-				array(
-					$tokens[ $stackPtr ]['content'],
-					$object_name,
-				)
+				$data
 			);
 		}
 	}

--- a/Yoast/Sniffs/Files/TestDoublesSniff.php
+++ b/Yoast/Sniffs/Files/TestDoublesSniff.php
@@ -89,8 +89,10 @@ class TestDoublesSniff implements Sniff {
 		}
 
 		$base_path = $this->normalize_directory_separators( $phpcsFile->config->basepath );
+		$base_path = rtrim( $base_path, '/' ) . '/'; // Make sure the base_path ends in a single slash.
+
 		if ( ! isset( $this->target_path ) || defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
-			$target_path  = $base_path . '/';
+			$target_path  = $base_path;
 			$target_path .= ltrim( $this->normalize_directory_separators( $this->doubles_path ), '/' );
 
 			$this->target_path = false;

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -102,6 +102,12 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 					5 => 1,
 				);
 
+			// In tests/doubles-not-correct.
+			case 'not-in-correct-subdir.inc':
+				return array(
+					3 => 1,
+				);
+
 			case 'not-double-or-mock.inc': // In tests.
 			case 'correct-dir-double.inc': // In tests/doubles.
 			case 'correct-dir-mock.inc': // In tests/doubles.

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -80,9 +80,14 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 					7 => 2,
 				);
 
+			case 'non-existant-doubles-dir.inc':
+				return array(
+					4 => 1,
+				);
+
 			case 'not-in-correct-custom-dir.inc':
 				return array(
-					4 => 2,
+					4 => 1,
 				);
 
 			case 'not-in-correct-dir-double.inc':
@@ -125,12 +130,19 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList( $testFile = '' ) {
-		if ( $testFile === 'no-basepath.inc' ) {
-			return array(
-				1 => 1,
-			);
-		}
+		switch ( $testFile ) {
+			case 'no-basepath.inc':
+				return array(
+					1 => 1,
+				);
 
-		return array();
+			case 'no-doubles-path-property.inc':
+				return array(
+					1 => 1,
+				);
+
+			default:
+				return array();
+		}
 	}
 }

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -75,6 +75,11 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 					5 => 2,
 				);
 
+			case 'multiple-objects-in-file-reverse.inc':
+				return array(
+					7 => 2,
+				);
+
 			case 'not-in-correct-custom-dir.inc':
 				return array(
 					4 => 2,
@@ -88,6 +93,13 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 			case 'not-in-correct-dir-mock.inc':
 				return array(
 					3 => 1,
+				);
+
+			// In tests/doubles.
+			case 'multiple-mocks-in-file.inc':
+				return array(
+					3 => 1,
+					5 => 1,
 				);
 
 			case 'not-double-or-mock.inc': // In tests.

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/doubles-not-correct/not-in-correct-subdir.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/doubles-not-correct/not-in-correct-subdir.inc
@@ -1,0 +1,3 @@
+<?php
+
+class ClassName_Double {}

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/doubles/multiple-mocks-in-file.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/doubles/multiple-mocks-in-file.inc
@@ -1,0 +1,5 @@
+<?php
+
+class Prefix_ClassName_Double {}
+
+class Prefix_ClassName_Mock {}

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/mocks/correct-custom-dir.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/mocks/correct-custom-dir.inc
@@ -1,6 +1,6 @@
-@codingStandardsChangeSetting Yoast.Files.TestDoubles doubles_path /tests/mocks
+phpcs:set Yoast.Files.TestDoubles doubles_path[] /tests/mocks,/tests/assets
 <?php
 
 class Prefix_ClassName_Double {}
 
-// @codingStandardsChangeSetting Yoast.Files.TestDoubles doubles_path /tests/doubles
+// phpcs:set Yoast.Files.TestDoubles doubles_path[] /tests/doubles

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/multiple-objects-in-file-reverse.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/multiple-objects-in-file-reverse.inc
@@ -1,0 +1,7 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class Test_ClassName extends extends TestCase {}
+
+class Prefix_ClassName_Double {}

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/no-doubles-path-property.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/no-doubles-path-property.inc
@@ -1,0 +1,6 @@
+<?php
+// phpcs:set Yoast.Files.TestDoubles doubles_path[]
+
+class Prefix_NoDoublesPathProperty_Double {}
+
+// phpcs:set Yoast.Files.TestDoubles doubles_path[] /tests/doubles

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/non-existant-doubles-dir.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/non-existant-doubles-dir.inc
@@ -1,0 +1,6 @@
+phpcs:set Yoast.Files.TestDoubles doubles_path[] /tests/doesnotexist,/tests/non-existant
+<?php
+
+class Prefix_ClassName_Double {}
+
+// phpcs:set Yoast.Files.TestDoubles doubles_path[] /tests/doubles

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/not-in-correct-custom-dir.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/not-in-correct-custom-dir.inc
@@ -1,6 +1,6 @@
-@codingStandardsChangeSetting Yoast.Files.TestDoubles doubles_path /tests/assets
+phpcs:set Yoast.Files.TestDoubles doubles_path[] /tests/mocks,/tests/assets
 <?php
 
 class Prefix_ClassName_Double {}
 
-// @codingStandardsChangeSetting Yoast.Files.TestDoubles doubles_path /tests/doubles
+// phpcs:set Yoast.Files.TestDoubles doubles_path[] /tests/doubles

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -45,6 +45,14 @@
 		</properties>
 	</rule>
 
+	<!-- Temporary work-around for upstream bug: squizlabs/PHP_CodeSniffer#2228 -->
+	<rule ref="Yoast.Files.TestDoubles">
+		<properties>
+			<property name="doubles_path" type="array">
+				<element value="/tests/doubles"/>
+			</property>
+		</properties>
+	</rule>
 
 	<!--
 	#############################################################################


### PR DESCRIPTION
As discussed with @moorscode, in rare circumstances, a plugin should be able to allow more than one directory to be used to place test doubles/mocks in.

This PR contains the sniff refactor to allow for that.

While looking at the sniff, I saw some more room for improvement, so I've fixed a few other things as well (in separate commits).

----

### TestDoubles: improve "OneObjectPerFile" check

While looking at this sniff, I realized that the "OneObjectPerFile" check only looked down, not up.

This commit fixes that.

### TestDoubles: stabilize slashes in base_path

Prevent the `$base_path` being double slashed if it would have a slash at the end of the path already.

### TestDoubles: improve path comparison

Make sure target_path always has an end slash to prevent a path like `/tests/doublesniff` to be recognized as correct when `/test/doubles` is in the allowed list.

This also changes the comparison from just using the `dirname` of the file being examined to using to complete file name, to prevent those kind of mismatches.

Unlikely to be a problem in real life, but the code should be correct.

### TestDoubles: allow for multiple paths

As discussed with @moorscode, in rare circumstances, a plugin should be able to allow more than one directory to be used to place test doubles/mocks in.

In this commit, the `doubles_path` sniff property is changed from a string to an array property.

In the previous version of this sniff, when the `doubles_path` would not be valid, both a `NoDoublesDirectory` as well as a `WrongDirectory` error would be thrown.

In this version, the `NoDoublesDirectory` error will only be thrown if none of the relative paths supplied exist.
If at least one path is valid and that path is not used, the sniff will only throw a `WrongDirectory` error.

Notes:
* Includes BC-break protection for if the value would still be supplied as a string to prevent BC-breaks.
    This snippet can be removed in YoastCS 2.0.0.
* Now uses PHPCS 3.2+ style annotations for the property changing within the test case files.
    This is preferred since setting array properties using `//phpcs:set` was greatly improved in PHPCS 3.3.0.
    See: squizlabs/PHP_CodeSniffer#1999

Includes unit tests.