### PR TITLE
YoastCS/AlternativeFunctions: activate disabled test

### DIFF
--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc
@@ -6,7 +6,7 @@ $json = WPSEO_Utils:format_json_encode( $thing ); // OK.
 $json = Class_Other_Plugin::json_encode( $thing ); // OK.
 $json = $obj->wp_json_encode( $thing ); // OK.
 $json = MyNamespace\json_encode( $thing ); // OK.
-//$json = namespace\wp_json_encode( $thing );  // OK - this will not (yet) be correctly recognized, but will with WPCS 2.1.0.
+$json = namespace\wp_json_encode( $thing );  // OK.
 
 // The sniff should trigger on these.
 $json = json_encode( $thing ); // Error.

--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc.fixed
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc.fixed
@@ -6,7 +6,7 @@ $json = WPSEO_Utils:format_json_encode( $thing ); // OK.
 $json = Class_Other_Plugin::json_encode( $thing ); // OK.
 $json = $obj->wp_json_encode( $thing ); // OK.
 $json = MyNamespace\json_encode( $thing ); // OK.
-//$json = namespace\wp_json_encode( $thing );  // OK - this will not (yet) be correctly recognized, but will with WPCS 2.1.0.
+$json = namespace\wp_json_encode( $thing );  // OK.
 
 // The sniff should trigger on these.
 $json = WPSEO_Utils::format_json_encode( $thing ); // Error.


### PR DESCRIPTION
See #125

This unit tests was disabled as the parent sniff from WPCS did not handle this correctly yet in WPCS < 2.1.0.

As the minimum WPCS requirement for YoastCS has gone up to WPCS 2.1.1, this test can now be enabled.