### PR TITLE
Travis: use the correct minimum PHPCS version for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   # Test against the highest supported PHPCS version.
   - PHPCS_BRANCH="dev-master" PHPLINT=1
   # Test against the lowest supported PHPCS version.
-  - PHPCS_BRANCH="3.3.1"
+  - PHPCS_BRANCH="3.4.0"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
My bad. Forgot to update the Travis script in #117.