### PR TITLE
New `Yoast.Commenting.FileComment` sniff

### DIFF
--- a/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
+++ b/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * YoastCS\Yoast\Sniffs\Commenting\CodeCoverageIgnoreDeprecatedSniff.
- *
- * @package Yoast\YoastCS
- * @author  Juliette Reinders Folmer
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace YoastCS\Yoast\Sniffs\Commenting;
 

--- a/Yoast/Sniffs/Commenting/FileCommentSniff.php
+++ b/Yoast/Sniffs/Commenting/FileCommentSniff.php
@@ -9,8 +9,18 @@ use PHP_CodeSniffer\Util\Tokens;
 /**
  * Namespaced files do not need a file docblock in YoastCS.
  *
- * - Non-namespaced files _do_ still need a file docblock.
- * - Files containing *scoped* namespaces also still need a file docblock.
+ * Note: Files without a namespace declaration do still need a file docblock.
+ * This includes files which have a non-named namespace declaration which
+ * falls back to the global namespace.
+ *
+ * {@internal At this moment - December 2018 -, the WordPress-Docs standard
+ * uses the PHPCS Squiz standard commenting sniffs. For that reason, this Yoast
+ * sniff extends the Squiz sniff as well.
+ * Once WPCS introduces a WordPress native FileComment sniff, this sniff should
+ * probably extend the WordPress native version instead.
+ * If/when that comes into play, the code in the sniff needs to be reviewed to
+ * see if it's still relevant to have this sniff and if so, if the sniff needs
+ * adjustments.}}
  *
  * @package Yoast\YoastCS
  * @author  Juliette Reinders Folmer
@@ -32,7 +42,7 @@ class FileCommentSniff extends Squiz_FileCommentSniff {
 
 		$namespace_token = $phpcsFile->findNext( T_NAMESPACE, $stackPtr );
 		if ( $namespace_token === false ) {
-			// No namespace found, normal rules apply.
+			// No namespace found, fall through to parent sniff.
 			return parent::process( $phpcsFile, $stackPtr );
 		}
 
@@ -45,16 +55,15 @@ class FileCommentSniff extends Squiz_FileCommentSniff {
 			|| $tokens[ $next_non_empty ]['code'] === T_NS_SEPARATOR
 		) {
 			// Either live coding, global namespace (i.e. not really namespaced) or namespace operator.
-			// Normal rules apply.
+			// Fall through to parent sniff.
 			return parent::process( $phpcsFile, $stackPtr );
 		}
-
 
 		$comment_start = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), $namespace_token, true );
 
 		if ( $tokens[ $comment_start ]['code'] === T_DOC_COMMENT_OPEN_TAG ) {
 			$phpcsFile->addWarning(
-				'A namespaced file does not need a file docblock',
+				'A file containing a (named) namespace declaration does not need a file docblock',
 				$comment_start,
 				'Unnecessary'
 			);

--- a/Yoast/Sniffs/Commenting/FileCommentSniff.php
+++ b/Yoast/Sniffs/Commenting/FileCommentSniff.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace YoastCS\Yoast\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FileCommentSniff as Squiz_FileCommentSniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Namespaced files do not need a file docblock in YoastCS.
+ *
+ * - Non-namespaced files _do_ still need a file docblock.
+ * - Files containing *scoped* namespaces also still need a file docblock.
+ *
+ * @package Yoast\YoastCS
+ * @author  Juliette Reinders Folmer
+ *
+ * @since   1.2.0
+ */
+class FileCommentSniff extends Squiz_FileCommentSniff {
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return int Stack pointer to skip the rest of the file.
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$namespace_token = $phpcsFile->findNext( T_NAMESPACE, $stackPtr );
+		if ( $namespace_token === false ) {
+			// No namespace found, normal rules apply.
+			return parent::process( $phpcsFile, $stackPtr );
+		}
+
+		$tokens = $phpcsFile->getTokens();
+
+		$next_non_empty = $phpcsFile->findNext( Tokens::$emptyTokens, ( $namespace_token + 1 ), null, true );
+		if ( $next_non_empty === false
+			|| $tokens[ $next_non_empty ]['code'] === T_SEMICOLON
+			|| $tokens[ $next_non_empty ]['code'] === T_OPEN_CURLY_BRACKET
+			|| $tokens[ $next_non_empty ]['code'] === T_NS_SEPARATOR
+		) {
+			// Either live coding, global namespace (i.e. not really namespaced) or namespace operator.
+			// Normal rules apply.
+			return parent::process( $phpcsFile, $stackPtr );
+		}
+
+
+		$comment_start = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), $namespace_token, true );
+
+		if ( $tokens[ $comment_start ]['code'] === T_DOC_COMMENT_OPEN_TAG ) {
+			$phpcsFile->addWarning(
+				'A namespaced file does not need a file docblock',
+				$comment_start,
+				'Unnecessary'
+			);
+		}
+
+		return ( $phpcsFile->numTokens + 1 );
+	}
+}

--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * YoastCS\Yoast\Sniffs\ControlStructures\IfElseDeclarationSniff.
- *
- * @package Yoast\YoastCS
- * @author  Juliette Reinders Folmer
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace YoastCS\Yoast\Sniffs\ControlStructures;
 

--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * YoastCS\Yoast\Sniffs\Files\FileNameSniff.
- *
- * @package Yoast\YoastCS
- * @author  Juliette Reinders Folmer
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace YoastCS\Yoast\Sniffs\Files;
 

--- a/Yoast/Sniffs/Files/TestDoublesSniff.php
+++ b/Yoast/Sniffs/Files/TestDoublesSniff.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * YoastCS\Yoast\Sniffs\Files\TestDoublesSniff.
- *
- * @package Yoast\YoastCS
- * @author  Juliette Reinders Folmer
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace YoastCS\Yoast\Sniffs\Files;
 

--- a/Yoast/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/Yoast/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * YoastCS\Yoast\Sniffs\WhiteSpace\FunctionSpacingSniff.
- *
- * @package Yoast\YoastCS
- * @author  Juliette Reinders Folmer
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace YoastCS\Yoast\Sniffs\WhiteSpace;
 

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Unit test class for the Yoast Coding Standard.
- *
- * @package Yoast\YoastCS
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace YoastCS\Yoast\Tests\Commenting;
 

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.1.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.1.inc
@@ -2,7 +2,14 @@
 /**
  * File Comment for a file without a namespace.
  *
- * @package Some\Package
+ * For the purposes of the unit test, the docblock here needs to comply with the
+ * complete Squiz file comment rules as the ruleset is not taken into account
+ * when unit testing sniffs.
+ *
+ * @package    Some\Package
+ * @subpackage Something\Else
+ * @author     Squiz Pty Ltd <products@squiz.net>
+ * @copyright  2018 Squiz Pty Ltd (ABN 77 084 670 600)
  */
 
 /**

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.1.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.1.inc
@@ -1,0 +1,15 @@
+<?php
+/**
+ * File Comment for a file without a namespace.
+ *
+ * @package Some\Package
+ */
+
+/**
+ * Class docblock.
+ */
+class Testing {
+	public function test() {
+		echo namespace\SomeClass::$static_property; // This is not a namespace declaration, but use of the namespace operator.
+	}
+}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.10.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.10.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace {
+
+	/**
+	 * Class docblock. A namespace keyword without actual namespace defaults to global namespace, so a file comment is needed, but missing.
+	 */
+	class Testing {}
+}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.2.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.2.inc
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * Class docblock. No namespace, file comment is needed, but missing.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.3.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.3.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yoast\Plugin\Sub;
+
+/**
+ * Class docblock. A file docblock is not needed in a namespaced file.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.4.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.4.inc
@@ -1,0 +1,13 @@
+<?php
+/**
+ * File Comment for a file WITH a namespace. This should be flagged as unnecessary.
+ *
+ * @package Some\Package
+ */
+
+namespace Yoast\Plugin\Sub;
+
+/**
+ * Class docblock.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.5.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.5.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Yoast\Plugin\Sub {
+
+	/**
+	 * Class docblock. A file docblock is not needed in a namespaced file, even when it contains scoped namespaces.
+	 */
+	class Testing {}
+}
+
+namespace Yoast\Plugin\Bub {
+
+	/**
+	 * Class docblock.
+	 */
+	class Testing {}
+}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.6.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.6.inc
@@ -1,0 +1,22 @@
+<?php
+/**
+ * File Comment for a file with one or more SCOPED namespace(s). This should be flagged as unnecessary.
+ *
+ * @package Some\Package
+ */
+
+namespace Yoast\Plugin\Sub {
+
+	/**
+	 * Class docblock.
+	 */
+	class Testing {}
+}
+
+namespace Yoast\Plugin\Bub {
+
+	/**
+	 * Class docblock.
+	 */
+	class Testing {}
+}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.7.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.7.inc
@@ -2,7 +2,10 @@
 /**
  * File Comment for a file with the namespace keyword, but no namespace.
  *
- * @package Some\Package
+ * @package    Some\Package
+ * @subpackage Something\Else
+ * @author     Squiz Pty Ltd <products@squiz.net>
+ * @copyright  2018 Squiz Pty Ltd (ABN 77 084 670 600)
  */
 
 namespace;

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.7.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.7.inc
@@ -1,0 +1,13 @@
+<?php
+/**
+ * File Comment for a file with the namespace keyword, but no namespace.
+ *
+ * @package Some\Package
+ */
+
+namespace;
+
+/**
+ * Class docblock.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.8.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.8.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace;
+
+/**
+ * Class docblock. A namespace keyword without actual namespace defaults to global namespace, so a file comment is needed, but missing.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.9.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.9.inc
@@ -2,7 +2,10 @@
 /**
  * File Comment for a file with the namespace keyword, but no namespace.
  *
- * @package Some\Package
+ * @package    Some\Package
+ * @subpackage Something\Else
+ * @author     Squiz Pty Ltd <products@squiz.net>
+ * @copyright  2018 Squiz Pty Ltd (ABN 77 084 670 600)
  */
 
 namespace {

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.9.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.9.inc
@@ -1,0 +1,14 @@
+<?php
+/**
+ * File Comment for a file with the namespace keyword, but no namespace.
+ *
+ * @package Some\Package
+ */
+
+namespace {
+
+	/**
+	 * Class docblock.
+	 */
+	class Testing {}
+}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.php
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace YoastCS\Yoast\Tests\Commenting;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the FileComment sniff.
+ *
+ * @package Yoast\YoastCS
+ *
+ * @since   1.2.0
+ */
+class FileCommentUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'FileCommentUnitTest.2.inc':
+			case 'FileCommentUnitTest.8.inc':
+			case 'FileCommentUnitTest.10.inc':
+				return array(
+					1 => 1,
+				);
+
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'FileCommentUnitTest.4.inc':
+			case 'FileCommentUnitTest.6.inc':
+				return array(
+					2 => 1,
+				);
+
+			default:
+				return array();
+		}
+	}
+}

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Unit test class for the Yoast Coding Standard.
- *
- * @package Yoast\YoastCS
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace YoastCS\Yoast\Tests\ControlStructures;
 

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Unit test class for Yoast Coding Standard.
- *
- * @package Yoast\YoastCS
- * @author  Juliette Reinders Folmer
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace YoastCS\Yoast\Tests\Files;
 

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Unit test class for Yoast Coding Standard.
- *
- * @package Yoast\YoastCS
- * @author  Juliette Reinders Folmer
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace YoastCS\Yoast\Tests\Files;
 

--- a/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Unit test class for the Yoast Coding Standard.
- *
- * @package Yoast\YoastCS
- * @license https://opensource.org/licenses/MIT MIT
- */
 
 namespace YoastCS\Yoast\Tests\WhiteSpace;
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -22,6 +22,23 @@
 		<!-- Excluded in favour of the YoastCS native Filename sniff. -->
 		<exclude name="WordPress.Files.FileName"/>
 
+		<!-- Excluded in favour of the YoastCS native FileComment sniff (which extends this sniff). -->
+		<exclude name="Squiz.Commenting.FileComment"/>
+		<!-- As the Yoast sniff extends the upstream sniff, we need to exclude the same error codes
+			 as WPCS excludes in the Docs ruleset, but now for the Yoast sniff.
+			 Once WPCS introduces a proper WP standards based FileComment sniff, the Yoast
+			 sniff should extend that sniff instead of the PHPCS Squiz sniff and
+			 these exclusions can then be removed. -->
+		<exclude name="Yoast.Commenting.FileComment.IncorrectAuthor"/>
+		<exclude name="Yoast.Commenting.FileComment.IncorrectCopyright"/>
+		<exclude name="Yoast.Commenting.FileComment.MissingAuthorTag"/>
+		<exclude name="Yoast.Commenting.FileComment.MissingSubpackageTag"/>
+		<exclude name="Yoast.Commenting.FileComment.MissingCopyrightTag"/>
+		<exclude name="Yoast.Commenting.FileComment.PackageTagOrder"/>
+		<exclude name="Yoast.Commenting.FileComment.SubpackageTagOrder"/>
+		<exclude name="Yoast.Commenting.FileComment.AuthorTagOrder"/>
+		<exclude name="Yoast.Commenting.FileComment.CopyrightTagOrder"/>
+
 		<!-- Demanding Yoda conditions is stupid. -->
 		<exclude name="WordPress.PHP.YodaConditions"/>
 
@@ -86,7 +103,7 @@
 	<!-- ##### Documentation Sniffs vs empty index files ##### -->
 
 	<!-- Exclude the 'empty' index files from some documentation checks -->
-	<rule ref="Squiz.Commenting.FileComment">
+	<rule ref="Yoast.Commenting.FileComment">
 		<exclude-pattern>*/index\.php</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.InlineComment.NoSpaceBefore">


### PR DESCRIPTION
This sniff is a wrapper around the `Squiz.Commenting.FileComment` sniff as included in the `WordPress-Docs` ruleset.

The wrapper checks whether the file is namespaced or not.

* If the file is namespaced (whether scoped or unscoped) and has a file comment, throw a warning about the file comment being unnecessary.
* If the file is namespaced, but without a namespace name, the normal rules from the `Squiz` sniff apply.

Includes unit test testing the logic in the wrapper. The logic in the Squiz sniff is tested upstream.

Fixes #106

### Remove redundant file comments

Remove file comments from the existing PHP files in this library to comply with the new `Yoast.Commenting.FileComment` sniff.