### PR TITLE
Composer: require WPCS ^2.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	"require": {
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.4.2",
-		"wp-coding-standards/wpcs": "^2.1.0",
+		"wp-coding-standards/wpcs": "^2.1.1",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
 	},


### PR DESCRIPTION
WPCS 2.1.1 has been released and contains a bug fix relevant to the Yoast repos.

Previously test classes imported via `use` statements were not correctly recognized. While, the `use` statements still won't be examined, WPCS will now regard every class which extends or implements a class or interface called `TestCase` as a test class.

This allows us to remove some temporary exclusions in relation to this bug from select repository custom rulesets.

Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/2.1.1