### PR TITLE
New `Yoast.Namespaces.NamespaceDeclaration` sniff

### DIFF
--- a/Yoast/Sniffs/Namespaces/NamespaceDeclarationSniff.php
+++ b/Yoast/Sniffs/Namespaces/NamespaceDeclarationSniff.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace YoastCS\Yoast\Sniffs\Namespaces;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Verify namespace declarations.
+ *
+ * This sniff:
+ * - Forbids the use of namespace declarations without a namespace name.
+ * - Forbids the use of scoped namespace declarations.
+ * - Forbids having more than one namespace declaration in a file.
+ *
+ * {@internal This sniff might be a good candidate for pulling upstream in PHPCS
+ * itself. An issue to that effect should be opened to see if there is interest.}}
+ *
+ * @package Yoast\YoastCS
+ * @author  Juliette Reinders Folmer
+ *
+ * @since   1.2.0
+ */
+class NamespaceDeclarationSniff implements Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_OPEN_TAG,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return int Stack pointer to skip the rest of the file.
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		$found_declaration = array();
+
+		while ( ( $stackPtr = $phpcsFile->findNext( T_NAMESPACE, ( $stackPtr + 1 ) ) ) !== false ) {
+
+			$next_non_empty = $phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+			if ( $next_non_empty === false ) {
+				// Live coding or parse error.
+				break;
+			}
+
+			if ( $tokens[ $next_non_empty ]['code'] === T_NS_SEPARATOR ) {
+				// Not a namespace declaration, but the use of the namespace keyword as operator.
+				continue;
+			}
+
+			// OK, found a namespace declaration.
+			$statements[] = $stackPtr;
+
+			if ( isset( $tokens[ $stackPtr ]['scope_condition'] )
+				&& $tokens[ $stackPtr ]['scope_condition'] === $stackPtr
+			) {
+				// Scoped namespace declaration.
+				$phpcsFile->addError(
+					'Scoped namespace declarations are not allowed.',
+					$stackPtr,
+					'ScopedForbidden'
+				);
+			}
+
+			if ( $tokens[ $next_non_empty ]['code'] === T_SEMICOLON
+				|| $tokens[ $next_non_empty ]['code'] === T_OPEN_CURLY_BRACKET
+			) {
+				// Namespace declaration without namespace name (= global namespace).
+				$phpcsFile->addError(
+					'Namespace declarations without a namespace name are not allowed.',
+					$stackPtr,
+					'NoNameForbidden'
+				);
+			}
+		}
+
+		$count = count( $statements );
+		if ( $count > 1 ) {
+			$data = array(
+				$count,
+				$tokens[ $statements[0] ]['line'],
+			);
+
+			for ( $i = 1; $i < $count; $i++ ) {
+				$phpcsFile->addError(
+					'There should be only one namespace declaration per file. Found %d namespace declarations. The first declaration was found on line %d',
+					$statements[ $i ],
+					'MultipleFound',
+					$data
+				);
+			}
+		}
+
+		return ( $phpcsFile->numTokens + 1 );
+	}
+}

--- a/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.1.inc
+++ b/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.1.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yoast\ValidDeclaration;
+
+echo namespace\ClassName::$property; // Ok, not namespace declaration.
+
+// Intentional parse error. This has to be the last test in the file.
+namespace

--- a/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.2.inc
+++ b/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.2.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace; // Error - no name.
+
+namespace {} // Error x 3 - no name + scoped namespace declaration + not the only namespace declaration in the file.
+
+namespace Yoast\SecondScopedNamespace {} // Error x 2 - scoped namespace declaration + not the only namespace declaration in the file.
+
+namespace /* some comment */ {} // Error x 3 - no name + scoped namespace declaration + not the only namespace declaration in the file.
+
+namespace /* some comment */; // Error x 2 - no name + not the only namespace declaration in the file.

--- a/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.php
+++ b/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace YoastCS\Yoast\Tests\Namespaces;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the NamespaceDeclaration sniff.
+ *
+ * @package Yoast\YoastCS
+ *
+ * @since   1.2.0
+ */
+class NamespaceDeclarationUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'NamespaceDeclarationUnitTest.2.inc':
+				return array(
+					3  => 1,
+					5  => 3,
+					7  => 2,
+					9  => 3,
+					11 => 2,
+				);
+
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+}


### PR DESCRIPTION
This sniff:
- Forbids the use of namespace declarations without a namespace name.
- Forbids the use of scoped namespace declarations.
- Forbids having more than one namespace declaration in a file.

Includes unit tests.

Fixes #110

---

Note: the build for this sniff won't pass until PR #111 has been merged as the code in this sniff already complies with the sniff being introduced in #111.
