### PR TITLE
YoastCS/FileName: always remove the longest matching prefix when prefixes overlap

### DIFF
--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -32,6 +32,11 @@ class FileNameSniff implements Sniff {
 	 *
 	 * These prefixes do not need to be reflected in the file name.
 	 *
+	 * Note:
+	 * - Prefixes are matched in a case-insensitive manner.
+	 * - When several overlapping prefixes match, the longest matching prefix
+	 *   will be removed.
+	 *
 	 * @var string[]
 	 */
 	public $prefixes = array();
@@ -125,6 +130,8 @@ class FileNameSniff implements Sniff {
 
 				$prefixes = $this->clean_custom_array_property( $this->prefixes );
 				if ( ! empty( $prefixes ) ) {
+					// Use reverse natural sorting to get the longest of overlapping prefixes first.
+					rsort( $prefixes, ( SORT_NATURAL | SORT_FLAG_CASE ) );
 					foreach ( $prefixes as $prefix ) {
 						if ( $name !== $prefix && stripos( $name, $prefix ) === 0 ) {
 							$name = substr( $name, strlen( $prefix ) );

--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -32,7 +32,7 @@ class FileNameSniff implements Sniff {
 	 *
 	 * These prefixes do not need to be reflected in the file name.
 	 *
-	 * @var string[]|string
+	 * @var string[]
 	 */
 	public $prefixes = array();
 
@@ -53,7 +53,7 @@ class FileNameSniff implements Sniff {
 	 * from the root of the repository - , the PHPCS `--basepath` config variable
 	 * needs to be set. If it is not, a warning will be issued.
 	 *
-	 * @var string[]|string
+	 * @var string[]
 	 */
 	public $exclude = array();
 
@@ -238,7 +238,6 @@ class FileNameSniff implements Sniff {
 	 * Clean a custom array property received from a ruleset.
 	 *
 	 * Deals with incorrectly passed custom array properties.
-	 * - If the property was passed as a string, change it to an array.
 	 * - Remove whitespace surrounding values.
 	 * - Remove empty array entries.
 	 *
@@ -251,15 +250,6 @@ class FileNameSniff implements Sniff {
 	 * @return array
 	 */
 	protected function clean_custom_array_property( $property, $flip = false, $to_lower = false ) {
-		if ( is_bool( $property ) ) {
-			// Allow for resetting in the unit tests.
-			return array();
-		}
-
-		if ( is_string( $property ) ) {
-			$property = explode( ',', $property );
-		}
-
 		$property = array_filter( array_map( 'trim', $property ) );
 
 		if ( true === $to_lower ) {

--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -46,7 +46,6 @@ class FileNameSniff implements Sniff {
 	 * File names should be provided including the path to the file relative
 	 * to the "basepath" known to PHPCS.
 	 * File names should not be prefixed with a directory separator.
-	 * File names are compared in a case-sensitive manner!
 	 * The list should be provided as a PHPCS array list.
 	 *
 	 * For this functionality to work with relative file paths - i.e. file paths

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -43,6 +43,7 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		'class-my-class.inc'              => 1, // Prefix 'class' not needed.
 		'some-class.inc'                  => 0,
 		'wpseo-some-class.inc'            => 1, // Prefix 'wpseo' not necessary.
+		'yoast-plugin-some-class.inc'     => 1, // Prefix 'yoast-plugin' not necessary.
 		'class-wpseo-some-class.inc'      => 1, // Prefixes 'class' and 'wpseo' not necessary.
 		'excluded-CLASS-file.inc'         => 1, // Lowercase expected.
 

--- a/Yoast/Tests/Files/FileNameUnitTests/ExcludedFile.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/ExcludedFile.inc
@@ -1,5 +1,6 @@
-@codingStandardsChangeSetting Yoast.Files.FileName exclude ExcludedFile.inc
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName exclude[] ExcludedFile.inc
 
 <?php
 
-// @codingStandardsChangeSetting Yoast.Files.FileName exclude false
+// phpcs:set Yoast.Files.FileName exclude[]

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/class-wpseo-some-class.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/class-wpseo-some-class.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 class WPSEO_Some_Class {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/excluded-CLASS-file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/excluded-CLASS-file.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName exclude classes/excluded-CLASS-file.inc
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName exclude[] classes/excluded-CLASS-file.inc
 
 <?php
 
 class Some_Class {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName exclude false
+// phpcs:set Yoast.Files.FileName exclude[]

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/some-class.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/some-class.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 class WPSEO_Some_Class {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/wpseo-some-class.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/wpseo-some-class.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 class WPSEO_Some_Class {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/yoast-plugin-some-class.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/yoast-plugin-some-class.inc
@@ -1,0 +1,8 @@
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast,yoast-plugin
+
+<?php
+
+class Yoast_Plugin_Some_Class {}
+
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/excluded-file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/excluded-file.inc
@@ -1,5 +1,6 @@
-@codingStandardsChangeSetting Yoast.Files.FileName exclude excluded-file.inc
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName exclude[] excluded-file.inc
 
 <?php
 
-// @codingStandardsChangeSetting Yoast.Files.FileName exclude false
+// phpcs:set Yoast.Files.FileName exclude[]

--- a/Yoast/Tests/Files/FileNameUnitTests/excluded_file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/excluded_file.inc
@@ -1,5 +1,6 @@
-@codingStandardsChangeSetting Yoast.Files.FileName exclude excluded_file.inc
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName exclude[] excluded_file.inc
 
 <?php
 
-// @codingStandardsChangeSetting Yoast.Files.FileName exclude false
+// phpcs:set Yoast.Files.FileName exclude[]

--- a/Yoast/Tests/Files/FileNameUnitTests/functions/excluded-functions-file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/functions/excluded-functions-file.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName exclude functions/excluded-functions-file.inc
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName exclude[] functions/excluded-functions-file.inc
 
 <?php
 
 function some_function() {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName exclude false
+// phpcs:set Yoast.Files.FileName exclude[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/different-interface.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/different-interface.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 interface Yoast_Outline_Something {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/excluded-interface-file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/excluded-interface-file.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName exclude interfaces/excluded-interface-file.inc
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName exclude[] interfaces/excluded-interface-file.inc
 
 <?php
 
 interface My_Interface {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName exclude false
+// phpcs:set Yoast.Files.FileName exclude[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/no-duplicate-interface.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/no-duplicate-interface.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 interface Yoast_No_Duplicate_Interface {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/outline-something-interface.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/outline-something-interface.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 interface Yoast_Outline_Something {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/outline-something.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/outline-something.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 interface Yoast_Outline_Something {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/yoast-outline-something.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/yoast-outline-something.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 interface Yoast_Outline_Something {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/no-basepath.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/no-basepath.inc
@@ -1,5 +1,6 @@
-@codingStandardsChangeSetting Yoast.Files.FileName exclude no-basepath.inc
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName exclude[] no-basepath.inc
 
 <?php
 
-// @codingStandardsChangeSetting Yoast.Files.FileName exclude false
+// phpcs:set Yoast.Files.FileName exclude[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/different-trait.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/different-trait.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 trait Yoast_Outline_Something {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/excluded-trait-file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/excluded-trait-file.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName exclude traits/excluded-trait-file.inc
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName exclude[] traits/excluded-trait-file.inc
 
 <?php
 
 trait My_Trait {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName exclude false
+// phpcs:set Yoast.Files.FileName exclude[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/no-duplicate-trait.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/no-duplicate-trait.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 trait Yoast_No_Duplicate_Trait {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/outline-something-trait.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/outline-something-trait.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 trait Yoast_Outline_Something {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/outline-something.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/outline-something.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 trait Yoast_Outline_Something {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/yoast-outline-something.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/yoast-outline-something.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting Yoast.Files.FileName prefixes wpseo,yoast
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
 
 <?php
 
 trait Yoast_Outline_Something {}
 
-// @codingStandardsChangeSetting Yoast.Files.FileName prefixes false
+// phpcs:set Yoast.Files.FileName prefixes[]


### PR DESCRIPTION
The sniff allows for passing a set of `prefixes` which will be removed from an OO name to get to the expected file name.

As it was, when two `prefixes` passed would overlap - think `yoast` and `yoast_news` -, the order in which these were provided in the configuration file would determine the order in which the sniff would attempt to match these.

I.e. if the prefixes were provided in the above order and the class name was `Yoast_News_Something`, the sniff would suggest `news-something.php` as the filename, not `something.php`.

The change in this commit, changes that behaviour by ordering the `prefixes` array before using it which ensures that the _longest_ matching prefix will be used when two prefixes overlap.

Includes unit test.

Unfortunately, as the tests are more similar to integration tests rather than unit tests, the actual message is not tested, even though that's where the change lies.

### To manually test this PR and see the difference:
* Check out the `develop` branch.
* Cherrypick the new test case file.
* Temporarily add a default value to the `$prefixes` property in the sniff file:
    ```php
	public $prefixes = array(
	    'yoast',
	    'wpseo',
	    'yoast_plugin',
	);
    ```
* Make sure you have run `composer install` and then run the following command from the repo root:
    `vendor/bin/phpcs ./yoast/tests/files/filenameunittests/classes/yoast-plugin-some-class.inc --standard=Yoast --sniffs=yoast.files.filename`
* The resulting error message will read:
    ` Class file names should be based on the class name without the plugin prefix. Expected plugin-some-class.inc, but found yoast-plugin-some-class.inc.`
* Now do a hard reset on the develop branch.
* Check out this branch.
* Make the same temporary change to the default value of the `$prefixes` property as before.
* Re-run the command.
* The resulting error message should now read:
    ` Class file names should be based on the class name without the plugin prefix. Expected some-class.inc, but found yoast-plugin-some-class.inc.`

----

PR includes removing some technical debt:

### YoastCS/FileName: remove support for passing properties as strings

Both the public `exclude`, as well as the `prefixes` property for this sniff are by nature array properties.

Setting array properties within unit tests was not yet properly supported by PHPCS until version 3.3.0. For that reason, the unit tests for this sniff still used the old-style property setting annotation and the sniff itself contained code to work around the issue.

As this problem has been solved now in PHPCS, the work-arounds in the sniff can be removed and the new-style property setting can now be used in the unit tests.