### PR TITLE
Travis: test builds against PHP 7.4 & work around for PHPUnit 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - nightly
+    - "7.4snapshot"
 
 env:
   # Test against the highest supported PHPCS version.
@@ -42,7 +42,7 @@ matrix:
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: nightly
+    - php: "7.4snapshot"
 
 before_install:
     # Speed up build time by disabling Xdebug.

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ before_install:
       else
           # For testing the YoastCS native sniffs, the rest of the packages aren't needed.
           composer remove wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp phpmd/phpmd --no-update
+          # The Travis images for PHP >= 7.2 ship with PHPUnit 8, but the unit test suite is not compatible with that.
+          if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then composer require phpunit/phpunit:^7.0 --no-update --no-suggest --no-scripts;fi
           # This will now only install the version of PHPCS to test against.
           composer install --no-dev --no-suggest --no-scripts
           # Set the installed_paths for the test environment.
@@ -69,7 +71,12 @@ before_install:
 
 script:
     - if [[ "$PHPLINT" == "1" ]]; then if find . -path ./vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
-    - phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
+    - |
+      if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
+        vendor/bin/phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
+      else
+        phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
+      fi
     # Check the codestyle of the files within YoastCS.
     - if [[ "$SNIFF" == "1" ]]; then composer check-cs; fi
     # Validate the xml files.


### PR DESCRIPTION
### Travis: test builds against PHP 7.4

Nightly has become PHP 8.0 since PHP 7.4 has been branched, so to continue to also test against PHP 7.4, it needs to be added separately.

Refs:
* https://twitter.com/nikita_ppv/status/1089839541828112384
* https://twitter.com/nikita_ppv/status/1094897743594770433

As PHP 8.x - current `nightly` - is not expected to be released until December 2020, with PHP 7.4 expected in December 2019, I've elected to replace the build against `nightly` with a build against `7.4snapshot`.

Once PHP 7.4 is released, the "high PHP" build - currently PHP 7.3 - should be replaced with a build against PHP 7.4 (stable) and the "unstable" build - now `7.4snapshot` - should be reverted to `nightly`.

### Travis: work around PHPUnit 8.x on PHP >= 7.2 images

As of recently, the Travis images for PHP 7.2+ ship with PHPUnit 8.x.
The PHPCS native test framework is not compatible with PHPUnit 8.x and won't be able to be made compatible with it until the minimum PHP version would be raised to PHP 7.1.

So for the unit tests to be able to run on PHP 7.2+, we need to explicitly require PHPUnit 7.x for those builds.

As for nightly: there is no PHPUnit version which is currently compatible with PHP 8.

---

#### Technical explanation:

PHPUnit 8 adds `void` return type declarations to the PHPUnit methods used by PHPCS, making it neigh impossible to make the unit test suite cross-version compatible for the PHP versions supported by PHPCS as the `void` return type was only added in PHP 7.1 and the minimum PHP version supported by PHPCS is 5.4.

Officially, PHPUnit 7 is compatible with PHP 7.1, 7.2 and 7.3. However for the functionality used by the PHPCS test suite, it looks to be compatible with PHP 7.4 as well (for now).
Ref: https://phpunit.de/supported-versions.html

For this reason, for Travis images which come natively with PHPUnit 8 (PHP >= 7.2), PHPUnit 7 needs to be installed via Composer.
This is not necessary for older PHP versions as the Travis native PHPUnit version works fine for those.

As for nightly/PHP 8:

* The Travis native PHPUnit version for nightly is PHPUnit 8, which will not work.
* Running composer install for PHPUnit on nightly currently installs PHPUnit 4.1.6. Most likely because the PHPUnit 4.x composer.json file did not yet contain a PHP requirement, while any higher PHPUnit versions do. Anyways, that will most definitely not work.
* Running composer install for PHPUnit with an explicit requirement of PHPUnit 7.x will also not work as PHPUnit 7 will not install on PHP 8 based on the PHPUnit composer.json file.

All in all, the unit tests can not currently be run on PHP 8.