### PR TITLE
PHPCS: add common exclude patterns to the ruleset

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,9 +8,6 @@
 	<!-- Scan all files. -->
 	<file>.</file>
 
-	<!-- Exclude Composer vendor directory. -->
-	<exclude-pattern>*/vendor/*</exclude-pattern>
-
 	<!-- Only check PHP files. -->
 	<arg name="extensions" value="php"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -5,6 +5,22 @@
 
 	<!--
 	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
+	-->
+
+	<!-- Always exclude all files in version management related directories. -->
+	<exclude-pattern>*/.git/*</exclude-pattern>
+	<exclude-pattern>*/.wordpress-svn/*</exclude-pattern>
+
+	<!-- Always exclude all files in dependency related directories. -->
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor(_prefixed)?/*</exclude-pattern>
+
+
+	<!--
+	#############################################################################
 	SNIFF AGAINST THE WordPress RULESET
 	Exclude a few select sniffs/errorcodes for specific reasons and
 	add configuration for a sniff.


### PR DESCRIPTION
As these exclude patterns are a special kind of regex which will be applied to the _absolute_ path of the file being scanned, setting these in the `YoastCS` ruleset instead of in the repo specific custom configs will work fine and will allow us to simplify the repo specific rulesets a little.

I've tested this change extensively with repo specific configs adjusted for this change and have found no problems.