### PR TITLE
PHPCS/NamespaceDeclaration: bug fix

### DIFF
--- a/Yoast/Sniffs/Namespaces/NamespaceDeclarationSniff.php
+++ b/Yoast/Sniffs/Namespaces/NamespaceDeclarationSniff.php
@@ -48,7 +48,7 @@ class NamespaceDeclarationSniff implements Sniff {
 
 		$tokens = $phpcsFile->getTokens();
 
-		$found_declaration = array();
+		$statements = array();
 
 		while ( ( $stackPtr = $phpcsFile->findNext( T_NAMESPACE, ( $stackPtr + 1 ) ) ) !== false ) {
 


### PR DESCRIPTION
Argh... renamed a variable while writing the sniff and forgot to update the orginal declaration....

This should be released as YoastCS 1.2.1 (or 1.3.0 depending on what other PR will go in) ASAP.