### PR TITLE
PHPCS unit tests: minor fixes to the test case files

### DIFF
--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc
@@ -15,7 +15,7 @@ class SomeThing {
 		// Code
     } // end function
 
-    public function functionWithoutDocblock {}
+    public function functionWithoutDocblock() {}
 
 	/**
 	 * @codeCoverageIgnore
@@ -47,7 +47,7 @@ class SomeThing {
 	 *
 	 * This is a sentence containing the phrase codeCoverageIgnore, but should not be regarded as the tag.
 	 */
-	static protected function missingCodeCoverageIgnore() {}
+	static protected function missingStaticCodeCoverageIgnore() {}
 
 	/**
 	 * @deprecated x.x

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc.fixed
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc.fixed
@@ -15,7 +15,7 @@ class SomeThing {
 		// Code
     } // end function
 
-    public function functionWithoutDocblock {}
+    public function functionWithoutDocblock() {}
 
 	/**
 	 * @codeCoverageIgnore
@@ -47,7 +47,7 @@ class SomeThing {
 	 *
 	 * This is a sentence containing the phrase codeCoverageIgnore, but should not be regarded as the tag.
 	 */
-	static protected function missingCodeCoverageIgnore() {}
+	static protected function missingStaticCodeCoverageIgnore() {}
 
 	/**
 	 * @deprecated x.x

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.inc
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.inc
@@ -10,11 +10,11 @@ else {
 
 // Ok.
 if ( false ):
-elseif:
-else if:
+elseif: // Intentional parse error.
+else if: // Intentional parse error.
 else /* comment */
-if:
-else:
+if: // Intentional parse error.
+else: // Intentional parse error.
 endif;
 
 if ( true ) {
@@ -34,7 +34,7 @@ if ( true ) {
 } else // Bad - else if should be on the next line.
 if (2) {
 	// ...
-} else ( 3 ) { // Bad - else should be on the next line.
+} else { // Bad - else should be on the next line.
 	// ...
 }
 

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/multiple-objects-in-file-reverse.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/multiple-objects-in-file-reverse.inc
@@ -2,6 +2,6 @@
 
 use PHPUnit\Framework\TestCase;
 
-class Test_ClassName extends extends TestCase {}
+class Test_ClassName extends TestCase {}
 
 class Prefix_ClassName_Double {}

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/multiple-objects-in-file.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/multiple-objects-in-file.inc
@@ -4,4 +4,4 @@ use PHPUnit\Framework\TestCase;
 
 class Prefix_ClassName_Double {}
 
-class Test_ClassName extends extends TestCase {}
+class Test_ClassName extends TestCase {}

--- a/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.2.inc
+++ b/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.2.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace; // Error - no name.
+namespace; // Error - no name. (Intentional parse error)
 
 namespace {} // Error x 3 - no name + scoped namespace declaration + not the only namespace declaration in the file.
 
@@ -8,4 +8,4 @@ namespace Yoast\SecondScopedNamespace {} // Error x 2 - scoped namespace declara
 
 namespace /* some comment */ {} // Error x 3 - no name + scoped namespace declaration + not the only namespace declaration in the file.
 
-namespace /* some comment */; // Error x 2 - no name + not the only namespace declaration in the file.
+namespace /* some comment */; // Error x 2 - no name + not the only namespace declaration in the file. (Intentional parse error)

--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc
@@ -1,6 +1,6 @@
 <?php
 
-$json = WPSEO_Utils:format_json_encode( $thing ); // OK.
+$json = WPSEO_Utils::format_json_encode( $thing ); // OK.
 
 // Don't trigger on calls to functions which are not the PHP or WP native functions.
 $json = Class_Other_Plugin::json_encode( $thing ); // OK.
@@ -16,7 +16,7 @@ return function_call(nested_call(json_encode( $thing ))); // Error.
 $json = json_encode ($value, $options); // Error, non-fixable.
 $json = wp_json_encode( $data, $options, $depth ); // Error, non-fixable.
 
-namespace Yoast\CMS\Plugin\Dir;
+namespace Yoast\CMS\Plugin\Dir; // Non-relevant parse error.
 
 $json = json_encode( $thing ); // Error.
 $json = wp_json_encode( $thing ); // Error.

--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc.fixed
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 
-$json = WPSEO_Utils:format_json_encode( $thing ); // OK.
+$json = WPSEO_Utils::format_json_encode( $thing ); // OK.
 
 // Don't trigger on calls to functions which are not the PHP or WP native functions.
 $json = Class_Other_Plugin::json_encode( $thing ); // OK.
@@ -16,7 +16,7 @@ return function_call(nested_call(WPSEO_Utils::format_json_encode( $thing ))); //
 $json = json_encode ($value, $options); // Error, non-fixable.
 $json = wp_json_encode( $data, $options, $depth ); // Error, non-fixable.
 
-namespace Yoast\CMS\Plugin\Dir;
+namespace Yoast\CMS\Plugin\Dir; // Non-relevant parse error.
 
 $json = \WPSEO_Utils::format_json_encode( $thing ); // Error.
 $json = \WPSEO_Utils::format_json_encode( $thing ); // Error.


### PR DESCRIPTION
Fix unintentional parse errors and annotate intentional parse errors which are there to test edge cases.