### PR TITLE
Composer: update PHPCompatibility requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
 	},
 	"require-dev": {
-		"phpcompatibility/php-compatibility": "^9.0.0",
+		"phpcompatibility/php-compatibility": "^9.2.0",
 		"roave/security-advisories": "dev-master",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
 	},


### PR DESCRIPTION
PHPCompatibility 9.2.0 has been released which contains a lot of checks for PHP 7.4.

Ref: https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.2.0