### PR TITLE
YoastCS: add new `Yoast.Commenting.CoversTag` sniff

### DIFF
--- a/Yoast/Sniffs/Commenting/CoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/CoversTagSniff.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace YoastCS\Yoast\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Verifies that a @covers tag annotation follows a format supported by PHPUnit.
+ *
+ * Also ensures that:
+ * - each @covers tag has an annotation;
+ * - there are no duplicate @covers tags;
+ * - there are no duplicate @coversNothing tags;
+ * - a method does not have both a @covers as well as a @coversNothing tag.
+ *
+ * @package Yoast\YoastCS
+ * @author  Juliette Reinders Folmer
+ *
+ * @since   1.3.0
+ */
+class CoversTagSniff implements Sniff {
+
+	/**
+	 * Regex to check for valid content of a @covers tags.
+	 *
+	 * Takes the WP naming conventions into account (up to a point).
+	 *
+	 * @var string
+	 */
+	const VALID_CONTENT_REGEX = '(?:\\\\?(?:(?<OOName>[A-Z][a-zA-Z0-9_\x7f-\xff]*)\\\\)*(?P>OOName)(?:<extended>|::<[!]?(?:public|protected|private)>|::(?<functionName>(?!public$|protected$|private$)[a-z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*))?|::(?P>functionName)|\\\\?(?:(?P>OOName)\\\\)+(?P>functionName))';
+
+	/**
+	 * Base error message.
+	 *
+	 * Will be enhanced during the run.
+	 *
+	 * @var string
+	 */
+	const ERROR_MSG = 'Invalid @covers annotation found.';
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_DOC_COMMENT_OPEN_TAG,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		$firstCoversTag    = false;
+		$coversTags        = [];
+		$coversNothingTags = [];
+		foreach ( $tokens[ $stackPtr ]['comment_tags'] as $tag ) {
+			if ( $tokens[ $tag ]['content'] === '@coversNothing' ) {
+				$coversNothingTags[] = $tag;
+				continue;
+			}
+
+			if ( $tokens[ $tag ]['content'] !== '@covers' ) {
+				continue;
+			}
+
+			if ( $firstCoversTag === false ) {
+				$firstCoversTag = $tag;
+			}
+
+			// Found a @covers tag.
+			$next = $phpcsFile->findNext( T_DOC_COMMENT_WHITESPACE, ( $tag + 1 ), null, true );
+			if ( $tokens[ $next ]['code'] !== T_DOC_COMMENT_STRING
+				|| $tokens[ $next ]['line'] !== $tokens[ $tag ]['line']
+			) {
+				$phpcsFile->addError(
+					'A @covers tag must indicate which class/function/method is being covered by the test',
+					$tag,
+					'Empty'
+				);
+
+				continue;
+			}
+
+			$annotation                 = $tokens[ $next ]['content'];
+			$coversTags[ "$tag-$next" ] = $annotation;
+
+			if ( preg_match( '`^' . self::VALID_CONTENT_REGEX . '$`', $annotation ) === 1 ) {
+				continue;
+			}
+
+			/*
+			 * Account for a number of common "mistakes".
+			 */
+
+			$errorThrown = false;
+
+			// Check for Union/Intersect types.
+			if ( strpos( $annotation, '&' ) !== false ) {
+				if ( $this->fixAnnotationToSplit( $phpcsFile, $next, 'IntersectFound', '&' ) === true ) {
+					continue;
+				}
+
+				$errorThrown = true;
+			}
+
+			if ( strpos( $annotation, '|' ) !== false ) {
+				if ( $this->fixAnnotationToSplit( $phpcsFile, $next, 'UnionFound', '|' ) === true ) {
+					continue;
+				}
+
+				$errorThrown = true;
+			}
+
+			// Parentheses/Braces at the end of the annotation.
+			$expected = rtrim( $annotation, '(){} ' );
+			if ( $this->fixSimpleError( $phpcsFile, $next, $expected, 'InvalidBraces' ) === true ) {
+				$errorThrown = true;
+
+			}
+
+			// Incorrect `<public|protected|private>` annotation.
+			if ( preg_match( '`::[{(\[]?(!)?(public|protected|private)[})\]]?`', $annotation, $matches ) === 1 ) {
+				$replacement = '::<' . $matches[1] . $matches[2] . '>';
+				$expected    = str_replace( $matches[0], $replacement, $annotation );
+
+				if ( $this->fixSimpleError( $phpcsFile, $next, $expected, 'InvalidFunctionGroup' ) === true ) {
+					$errorThrown = true;
+				}
+			}
+
+			if ( $errorThrown === true ) {
+				// We've already thrown an error. No need for duplicates.
+				continue;
+			}
+
+			// Throw a generic error for all other invalid annotations.
+			$error  = self::ERROR_MSG;
+			$error .= ' Check the PHPUnit documentation to see which annotations are supported. Found: %s';
+			$data   = array( $annotation );
+			$phpcsFile->addError( $error, $next, 'Invalid', $data );
+		}
+
+		$coversNothingCount = count( $coversNothingTags );
+		if ( $firstCoversTag !== false && $coversNothingCount > 0 ) {
+			$error = 'A test can\'t both cover something as well as cover nothing. First @coversNothing tag encountered on line %d; first @covers tag encountered on line %d';
+			$data  = array(
+				$tokens[ $coversNothingTags[0] ]['line'],
+				$tokens[ $firstCoversTag ]['line'],
+			);
+
+			$phpcsFile->addError( $error, $tokens[ $stackPtr ]['comment_closer'], 'Contradictory', $data );
+		}
+
+		if ( $coversNothingCount > 1 ) {
+			$error      = 'Only one @coversNothing tag allowed per test';
+			$code       = 'DuplicateCoversNothing';
+			$fixable    = true;
+			$removeTags = array();
+			foreach ( $coversNothingTags as $position => $ptr ) {
+				$next = ( $ptr + 1 );
+				if ( $tokens[ $next ]['code'] === T_DOC_COMMENT_WHITESPACE
+					&& $tokens[ $next ]['content'] === $phpcsFile->eolChar
+				) {
+					// No comment, ok to remove.
+					$removeTags[] = $ptr;
+				}
+			}
+
+			$removalCount = count( $removeTags );
+			if ( ( $coversNothingCount - $removalCount ) > 1 ) {
+				// More than one tag had a comment.
+				$phpcsFile->addError( $error, $tokens[ $stackPtr ]['comment_closer'], $code );
+			}
+			else {
+
+				$fix = $phpcsFile->addFixableError( $error, $tokens[ $stackPtr ]['comment_closer'], $code );
+				if ( $fix === true ) {
+					$skipFirst = ( $coversNothingCount === $removalCount );
+
+					$phpcsFile->fixer->beginChangeset();
+
+					foreach ( $removeTags as $key => $ptr ) {
+						if ( $skipFirst === true && $key === 0 ) {
+							// Let the first one remain if none of the tags has a comment.
+							continue;
+						}
+
+						// Remove the whole line.
+						for ( $i = ( $ptr + 1 ); $i >= 0; $i-- ) {
+							if ( $tokens[ $i ]['line'] !== $tokens[ $ptr ]['line'] ) {
+								break;
+							}
+
+							$phpcsFile->fixer->replaceToken( $i, '' );
+						}
+					}
+
+					$phpcsFile->fixer->endChangeset();
+				}
+			}
+		}
+
+		$coversCount = count( $coversTags );
+		if ( $coversCount > 1 ) {
+			$unique = array_unique( $coversTags );
+			if ( count( $unique ) !== $coversCount ) {
+				$value_count = array_count_values( $coversTags );
+				$error       = 'Duplicate @covers tag found. First tag with the same annotation encountered on line %d';
+				$code        = 'DuplicateCovers';
+				foreach ( $value_count as $annotation => $count ) {
+					if ( $count < 2 ) {
+						continue;
+					}
+
+					$first = null;
+					foreach ( $coversTags as $ptrs => $annot ) {
+						if ( $annotation !== $annot ) {
+							continue;
+						}
+
+						if ( ! isset( $first ) ) {
+							$first = explode( '-', $ptrs );
+							$data  = array( $tokens[ $first[0] ]['line'] );
+							continue;
+						}
+
+						$ptrs = explode( '-', $ptrs );
+
+						$fix = $phpcsFile->addFixableError( $error, $ptrs[0], $code, $data );
+						if ( $fix === true ) {
+
+							$phpcsFile->fixer->beginChangeset();
+
+							// Remove the whole line.
+							for ( $i = ( $ptrs[1] ); $i >= 0; $i-- ) {
+								if ( $tokens[ $i ]['line'] !== $tokens[ $ptrs[1] ]['line'] ) {
+									if ( $tokens[ $i ]['code'] === T_DOC_COMMENT_WHITESPACE
+										&& $tokens[ $i ]['content'] === $phpcsFile->eolChar
+									) {
+										$phpcsFile->fixer->replaceToken( $i, '' );
+									}
+									break;
+								}
+
+								$phpcsFile->fixer->replaceToken( $i, '' );
+							}
+
+							$phpcsFile->fixer->endChangeset();
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Add a fixable error if a suitable alternative is available.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 * @param string                      $expected  The expected alternative annotation.
+	 *                                               This annotation might not be valid itself.
+	 * @param string                      $errorCode The error code.
+	 *
+	 * @return bool Whether an error has been thrown or not.
+	 */
+	protected function fixSimpleError( File $phpcsFile, $stackPtr, $expected, $errorCode ) {
+		$tokens     = $phpcsFile->getTokens();
+		$annotation = $tokens[ $stackPtr ]['content'];
+
+		if ( $expected === $annotation
+			|| preg_match( '`^' . self::VALID_CONTENT_REGEX . '$`', $expected ) !== 1
+		) {
+			return false;
+		}
+
+		$error = self::ERROR_MSG . "\nExpected: `%s`\nFound:    `%s`";
+		$data  = array(
+			$expected,
+			$annotation,
+		);
+
+		$fix = $phpcsFile->addFixableError( $error, $stackPtr, $errorCode, $data );
+		if ( $fix === true ) {
+			$phpcsFile->fixer->replaceToken( $stackPtr, $expected );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Add a fixable error for a union/intersect @covers annotation.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 * @param string                      $errorCode The error code.
+	 * @param string                      $separator The separator to split the
+	 *                                               annotation on.
+	 *
+	 * @return bool Whether to skip the rest of the annotation examination or not.
+	 */
+	protected function fixAnnotationToSplit( File $phpcsFile, $stackPtr, $errorCode, $separator ) {
+		$fix = $phpcsFile->addFixableError(
+			'Each @covers annotation should reference only one covered structure',
+			$stackPtr,
+			$errorCode
+		);
+
+		if ( $fix === true ) {
+			$tokens      = $phpcsFile->getTokens();
+			$annotation  = $tokens[ $stackPtr ]['content'];
+			$annotations = explode( $separator, $annotation );
+			$annotations = array_map( 'trim', $annotations );
+			$annotations = array_filter( $annotations ); // Remove empties.
+
+			$phpcsFile->fixer->beginChangeset();
+			$phpcsFile->fixer->replaceToken( $stackPtr, '' );
+
+			for ( $i = ( $stackPtr - 1 ); $i >= 0; $i-- ) {
+				if ( $tokens[ $i ]['line'] !== $tokens[ $stackPtr ]['line'] ) {
+					break;
+				}
+
+				$phpcsFile->fixer->replaceToken( $i, '' );
+			}
+
+			$stub        = $phpcsFile->getTokensAsString( $i, ( $stackPtr - $i ), true );
+			$replacement = '';
+			foreach ( $annotations as $annotation ) {
+				$replacement .= $stub . $annotation;
+			}
+
+			$phpcsFile->fixer->replaceToken( $i, $replacement );
+			$phpcsFile->fixer->endChangeset();
+
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.inc
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.inc
@@ -1,0 +1,156 @@
+<?php
+
+class ClassNameTest {
+
+	/**
+	 * Docblock.
+	 *
+	 * Correct:
+	 * @covers ::global_function
+	 * @covers Name\Space\function_name
+	 * @covers \Name\Space\function_name
+	 * @covers Class_Name
+	 * @covers Class_Name<extended>
+	 * @covers Class_Name::<public>
+	 * @covers Class_Name::<protected>
+	 * @covers Class_Name::<private>
+	 * @covers Class_Name::<!public>
+	 * @covers Class_Name::<!protected>
+	 * @covers Class_Name::<!private>
+	 * @covers Name\Space\Class_Name
+	 * @covers \Name\Space\Class_Name
+	 * @covers Name\Space\Class_Name::<public>
+	 * @covers Name\Space\Class_Name::<protected>
+	 * @covers Name\Space\Class_Name::<private>
+	 * @covers Name\Space\Class_Name::<!public>
+	 * @covers Name\Space\Class_Name::<!protected>
+	 * @covers Name\Space\Class_Name::<!private>
+	 * @covers Class_Name::method_name
+	 * @covers \Class_name::method_name
+	 * @covers Name\Space\Class_Name::method_name
+	 * @covers \Name\Space\Class_name::method_name
+	 *
+	 * Incorrect:
+	 * @covers global_function
+	 * @covers ::global_func()
+	 * @covers Name\Space\func_name()
+	 * @covers My_Class {}
+	 * @covers self::method_name
+	 * @covers My_Class::another_method_name()
+	 * @covers Name\Space\My_Class::another_method_name()
+	 */
+	public function testCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers ::global_functionA && ::other_functionA
+	 * @covers ::global_functionB & ::other_functionB
+	 * @covers ::global_functionC|::other_functionC
+	 * @covers ::global_functionD||::other_functionD & Some_Class_Name
+	 */
+	public function testCoversTagSplitUnionIntersect() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers Class_Name::public
+	 * @covers Class_Name::protected
+	 * @covers Class_Name::private
+	 */
+	public function testCoversTagFixGroupsTypeA() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers Class_Name::!public
+	 * @covers Class_Name::!protected
+	 * @covers Class_Name::!private
+	 */
+	public function testCoversTagFixGroupsTypeB() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers Class_Name::{public}
+	 * @covers Class_Name::(!protected)
+	 * @covers Class_Name::[private]
+	 */
+	public function testCoversTagFixGroupsTypeC() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers
+	 */
+	public function testHasCoversTagNoContent() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers
+	 * Some unrelated comment.
+	 */
+	public function testHasCoversTagNoContentOnSameLine() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @coversNothing
+	 * @covers ::globalFunction
+	 */
+	public function testCoversNothingAndCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @coversNothing
+	 * @since x.x.x
+	 *
+	 * @coversNothing
+	 * @param int $int Description.
+	 *
+	 * @coversNothing
+	 */
+	public function testDuplicateCoversNothingTagFixable($int) {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @coversNothing
+	 * @since x.x.x
+	 *
+	 * @coversNothing Some comment.
+	 * @param int $int Description.
+	 *
+	 * @coversNothing
+	 */
+	public function testDuplicateCoversNothingTagWithCommentFixable($int) {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @coversNothing
+	 * @since x.x.x
+	 *
+	 * @coversNothing Some comment.
+	 * @param int $int Description.
+	 *
+	 * @coversNothing Another comment.
+	 */
+	public function testDuplicateCoversNothingTagUnfixable($int) {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @since x.x.x
+	 *
+	 * @covers Name\Space\function_name
+	 * @covers Class_Name
+	 * @covers Name\Space\function_name
+	 * @covers Name\Space\function_name
+	 *
+	 * @param int $int Description.
+	 */
+	public function testDuplicateCoversTagFixable($int) {}
+}

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.inc.fixed
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.inc.fixed
@@ -1,0 +1,155 @@
+<?php
+
+class ClassNameTest {
+
+	/**
+	 * Docblock.
+	 *
+	 * Correct:
+	 * @covers ::global_function
+	 * @covers Name\Space\function_name
+	 * @covers \Name\Space\function_name
+	 * @covers Class_Name
+	 * @covers Class_Name<extended>
+	 * @covers Class_Name::<public>
+	 * @covers Class_Name::<protected>
+	 * @covers Class_Name::<private>
+	 * @covers Class_Name::<!public>
+	 * @covers Class_Name::<!protected>
+	 * @covers Class_Name::<!private>
+	 * @covers Name\Space\Class_Name
+	 * @covers \Name\Space\Class_Name
+	 * @covers Name\Space\Class_Name::<public>
+	 * @covers Name\Space\Class_Name::<protected>
+	 * @covers Name\Space\Class_Name::<private>
+	 * @covers Name\Space\Class_Name::<!public>
+	 * @covers Name\Space\Class_Name::<!protected>
+	 * @covers Name\Space\Class_Name::<!private>
+	 * @covers Class_Name::method_name
+	 * @covers \Class_name::method_name
+	 * @covers Name\Space\Class_Name::method_name
+	 * @covers \Name\Space\Class_name::method_name
+	 *
+	 * Incorrect:
+	 * @covers global_function
+	 * @covers ::global_func
+	 * @covers Name\Space\func_name
+	 * @covers My_Class
+	 * @covers self::method_name
+	 * @covers My_Class::another_method_name
+	 * @covers Name\Space\My_Class::another_method_name
+	 */
+	public function testCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers ::global_functionA
+	 * @covers ::other_functionA
+	 * @covers ::global_functionB
+	 * @covers ::other_functionB
+	 * @covers ::global_functionC
+	 * @covers ::other_functionC
+	 * @covers ::global_functionD
+	 * @covers ::other_functionD
+	 * @covers Some_Class_Name
+	 */
+	public function testCoversTagSplitUnionIntersect() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers Class_Name::<public>
+	 * @covers Class_Name::<protected>
+	 * @covers Class_Name::<private>
+	 */
+	public function testCoversTagFixGroupsTypeA() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers Class_Name::<!public>
+	 * @covers Class_Name::<!protected>
+	 * @covers Class_Name::<!private>
+	 */
+	public function testCoversTagFixGroupsTypeB() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers Class_Name::<public>
+	 * @covers Class_Name::<!protected>
+	 * @covers Class_Name::<private>
+	 */
+	public function testCoversTagFixGroupsTypeC() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers
+	 */
+	public function testHasCoversTagNoContent() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers
+	 * Some unrelated comment.
+	 */
+	public function testHasCoversTagNoContentOnSameLine() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @coversNothing
+	 * @covers ::globalFunction
+	 */
+	public function testCoversNothingAndCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @coversNothing
+	 * @since x.x.x
+	 *
+	 * @param int $int Description.
+	 *
+	 */
+	public function testDuplicateCoversNothingTagFixable($int) {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @since x.x.x
+	 *
+	 * @coversNothing Some comment.
+	 * @param int $int Description.
+	 *
+	 */
+	public function testDuplicateCoversNothingTagWithCommentFixable($int) {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @coversNothing
+	 * @since x.x.x
+	 *
+	 * @coversNothing Some comment.
+	 * @param int $int Description.
+	 *
+	 * @coversNothing Another comment.
+	 */
+	public function testDuplicateCoversNothingTagUnfixable($int) {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @since x.x.x
+	 *
+	 * @covers Name\Space\function_name
+	 * @covers Class_Name
+	 *
+	 * @param int $int Description.
+	 */
+	public function testDuplicateCoversTagFixable($int) {}
+}

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace YoastCS\Yoast\Tests\Commenting;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the CoversTag sniff.
+ *
+ * @package Yoast\YoastCS
+ *
+ * @since   1.3.0
+ *
+ * @covers  YoastCS\Yoast\Sniffs\Commenting\CoversTagSniff
+ */
+class CoversTagUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			34  => 1,
+			35  => 1,
+			36  => 1,
+			37  => 1,
+			38  => 1,
+			39  => 1,
+			40  => 1,
+			47  => 1,
+			48  => 1,
+			49  => 1,
+			50  => 2,
+			57  => 1,
+			58  => 1,
+			59  => 1,
+			66  => 1,
+			67  => 1,
+			68  => 1,
+			75  => 1,
+			76  => 1,
+			77  => 1,
+			84  => 1,
+			91  => 1,
+			101 => 1,
+			114 => 1,
+			127 => 1,
+			140 => 1,
+			150 => 1,
+			151 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+}


### PR DESCRIPTION
This new sniff checks the following:
* That the contents of PHPUnit `@covers` contains a supported annotation.
   Includes a fixer for some common errors.
* That union/intersect annotations aren't used.
    If found, the annotation will be split in separate `@covers` tags.
* That a docblock doesn't contain both a `@covers` tag as well as a `@coversNothing` tag.
* That a docblock doesn't contain multiple `@coversNothing` tags.
    If found and none or only one of the annotations contains a comment, the superfluous tags will be removed.
* That a docblock doesn't contain duplicate `@covers` tags.
    If found, the superfluous tags will be removed.

Includes unit tests.

Note: a future enhancement to this sniff could be to add support for detecting class-level `@coversDefaultClass` annotations and verifying that the default class name is not used in method-level `@covers` tags, including auto-fixing those.

Partially fixes #123

### Testing

To see the effect of this new sniff:
* Check out this branch.
* Run `composer install`.
* From the root of this repo, run `vendor/bin/phpcs ./yoast/tests/commenting/coverstagunittest.inc --standard=yoast --sniffs=yoast.commenting.coverstag` to see the errors reported based on the unit tests.
* To see the fixer in action, run `vendor/bin/phpcbf ./yoast/tests/commenting/coverstagunittest.inc --standard=yoast --sniffs=yoast.commenting.coverstag`
* If you get an error try deleting the `vendor` folder and the `composer.lock` file and run `composer install` again.

Note: I have tested this sniff on a number of the plugin repos and found no issues with the sniff (and plenty in the plugins).