### PR TITLE
Travis: update script for updated minimum requirements of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,16 @@ php:
 env:
   # Test against the highest/lowest supported PHPCS and WPCS versions.
   - PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
-  - PHPCS_BRANCH="dev-master" WPCS="2.0.0"
-  - PHPCS_BRANCH="3.4.0" WPCS="dev-develop"
-  - PHPCS_BRANCH="3.4.0" WPCS="2.0.0"
+  - PHPCS_BRANCH="dev-master" WPCS="2.1.1"
+  - PHPCS_BRANCH="3.4.2" WPCS="dev-develop"
+  - PHPCS_BRANCH="3.4.2" WPCS="2.1.1"
 
 matrix:
   fast_finish: true
   include:
     # Extra build to check for XML codestyle.
     - php: 7.1
-      env: PHPCS_BRANCH="dev-master" WPCS="^2.0.0" SNIFF=1
+      env: PHPCS_BRANCH="dev-master" WPCS="^2.1.1" SNIFF=1
       addons:
           apt:
               packages:


### PR DESCRIPTION
PR #126 updated the PHPCS minimum requirement to `3.4.2`.
PR #134 updated the WPCS minimum requirement to `2.1.1`.

The Travis script should have been updated at the same time to reflect these new minimum requirements. (My bad, mea culpa)