### PR TITLE
PHPCS/PHPCompatibility: only scan PHP files

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -77,7 +77,9 @@
 	#############################################################################
 	-->
 	<config name="testVersion" value="5.2-"/>
-	<rule ref="PHPCompatibilityWP"/>
+	<rule ref="PHPCompatibilityWP">
+		<include-pattern>*\.php$</include-pattern>
+	</rule>
 
 
 	<!--


### PR DESCRIPTION
The YoastCS ruleset can be used to scan PHP, JS and CSS files, just like PHPCS and WPCS.

The PHPCompatibility ruleset, however, is only aimed at PHP files.

This small tweak makes sure that if a project contains JS and CSS files and the project based ruleset allows for those to be scanned, that the PHPCompatibility checks are only applied to PHP files.