### PR TITLE
Update to using WPCS 2.0.0

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -94,11 +94,6 @@
 	<!-- Error prevention: Make sure arithmetics are bracketed. -->
 	<rule ref="Squiz.Formatting.OperatorBracket.MissingBrackets"/>
 
-	<!-- CS: PHP type casts and type declarations should be in short form and lowercase. -->
-	<!-- These sniffs will be most likely be added to WPCS 2.0 and can then be removed from this ruleset. -->
-	<rule ref="Generic.PHP.LowerCaseType"/>
-	<rule ref="PSR12.Keywords.ShortFormTypeKeywords"/>
-
 	<!-- CS: no blank line between the content of a function and a function close brace.-->
 	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	"require": {
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.4.0",
-		"wp-coding-standards/wpcs": "^1.2.0",
+		"wp-coding-standards/wpcs": "^2.0.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"phpmd/phpmd": "^2.2.3",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"


### PR DESCRIPTION
* Update the Composer requirement;
* Remove sniffs from the ruleset which are now included in WPCS 2.0.0.

I've reviewed the existing sniffs and no other changes are needed, though the open PR #76 will need a change to the namespace used.

I propose we release/tag YoastCS 1.2.2 after this PR has been merged.

Refs:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/2.0.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-2.0.0-for-Developers-of-external-standards