### PR TITLE
Travis: ignore PHP deprecation notices for stable PHPCS releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,16 @@ before_install:
     # https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/
     # https://twitter.com/kelunik/status/954242454676475904
     - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+
+    # On stable PHPCS versions, allow for PHP deprecation notices.
+    # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+    - |
+      if [[ $PHPCS_BRANCH != "dev-master" && $WPCS != "dev-develop" ]]; then
+        echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+      fi
+    - php -r "echo ini_get('error_reporting');"
+
+
     - export XMLLINT_INDENT="	"
     - export PHPCS_DIR=$(pwd)/vendor/squizlabs/php_codesniffer
     - export PHPCS_BIN=$(pwd)/vendor/bin/phpcs


### PR DESCRIPTION
The unit tests will fail when a PHP warning/notice/deprecation notice is encountered.

Notices thrown by already released PHPCS versions won't get fixed anymore (in that version), so failing the unit tests on those is moot and will skew the reliability of the Travis results.

For now, I've chosen to just ignore Deprecation notices.
At a later point, this can be re-evaluated to see if more notices should be ignored for already released upstream versions.

To see the effect of this PR, compare the output from the following builds:
* Recent build against `develop`: https://travis-ci.org/Yoast/yoastcs/jobs/561796949#L565
* The same build against this branch: https://travis-ci.org/Yoast/yoastcs/jobs/561842077#L541