### PR TITLE
PHPUnit: add Composer script to run the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
     - |
       if [[ "$SNIFF" == "1" ]]; then
           composer install --dev --no-suggest
-          # The post-install-cmd script takes care of the installed_paths.
+          # The DealerDirect Composer plugin script takes care of the installed_paths.
       else
           # For testing the YoastCS native sniffs, the rest of the packages aren't needed.
           composer remove wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp phpmd/phpmd --no-update

--- a/composer.json
+++ b/composer.json
@@ -29,17 +29,19 @@
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0.0",
-		"roave/security-advisories": "dev-master"
+		"roave/security-advisories": "dev-master",
+		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
 	},
 	"scripts": {
 		"config-yoastcs" : [
 			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
-			"\"vendor/bin/phpcs\" --config-set default_standard Yoast"
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
 		],
 		"check-cs": [
-			"\"vendor/bin/phpcs\" --runtime-set testVersion 5.4-"
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.4-"
 		],
-		"post-install-cmd": "composer config-yoastcs",
-		"post-update-cmd": "composer config-yoastcs"
+		"test": [
+			"@php ./vendor/phpunit/phpunit/phpunit --filter Yoast --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+		]
 	}
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,6 @@
 	colors="true">
 
 	<php>
-		<env name="PHPCS_IGNORE_TESTS" value="PHPCompatibility,WordPress,WordPress-Core,WordPress-Docs,WordPress-Extra,WordPress-VIP"/>
+		<env name="PHPCS_IGNORE_TESTS" value="PHPCompatibility,WordPress"/>
 	</php>
 </phpunit>


### PR DESCRIPTION
.. and various other tweaks.

### Unit testing the sniffs

A `dev` requirement of `phpunit/phpunit` has been added to the `composer.json` file, as well as a script to run the unit tests.
While PHPUnit is not strictly speaking a dependency of YoastCS (but of PHPCS), this just makes life easier on YoastCS developers who use the Composer install for development.

If - as a YoastCS sniff developer - you've installed YoastCS using Composer, you can now run the unit tests, like so:
```bash
composer test
```

**Note**: the `travis.yml` script does not use this script as it uses the Travis image native PHPUnit version instead of a (potentially) Composer installed one. For most builds PHPUnit wouldn't be Composer installed anyway as - except for one - all builds use `--no-dev`.

### Use the PHP version used by Composer for Composer scripts

Using the `@php` prefix in the scripts ensures that the scripts are run against the same PHP version as with which Composer is called, instead of against the system default PHP version.

This is important if - as a YoastCS dev - you change the PHP version for Composer to be able to test things against different PHP versions.

Ref: composer/composer#7645

### Minor cleanup of the `PHPCS_IGNORE_TESTS` directive

WPCS 2.0.0 will remove the `WordPress-VIP` standard. As that standard, as well as the other sub-standards of WPCS don't have their own unit tests anyway, we may as well remove references to them from the `phpunit.xml.dist` `PHPCS_IGNORE_TESTS` environment variable.

## Testing this PR;

It is recommended to test the Composer scripts as added/adjusted by this PR.