### PR TITLE
PHPCS: upgrade variable alignment issues from warning to error

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -51,6 +51,10 @@
 		<exclude name="WordPress.PHP.StrictInArray.FoundNonStrictFalse"/>
 	</rule>
 
+	<rule ref="Generic.Formatting.MultipleStatementAlignment">
+		<type>error</type>
+	</rule>
+
 	<rule ref="WordPress.WP.AlternativeFunctions">
 		<properties>
 			<property name="exclude" type="array">
@@ -61,6 +65,7 @@
 	</rule>
 
 	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<type>error</type>
 		<properties>
 			<!-- No need to adjust alignment of large arrays when the item with the largest key is removed. -->
 			<property name="exact" value="false"/>


### PR DESCRIPTION
Variable alignment is a simple whitespace issue which should be easy to solve in all cases.

However, as the sniffs throw warnings instead of errors and warnings are ignored by some of the repos, these are typically issues which creep back into the repo quickly if builds don't break on them, necessitating a regular clean up again.

By changing the message type for these sniffs from `warning` to `error`, we can safeguard that these issues will be kept at bay.