### PR TITLE
Composer: sync with other config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
 		"wordpress",
 		"yoast"
 	],
+	"homepage": "https://github.com/Yoast/yoastcs",
 	"license": "MIT",
 	"authors": [
 		{
@@ -17,7 +18,8 @@
 	],
 	"type" : "phpcodesniffer-standard",
 	"support": {
-		"issues": "https://github.com/Yoast/yoastcs/issues"
+		"issues": "https://github.com/Yoast/yoastcs/issues",
+		"source": "https://github.com/Yoast/yoastcs"
 	},
 	"require": {
 		"php": ">=5.4",
@@ -32,6 +34,8 @@
 		"roave/security-advisories": "dev-master",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
 	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"scripts": {
 		"config-yoastcs" : [
 			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
@@ -39,6 +43,9 @@
 		],
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.4-"
+		],
+		"fix-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
 		],
 		"test": [
 			"@php ./vendor/phpunit/phpunit/phpunit --filter Yoast --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"


### PR DESCRIPTION
I've done a compare between the `composer.json` config files in (nearly) all plugin/library repos.

This commit adds some additional properties to the config file to improve consistency with the other repos.

Additionally, it adds a `fix-cs` script for the convenience of developers.

Note: The `fix-cs` script does not have `--runtime-set testVersion 5.4-` in the command as that is only relevant for PHPCompatibility and the PHPCompatibility standard does not contain any fixers, so setting the `testVersion` is not needed when running `phpcbf`.

### Testing

I've tested the new script already, but if someone else wants to test as well:
1. Throw away an existing `vendor` directory and `composer.lock` file.
2. Run `composer install`
3. Run `composer fix-cs`. Take note of the reported progress and that no fixable errors were found.
4. Introduce some (whitespace) issues in one of the files in this repo.
5. Run `composer fix-cs` again. The progress dot for the changed file should now be changed to an `F` and it should finish with a summary of the errors & warnings fixed.