### PR TITLE
PHPCS: set the minimum supported WP version via a property

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -11,6 +11,13 @@
 	#############################################################################
 	-->
 	<rule ref="WordPress">
+		<!-- Set the minimum supported WP version for all sniff which use it in one go.
+			 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
+		-->
+		<properties>
+			<property name="minimum_supported_version" value="4.9"/>
+		</properties>
+
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>
 
 		<!-- No need for this sniff as every Yoast travis script includes linting all files. -->


### PR DESCRIPTION
Properties are supposed to be set per sniff, but (bug or feature?) it turns out that setting them for a standard will set them for all sniffs included in that standard.

Sniffs which don't use the property will just ignore it.
Sniffs which do use it, now have it available as if it were set for the individual sniff.

As this was unknown (and possibly/probably not supported) in the past with older PHPCS versions, WPCS added the ability to set the `minimum_supported_wp_version` for all sniffs in one go via a `config`directive.

The problem with a `config` directive is that it is currently impossible to overrule it from a repo ruleset. It can only be overruled on the command-line, and even then only since PHPCS 3.3.0.

For that reason, the `config` directive was previously set in each individual repo ruleset.

Properties, however, can easily be overruled from within repo rulesets, so this change will allow us to manage the "_minimum supported WP version_" centrally, while still allowing for individual repos to overrule the default value.

I've tested this change extensively with repo specific configs adjusted for this change and have found no problems.

Ref:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters - WPCS documentation about the property/config directive.
* https://github.com/squizlabs/PHP_CodeSniffer/pull/2501 - PR through which this "feature" was discovered, included unit tests demonstrating it.
* https://github.com/squizlabs/PHP_CodeSniffer/issues/1821 - Issue which made the config directive possible to be overruled from the command-line.
* https://github.com/squizlabs/PHP_CodeSniffer/issues/2197- Feature request to allow for config directives to be overruled by other rulesets.