### PR TITLE
Add new Yoast.Yoast.AlternativeFunctions sniff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,17 +24,18 @@ php:
     - "7.4snapshot"
 
 env:
-  # Test against the highest supported PHPCS version.
-  - PHPCS_BRANCH="dev-master" PHPLINT=1
-  # Test against the lowest supported PHPCS version.
-  - PHPCS_BRANCH="3.4.0"
+  # Test against the highest/lowest supported PHPCS and WPCS versions.
+  - PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
+  - PHPCS_BRANCH="dev-master" WPCS="2.0.0"
+  - PHPCS_BRANCH="3.4.0" WPCS="dev-develop"
+  - PHPCS_BRANCH="3.4.0" WPCS="2.0.0"
 
 matrix:
   fast_finish: true
   include:
     # Extra build to check for XML codestyle.
     - php: 7.1
-      env: PHPCS_BRANCH="dev-master" SNIFF=1
+      env: PHPCS_BRANCH="dev-master" WPCS="^2.0.0" SNIFF=1
       addons:
           apt:
               packages:
@@ -54,20 +55,22 @@ before_install:
     - export PHPCS_BIN=$(pwd)/vendor/bin/phpcs
     # Set the PHPCS version to test against.
     - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --no-update --no-suggest --no-scripts
+    # Set the WPCS version to test against.
+    - composer require wp-coding-standards/wpcs:${WPCS} --no-update --no-suggest --no-scripts
     - |
       if [[ "$SNIFF" == "1" ]]; then
           composer install --dev --no-suggest
           # The DealerDirect Composer plugin script takes care of the installed_paths.
       else
           # For testing the YoastCS native sniffs, the rest of the packages aren't needed.
-          composer remove wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp phpmd/phpmd --no-update
+          composer remove phpcompatibility/phpcompatibility-wp phpmd/phpmd --no-update
           # The Travis images for PHP >= 7.2 ship with PHPUnit 8, but the unit test suite is not compatible with that.
           if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then composer require phpunit/phpunit:^7.0 --no-update --no-suggest --no-scripts;fi
-          # This will now only install the version of PHPCS to test against.
-          composer install --no-dev --no-suggest --no-scripts
-          # Set the installed_paths for the test environment.
-          $PHPCS_BIN --config-set installed_paths $(pwd)
+          # This will now only install the version of PHPCS/WPCS to test against.
+          composer install --no-dev --no-suggest
+          # The DealerDirect Composer plugincompos script takes care of the installed_paths.
       fi
+    - $PHPCS_BIN -i
 
 script:
     - if [[ "$PHPLINT" == "1" ]]; then if find . -path ./vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi

--- a/Yoast/Sniffs/Yoast/AlternativeFunctionsSniff.php
+++ b/Yoast/Sniffs/Yoast/AlternativeFunctionsSniff.php
@@ -50,11 +50,11 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			$replacement = $this->groups[ $group_name ]['replacement'];
 		}
 
-		$fixable = true;
-		$error   = $this->groups[ $group_name ]['message'];
-		$type    = ( $this->groups[ $group_name ]['type'] === 'error' );
-		$code    = $this->string_to_errorcode( $group_name . '_' . $matched_content );
-		$data    = array(
+		$fixable    = true;
+		$message    = $this->groups[ $group_name ]['message'];
+		$is_error   = ( $this->groups[ $group_name ]['type'] === 'error' );
+		$error_code = $this->string_to_errorcode( $group_name . '_' . $matched_content );
+		$data       = array(
 			$matched_content,
 			$replacement,
 		);
@@ -70,19 +70,19 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				 * when only the first parameter is passed.
 				 */
 				if ( $this->get_function_call_parameter_count( $stackPtr ) !== 1 ) {
-					$fixable = false;
-					$code   .= 'WithAdditionalParams';
+					$fixable     = false;
+					$error_code .= 'WithAdditionalParams';
 				}
 
 				break;
 		}
 
 		if ( $fixable === false ) {
-			$this->addMessage( $error, $stackPtr, $type, $code, $data );
+			$this->addMessage( $message, $stackPtr, $is_error, $error_code, $data );
 			return;
 		}
 
-		$fix = $this->addFixableMessage( $error, $stackPtr, $type, $code, $data );
+		$fix = $this->addFixableMessage( $message, $stackPtr, $is_error, $error_code, $data );
 		if ( $fix === true ) {
 			$namespaced = $this->determine_namespace( $stackPtr );
 

--- a/Yoast/Sniffs/Yoast/AlternativeFunctionsSniff.php
+++ b/Yoast/Sniffs/Yoast/AlternativeFunctionsSniff.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace YoastCS\Yoast\Sniffs\Yoast;
+
+use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Discourages the use of various functions and suggests (Yoast) alternatives.
+ *
+ * @package Yoast\YoastCS
+ * @author  Juliette Reinders Folmer
+ *
+ * @since   1.3.0
+ */
+class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'json_encode' => array(
+				'type'        => 'error',
+				'message'     => 'Detected a call to %s(). Use %s() instead.',
+				'functions'   => array(
+					'json_encode',
+					'wp_json_encode',
+				),
+				'replacement' => 'WPSEO_Utils::format_json_encode',
+			),
+		);
+	}
+
+	/**
+	 * Process a matched token.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+
+		$replacement = '';
+		if ( isset( $this->groups[ $group_name ]['replacement'] ) ) {
+			$replacement = $this->groups[ $group_name ]['replacement'];
+		}
+
+		$fixable = true;
+		$error   = $this->groups[ $group_name ]['message'];
+		$type    = ( $this->groups[ $group_name ]['type'] === 'error' );
+		$code    = $this->string_to_errorcode( $group_name . '_' . $matched_content );
+		$data    = array(
+			$matched_content,
+			$replacement,
+		);
+
+		/*
+		 * Deal with specific situations.
+		 */
+		switch ( $matched_content ) {
+			case 'json_encode':
+			case 'wp_json_encode':
+				/*
+				 * The function `WPSEO_Utils:format_json_encode()` is only a valid alternative
+				 * when only the first parameter is passed.
+				 */
+				if ( $this->get_function_call_parameter_count( $stackPtr ) !== 1 ) {
+					$fixable = false;
+					$code   .= 'WithAdditionalParams';
+				}
+
+				break;
+		}
+
+		if ( $fixable === false ) {
+			$this->addMessage( $error, $stackPtr, $type, $code, $data );
+			return;
+		}
+
+		$fix = $this->addFixableMessage( $error, $stackPtr, $type, $code, $data );
+		if ( $fix === true ) {
+			$namespaced = $this->determine_namespace( $stackPtr );
+
+			if ( empty( $namespaced ) || empty( $replacement ) ) {
+				$this->phpcsFile->fixer->replaceToken( $stackPtr, $replacement );
+			}
+			else {
+				$this->phpcsFile->fixer->replaceToken( $stackPtr, '\\' . $replacement );
+			}
+		}
+	}
+}

--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc
@@ -1,0 +1,22 @@
+<?php
+
+$json = WPSEO_Utils:format_json_encode( $thing ); // OK.
+
+// Don't trigger on calls to functions which are not the PHP or WP native functions.
+$json = Class_Other_Plugin::json_encode( $thing ); // OK.
+$json = $obj->wp_json_encode( $thing ); // OK.
+$json = MyNamespace\json_encode( $thing ); // OK.
+//$json = namespace\wp_json_encode( $thing );  // OK - this will not (yet) be correctly recognized, but will with WPCS 2.1.0.
+
+// The sniff should trigger on these.
+$json = json_encode( $thing ); // Error.
+$json = wp_json_encode( $thing ); // Error.
+return function_call(nested_call(json_encode( $thing ))); // Error.
+
+$json = json_encode ($value, $options); // Error, non-fixable.
+$json = wp_json_encode( $data, $options, $depth ); // Error, non-fixable.
+
+namespace Yoast\CMS\Plugin\Dir;
+
+$json = json_encode( $thing ); // Error.
+$json = wp_json_encode( $thing ); // Error.

--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc.fixed
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc.fixed
@@ -1,0 +1,22 @@
+<?php
+
+$json = WPSEO_Utils:format_json_encode( $thing ); // OK.
+
+// Don't trigger on calls to functions which are not the PHP or WP native functions.
+$json = Class_Other_Plugin::json_encode( $thing ); // OK.
+$json = $obj->wp_json_encode( $thing ); // OK.
+$json = MyNamespace\json_encode( $thing ); // OK.
+//$json = namespace\wp_json_encode( $thing );  // OK - this will not (yet) be correctly recognized, but will with WPCS 2.1.0.
+
+// The sniff should trigger on these.
+$json = WPSEO_Utils::format_json_encode( $thing ); // Error.
+$json = WPSEO_Utils::format_json_encode( $thing ); // Error.
+return function_call(nested_call(WPSEO_Utils::format_json_encode( $thing ))); // Error.
+
+$json = json_encode ($value, $options); // Error, non-fixable.
+$json = wp_json_encode( $data, $options, $depth ); // Error, non-fixable.
+
+namespace Yoast\CMS\Plugin\Dir;
+
+$json = \WPSEO_Utils::format_json_encode( $thing ); // Error.
+$json = \WPSEO_Utils::format_json_encode( $thing ); // Error.

--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.php
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace YoastCS\Yoast\Tests\Yoast;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the AlternativeFunctions sniff.
+ *
+ * @package Yoast\YoastCS
+ *
+ * @since   1.3.0
+ */
+class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			12 => 1,
+			13 => 1,
+			14 => 1,
+			16 => 1,
+			17 => 1,
+			21 => 1,
+			22 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+}

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -51,6 +51,15 @@
 		<exclude name="WordPress.PHP.StrictInArray.FoundNonStrictFalse"/>
 	</rule>
 
+	<rule ref="WordPress.WP.AlternativeFunctions">
+		<properties>
+			<property name="exclude" type="array">
+				<!-- Excluded in favour of the YoastCS native AlternativeFunctions sniff. -->
+				<element value="json_encode"/>
+			</property>
+		</properties>
+	</rule>
+
 	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
 		<properties>
 			<!-- No need to adjust alignment of large arrays when the item with the largest key is removed. -->


### PR DESCRIPTION
This introduces a new sniff to YoastCS: `Yoast.Yoast.AlternativeFunctions` which will initially sniff for function calls to `json_encode()` and `wp_json_encode()` and throw an `error` when these are detected, suggesting to use `WPSEO_Utils::format_json_encode()`  instead.

The sniff has been set up to easily allow for additional function groups to be added where the use of PHP/WP native functions should be discouraged in favour of using Yoast native functions.

Includes auto-fixer.
Includes unit tests.

Includes disabling the WPCS native check for `json_encode()` which recommends using `wp_json_encode()`.

Additional notes:
* The sniff will not trigger on calls to non-global functions of the same name.
* As it currently is, the sniff will throw false positives for namespaced functions imported via a `use` statement, like in the below code sample, but this is not an issue for the current Yoast code bases.
    ```php
    use function My\Namespace\some_function as wp_json_encode;

    wp_json_encode( $data );
    ```
* As it currently is, the sniff will throw a false positive for code using the `namespace` keyword as an operator.
     This will be fixed in WPCS 2.1.0 and the unit test can be uncommented once WPCS 2.1.0 has been released and YoastCS ups its minimum WPCS requirement.
* The auto-fixer will only be allowed to run when the function call detected only passes one parameter.
    Both the `json_encode()`, as well as the `wp_json_encode()` functions allow for passing three parameters `$data, $options, $depth`.
    The new Yoast native `WPSEO_Utils:format_json_encode()` method only allows for the first parameter and auto-fixing would break any function call passing more than one parameter.
    An (non-fixable) error with a separate error code will still be thrown in that case.
* The auto-fixer takes into account that code may be namespaced and will prefix the replacement with a `\` to indicate that the class name is fully qualified if it is detected that the file is namespaced.
    It will *not* add a `use` statement for the class, that is outside the scope of this sniff.
* While the duplication within the name may appear a little redundant, I've created this to mirror WPCS, where the `WP` category has sniffs regarding WP features being sniffed for, just like this sniff is sniffing for a `Yoast` specific feature (not) being used.
    Alternative category name suggestions welcome.
* Once the sniff has been merged and WPSEO has adopted the latest version of YoastCS, the call to `wp_json_encode()` from within the `WPSEO_Utils::format_json_encode()` function will need to be whitelisted for this sniff.

Fixes #124