### PR TITLE
YoastCS: add new `Yoast.Commenting.TestsHaveCoversTag` sniff

### DIFF
--- a/Yoast/Sniffs/Commenting/TestsHaveCoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/TestsHaveCoversTagSniff.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace YoastCS\Yoast\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Verifies that all test functions have at least one @covers tag.
+ *
+ * @package Yoast\YoastCS
+ * @author  Juliette Reinders Folmer
+ *
+ * @since   1.3.0
+ */
+class TestsHaveCoversTagSniff implements Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_CLASS,
+			T_FUNCTION,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return void|int Optionally returns a stack pointer. This sniff will not be
+	 *                  called again on the current file until the returned stack
+	 *                  pointer is reached.
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( $tokens[ $stackPtr ]['code'] === T_CLASS ) {
+			return $this->process_class( $phpcsFile, $stackPtr );
+		}
+
+		if ( $tokens[ $stackPtr ]['code'] === T_FUNCTION ) {
+			return $this->process_function( $phpcsFile, $stackPtr );
+		}
+	}
+
+	/**
+	 * Processes the docblock for a class token.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return void|int If covers annotations were found (or this is not a test class),
+	 *                  will returns the stack pointer to the end of the class.
+	 */
+	protected function process_class( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$name   = $phpcsFile->getDeclarationName( $stackPtr );
+
+		if ( substr( $name, -4 ) !== 'Test' ) {
+			// Not a test class.
+			if ( isset( $tokens[ $stackPtr ]['scope_closer'] ) ) {
+				// No need to examine the methods in this class.
+				return $tokens[ $stackPtr ]['scope_closer'];
+			}
+
+			return;
+		}
+
+		// @todo: Once PHPCS 3.5.0 is out, replace with call to new findCommentAboveOOStructure() method.
+		$find = [
+			T_WHITESPACE,
+			T_ABSTRACT,
+			T_FINAL,
+		];
+
+		$commentEnd = $stackPtr;
+		do {
+			$commentEnd = $phpcsFile->findPrevious( $find, ( $commentEnd - 1 ), null, true );
+		} while ( $tokens[ $commentEnd ]['line'] === $tokens[ $stackPtr ]['line'] );
+
+		if ( $tokens[ $commentEnd ]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+			|| $tokens[ $commentEnd ]['line'] !== ( $tokens[ $stackPtr ]['line'] - 1 )
+		) {
+			// Class without (proper) docblock. Not our concern.
+			return;
+		}
+
+		$commentStart = $tokens[ $commentEnd ]['comment_opener'];
+
+		$foundCovers        = false;
+		$foundCoversNothing = false;
+		foreach ( $tokens[ $commentStart ]['comment_tags'] as $tag ) {
+			if ( $tokens[ $tag ]['content'] === '@covers' ) {
+				$foundCovers = true;
+			}
+
+			if ( $tokens[ $tag ]['content'] === '@coversNothing' ) {
+				$foundCoversNothing = true;
+			}
+		}
+
+		if ( $foundCovers === true || $foundCoversNothing === true ) {
+			// Class level tags found, valid for all methods. No need to examine the individual methods.
+			if ( isset( $tokens[ $stackPtr ]['scope_closer'] ) ) {
+				return $tokens[ $stackPtr ]['scope_closer'];
+			}
+		}
+	}
+
+	/**
+	 * Processes the docblock for a function token.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	protected function process_function( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// @todo: Once PHPCS 3.5.0 is out, replace with call to new findCommentAboveOOStructure() method.
+		$find   = Tokens::$methodPrefixes;
+		$find[] = T_WHITESPACE;
+
+		$commentEnd = $stackPtr;
+		do {
+			$commentEnd = $phpcsFile->findPrevious( $find, ( $commentEnd - 1 ), null, true );
+		} while ( $tokens[ $commentEnd ]['line'] === $tokens[ $stackPtr ]['line'] );
+
+		if ( $tokens[ $commentEnd ]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+			|| $tokens[ $commentEnd ]['line'] !== ( $tokens[ $stackPtr ]['line'] - 1 )
+		) {
+			// Function without (proper) docblock. Not our concern.
+			return;
+		}
+
+		$commentStart = $tokens[ $commentEnd ]['comment_opener'];
+
+		$foundTest          = false;
+		$foundCovers        = false;
+		$foundCoversNothing = false;
+		foreach ( $tokens[ $commentStart ]['comment_tags'] as $tag ) {
+			if ( $tokens[ $tag ]['content'] === '@test' ) {
+				$foundTest = true;
+				continue;
+			}
+
+			if ( $tokens[ $tag ]['content'] === '@covers' ) {
+				$foundCovers = true;
+				continue;
+			}
+
+			if ( $tokens[ $tag ]['content'] === '@coversNothing' ) {
+				$foundCoversNothing = true;
+				continue;
+			}
+		}
+
+		$name = $phpcsFile->getDeclarationName( $stackPtr );
+		if ( stripos( $name, 'test' ) !== 0 && $foundTest === false ) {
+			// Not a test method.
+			return;
+		}
+
+		if ( $foundCovers === true || $foundCoversNothing === true ) {
+			// Docblock contains one or more @covers tags.
+			return;
+		}
+
+		$phpcsFile->addError(
+			'Each test function should have at least one @covers tag annotating which class/method/function is being tested. Tag missing for function %s()',
+			$stackPtr,
+			'Missing',
+			array( $name )
+		);
+	}
+}

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
@@ -10,6 +10,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package Yoast\YoastCS
  *
  * @since   1.1.0
+ *
+ * @covers  YoastCS\Yoast\Sniffs\Commenting\CodeCoverageIgnoreDeprecatedSniff
  */
 class CodeCoverageIgnoreDeprecatedUnitTest extends AbstractSniffUnitTest {
 

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.php
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.php
@@ -10,6 +10,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package Yoast\YoastCS
  *
  * @since   1.2.0
+ *
+ * @covers  YoastCS\Yoast\Sniffs\Commenting\FileCommentSniff
  */
 class FileCommentUnitTest extends AbstractSniffUnitTest {
 

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.inc
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.inc
@@ -1,0 +1,105 @@
+<?php
+
+class NotATestClass {
+
+	/**
+	 * Docblock.
+	 */
+	function testSomething() {}
+}
+
+/**
+ * @covers ClassName
+ */
+class ClassLevelCoversTest {
+
+	/**
+	 * Docblock.
+	 */
+	public function testMissingCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @coversNothing
+	 */
+	public function testCoversNothingTag() {}
+}
+
+/**
+ * @coversNothing
+ */
+class ClassLevelCoversNothingTest {
+
+	/**
+	 * Docblock.
+	 */
+	public function testMissingCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers ::something
+	 */
+	public function testCoversTag() {}
+}
+
+class ClassNameTest {
+
+	public function testMissingDocblock() {}
+
+	/**
+	 * Docblock.
+	 */
+	function notATestMethod() {}
+
+	/**
+	 * Docblock.
+	 */
+	public function testMissingCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @coversNothing
+	 */
+	public function testCoversNothingTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @coversNothing
+	 * @covers ::globalFunction
+	 */
+	public function testCoversNothingAndCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers ::globalFunction
+	 */
+	public function testHasCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @test
+	 */
+	public function annotatedTestMissingCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @test
+	 * @coversNothing
+	 */
+	public function annotatedTestCoversNothingTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @test
+	 * @covers ::globalFunction
+	 */
+	public function annotatedTestHasCoversTag() {}
+}

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
@@ -10,6 +10,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package Yoast\YoastCS
  *
  * @since   1.3.0
+ *
+ * @covers  YoastCS\Yoast\Sniffs\Commenting\TestsHaveCoversTagSniff
  */
 class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
 

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace YoastCS\Yoast\Tests\Commenting;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the TestsHaveCoversTag sniff.
+ *
+ * @package Yoast\YoastCS
+ *
+ * @since   1.3.0
+ */
+class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			59 => 1,
+			88 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+}

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -11,6 +11,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.4.1
  * @since   0.5   This class now uses namespaces and is no longer compatible with PHPCS 2.x.
+ *
+ * @covers  YoastCS\Yoast\Sniffs\ControlStructures\IfElseDeclarationSniff
  */
 class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -10,6 +10,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package Yoast\YoastCS
  *
  * @since   0.5
+ *
+ * @covers  YoastCS\Yoast\Sniffs\Files\FileNameSniff
  */
 class FileNameUnitTest extends AbstractSniffUnitTest {
 

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -10,6 +10,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package Yoast\YoastCS
  *
  * @since   1.0.0
+ *
+ * @covers  YoastCS\Yoast\Sniffs\Files\TestDoublesSniff
  */
 class TestDoublesUnitTest extends AbstractSniffUnitTest {
 

--- a/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.php
+++ b/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.php
@@ -10,6 +10,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package Yoast\YoastCS
  *
  * @since   1.2.0
+ *
+ * @covers  YoastCS\Yoast\Sniffs\Namespaces\NamespaceDeclarationSniff
  */
 class NamespaceDeclarationUnitTest extends AbstractSniffUnitTest {
 

--- a/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -10,6 +10,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package Yoast\YoastCS
  *
  * @since   1.0.0
+ *
+ * @covers  YoastCS\Yoast\Sniffs\WhiteSpace\FunctionSpacingSniff
  */
 class FunctionSpacingUnitTest extends AbstractSniffUnitTest {
 


### PR DESCRIPTION
This new sniff checks that each test method/class has either at least one `@covers` tag or a `@coversNothing` tag.

Notes:
* As per the PHPUnit conventions, test classes are expected to have a class name ending in `Test`.
* As per the PHPUnit conventions, test functions are expected to have a function name starting with `test`.
* Functions within a test class where the function name doesn't start with test _will_ still be recognized as test methods if they have a `@test` annotation in the method docblock.
* Having a `@covers` tag at the class level is allowed and will be recognized.
    In that case, the individual methods do not need the tag anymore.

Includes unit tests.

Note: potential enhancement for the future: check if when a class contains a `@covers` tag, methods do not contain the same `@covers` tag (as those would be redundant).

Includes a separate commit to add `@covers` tags to the YoastCS native unit tests.

Partially fixes #123

### Testing

To see the effect of this new sniff:
* Check out this branch.
* From the root of this repo, run `vendor/bin/phpcs ./yoast/tests/commenting/testshavecoverstagunittest.inc --standard=yoast --sniffs=yoast.commenting.testshavecoverstag` to see the errors reported based on the unit tests.

Note: I have tested this sniff on a number of the plugin repos and found no issues with the sniff (and plenty in the plugins).