### PR TITLE
PHPCS ruleset: add sniff to check spacing between property declarations

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -106,6 +106,9 @@
 	<!-- CS: no blank line between the content of a function and a function close brace.-->
 	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
 
+	<!-- CS: ensure exactly one blank line before each property declaration. -->
+	<rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
+
 	<!-- Error prevention: Ensure no git conflicts make it into the code base. -->
 	<!-- PHPCS 3.4.0: This sniff will be added to WPCS 2.x in due time and can then be removed from this ruleset.
 		 Related: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1500 -->


### PR DESCRIPTION
The `Yoast.WhiteSpace.FunctionSpacing` sniff which was added in PR #86 checks that each function within an OO structure has one blank line before the function declaration and no blank line(s) after the last function in a class.

This sniff was added as there was quite some inconsistency regarding this across classes and repos and this way we could enforce consistency.

Similar to this, we should also enforce consistency regarding the spacing out of property declarations in OO structures, which I've noticed becoming inconsistent in some repos as well.

The sniff I'm proposing to add, is a PHPCS native sniff which checks that there is one blank line before the first property declaration in an OO structure, as well as one blank line between property declarations in OO structures.

The sniff includes an auto-fixer.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#squizwhitespacemembervarspacing

### Code sample:
Incorrect:
```php
class ABC {
	public $a;
	/**
	 * Docblock.
	 */
	protected $b;


	/**
	 * Docblock.
	 */
	private $c;
}
```

Correct:
```php
class ABC {

	public $a;

	/**
	 * Docblock.
	 */
	protected $b;

	/**
	 * Docblock.
	 */
	private $c;
}
```