### PR TITLE
Composer: update minimum CS versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
 	},
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.4.0",
-		"wp-coding-standards/wpcs": "^2.0.0",
+		"squizlabs/php_codesniffer": "^3.4.2",
+		"wp-coding-standards/wpcs": "^2.1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"phpmd/phpmd": "^2.2.3",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"


### PR DESCRIPTION
* PHPCS has released version 3.4.2.
* WPCS has released version 2.1.0.

Refs:
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.4.1
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.4.2
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/2.1.0