### PR TITLE
PHPCS: Add XML based sniff documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ script:
     # Validate the xml files.
     # @link http://xmlsoft.org/xmllint.html
     - if [[ "$SNIFF" == "1" ]]; then xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./Yoast/ruleset.xml; fi
+    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./Yoast/Docs/*/*Standard.xml; fi
     # Check the code-style consistency of the xml files.
     - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./Yoast/ruleset.xml <(xmllint --format "./Yoast/ruleset.xml"); fi
     # Validate the composer.json file.

--- a/Yoast/Docs/Commenting/CodeCoverageIgnoreDeprecatedStandard.xml
+++ b/Yoast/Docs/Commenting/CodeCoverageIgnoreDeprecatedStandard.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<documentation title="Code Coverage Ignore Deprecated">
+    <standard>
+    <![CDATA[
+    Deprecated functions and methods should be ignored for code coverage calculations.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Function marked as deprecated has a @codeCoverageIgnore tag.">
+        <![CDATA[
+/**
+ * <em>@deprecated x.x
+ * @codeCoverageIgnore</em>
+ */
+function deprecated_function() {}
+        ]]>
+        </code>
+        <code title="Invalid: Function marked as deprecated is missing a @codeCoverageIgnore tag.">
+        <![CDATA[
+/**
+ * <em>@deprecated x.x</em>
+ */
+function deprecated_function() {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Yoast/Docs/Commenting/CoversTagStandard.xml
+++ b/Yoast/Docs/Commenting/CoversTagStandard.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<documentation title="PHPUnit Covers Tag">
+    <standard>
+    <![CDATA[
+    The @covers tag used to annotate which code is coverage by a test should follow the specifications of PHPUnit with regards to the supported annotations.
+See:
+* https://phpunit.readthedocs.io/en/7.5/code-coverage-analysis.html#specifying-covered-code-parts
+* https://phpunit.readthedocs.io/en/7.5/annotations.html#covers
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Correct covers tag annotation.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     *
+     * @covers <em>Class_Name::method_name</em>
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+        <code title="Invalid: Incorrect covers tag annotation.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     *
+     * @covers Class_Name::method_name<em>()</em>
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    There should be no duplicate @covers tags for the same test.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Unique @covers tags.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     *
+     * @covers Name\Space\function_name
+     * @covers Class_Name
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+        <code title="Invalid: Duplicate @covers tag.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     *
+     * @covers Name\Space\function_name
+     * @covers Class_Name
+     * @covers <em>Name\Space\function_name</em>
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    There should be not be both a @covers tag as well as a @coversNothing tag for the same test.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Either one or more @covers tags or a @coversNothing tag.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     *
+     * <em>@covers ::globalFunction</em>
+     */
+    function test_something() {}
+
+    /**
+     * Testing...
+     *
+     * <em>@coversNothing</em>
+     */
+    function test_something_else() {}
+}
+        ]]>
+        </code>
+        <code title="Invalid: Both a @covers tag as well as a @coversNothing tag.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     *
+     * <em>@coversNothing
+     * @covers ::globalFunction</em>
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Yoast/Docs/Commenting/FileCommentStandard.xml
+++ b/Yoast/Docs/Commenting/FileCommentStandard.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0"?>
+<documentation title="File Comment">
+    <standard>
+    <![CDATA[
+    A file containing a (named) namespace declaration does not need a file docblock.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Start of a namespaced file without a file docblock.">
+        <![CDATA[
+<?php
+
+<em>namespace Yoast\A\B;</em>
+
+/**
+ * Class docblock.
+ */
+class {
+    ...
+        ]]>
+        </code>
+        <code title="Invalid: Start of a namespaced file with a file docblock.">
+        <![CDATA[
+<?php
+<em>/**
+ * File comment.
+ */
+
+namespace Yoast\A\B;</em>
+
+/**
+ * Class docblock.
+ */
+class {
+    ...
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    A non-namespaced file must have a file docblock.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Start of a non-namespaced file with a file docblock.">
+        <![CDATA[
+<?php
+<em>/**
+ * File comment.
+ */</em>
+
+/**
+ * Class docblock.
+ */
+class {
+    ...
+        ]]>
+        </code>
+        <code title="Invalid: Start of a non-namespaced file missing a file docblock.">
+        <![CDATA[
+<?php
+<em></em>
+/**
+ * Class docblock.
+ */
+class {
+    ...
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    A file comment should be a docblock.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: File docblock.">
+        <![CDATA[
+<?php
+<em>/**
+ * File comment.
+ */</em>
+        ]]>
+        </code>
+        <code title="Invalid: File comment is not a docblock.">
+        <![CDATA[
+<?php
+<em>/*</em>
+ * File comment.
+ */
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    There must be no blank lines before the file comment.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No blank line between the PHP open tag and the file comment.">
+        <![CDATA[
+<?php<em>
+</em>/**
+ * File comment.
+ */
+        ]]>
+        </code>
+        <code title="Invalid: Blank line(s) between the PHP open tag and the file comment.">
+        <![CDATA[
+<?php<em>
+
+
+</em>/**
+ * File comment.
+ */
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    There must be exactly one blank line after the file comment.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: One blank line after file comment.">
+        <![CDATA[
+<?php
+/**
+ * File comment.
+ */<em>
+
+ </em>echo $something;
+        ]]>
+        </code>
+        <code title="Invalid: No blank line or more than one blank line after file comment.">
+        <![CDATA[
+<?php
+/**
+ * File comment.
+ */<em>
+ </em>echo $something;
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    A file comment must contain a @package tag.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: File comment containing the @package tag.">
+        <![CDATA[
+<?php
+/**
+ * File comment.
+ *
+ * <em>@package Yoast\Package</em>
+ */
+        ]]>
+        </code>
+        <code title="Invalid: File comment missing the @package tag.">
+        <![CDATA[
+<?php
+/**
+ * File comment.
+ */
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    A file comment @package tag must have a package name.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: File comment @package tag with a package name.">
+        <![CDATA[
+<?php
+/**
+ * File comment.
+ *
+ * <em>@package Yoast\Package</em>
+ */
+        ]]>
+        </code>
+        <code title="Invalid: File comment @package tag without a package name.">
+        <![CDATA[
+<?php
+/**
+ * File comment.
+ *
+ * <em>@package</em>
+ */
+        ]]>
+        </code>
+    </code_comparison>
+
+</documentation>

--- a/Yoast/Docs/Commenting/TestsHaveCoversTagStandard.xml
+++ b/Yoast/Docs/Commenting/TestsHaveCoversTagStandard.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<documentation title="Tests Have Covers tag">
+    <standard>
+    <![CDATA[
+    Each test function should have at least one @covers tag annotating which class/method/function is being tested.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: @covers tag at method level.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     *
+     * @covers Class_Name::method_name
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+        <code title="Invalid: Missing @covers tag.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: @covers tag at class level.">
+        <![CDATA[
+/**
+ * Testing...
+ *
+ * @covers \Name\Space\Class_Name
+ */
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+        <code title="Invalid: Missing @covers tag.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Using a @coversNothing tag.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     *
+     * @coversNothing Don't record coverage
+     *                as this is an integration
+     *                test, not a unit test.
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+        <code title="Invalid: Missing @covers tag.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Yoast/Docs/ControlStructures/IfElseDeclarationStandard.xml
+++ b/Yoast/Docs/ControlStructures/IfElseDeclarationStandard.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<documentation title="If-else Declarations">
+    <standard>
+    <![CDATA[
+    The `else` and `elseif` keywords should be on a new line.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: `elseif` on a new line.">
+        <![CDATA[
+if ($foo) {
+    $var = 1;
+}<em>
+elseif</em> ($bar) {
+    $var = 2;
+}
+        ]]>
+        </code>
+        <code title="Invalid: `elseif` on the same line as the closing curly of the preceding (else)if.">
+        <![CDATA[
+if ($foo) {
+    $var = 1;
+} <em>elseif</em> ($bar) {
+    $var = 2;
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    The indentation for the `else` and `elseif` keywords should be the same as the indentation for the preceding (else)if.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Correct indentation.">
+        <![CDATA[
+if ($foo) {
+    $var = 1;
+}
+<em>elseif</em> ($bar) {
+    $var = 2;
+}
+        ]]>
+        </code>
+        <code title="Invalid: Indentation of the else not aligned with the preceding if.">
+        <![CDATA[
+if ($foo) {
+    $var = 1;
+}
+<em>    else</em> {
+<em>        </em>$var = 2;
+<em>    </em>}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Yoast/Docs/Files/FileNameStandard.xml
+++ b/Yoast/Docs/Files/FileNameStandard.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<documentation title="File Name">
+    <standard>
+    <![CDATA[
+    Same as in WP, file names should be lowercase and words should be separated by dashes (not underscores).
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: File name lowercase with dashes.">
+        <![CDATA[
+<em>file-name</em>.php
+        ]]>
+        </code>
+        <code title="Invalid: File name mixed case with underscores.">
+        <![CDATA[
+<em>File_Name</em>.php
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    For all class files, the file name should reflect the class name without the plugin specific prefix.
+The plugin specific prefix is configurable.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: File named after class without the plugin prefix.">
+        <![CDATA[
+<!-- File name: <em>utils</em>.php -->
+<?php
+class WPSEO_<em>Utils</em> {}
+        ]]>
+        </code>
+        <code title="Invalid: File name contains irrelevant 'class-' and plugin prefix.">
+        <![CDATA[
+<!-- File name: <em>class-wpseo-</em>utils.php -->
+<?php
+class WPSEO_Utils {}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    For all interface and trait files, the file name should reflect the interface/trait name without the plugin specific prefix and with an "-interface" or "-trait" suffix.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: File named after interface with '-interface' suffix and without the plugin prefix.">
+        <![CDATA[
+<!-- File name: <em>output-thing-interface</em>.php -->
+<?php
+<em>interface</em> Yoast_<em>Output_Thing</em> {}
+        ]]>
+        </code>
+        <code title="Invalid: File name contains plugin prefix and is missing '-trait' suffix.">
+        <![CDATA[
+<!-- File name: <em>yoast</em>-outline-something.php -->
+<?php
+<em>trait</em> Yoast_Outline_Something {}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Files which don't contain an object structure, but do contain function declarations should have a "-functions" suffix.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: File containing functions with '-functions' suffix.">
+        <![CDATA[
+<!-- File name: some-<em>functions</em>.php -->
+<?php
+function something() {}
+function something_else() {}
+        ]]>
+        </code>
+        <code title="Invalid: File name missing '-functions' suffix.">
+        <![CDATA[
+<!-- File name: utilities.php -->
+<?php
+function something() {}
+function something_else() {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Yoast/Docs/Files/TestDoublesStandard.xml
+++ b/Yoast/Docs/Files/TestDoublesStandard.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<documentation title="Test Doubles">
+    <standard>
+    <![CDATA[
+    Double/Mock test helper classes should be in their own file and placed in a dedicated test doubles sub-directory.
+The name of the dedicated sub-directory is configurable.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Double class in separate file in double sub-directory.">
+        <![CDATA[
+<!-- Doubles file in double sub-directory -->
+<?php
+class Test_Double extends Original_Class {
+    // Code.
+}
+
+<!-- Unit test file -->
+<?php
+class Test_Original_Class extends TestCase {
+    // Test code.
+}
+        ]]>
+        </code>
+        <code title="Invalid: Having both the double class as well as the test class in the same file in the test directory.">
+        <![CDATA[
+<!-- Unit test file -->
+<?php
+class Test_Double extends Original_Class {
+    // Code.
+}
+
+class Test_Original_Class extends TestCase {
+    // Test code.
+}
+        ]]>
+        </code>
+    </code_comparison>
+
+</documentation>

--- a/Yoast/Docs/Namespaces/NamespaceDeclarationStandard.xml
+++ b/Yoast/Docs/Namespaces/NamespaceDeclarationStandard.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<documentation title="Namespace Declarations">
+    <standard>
+    <![CDATA[
+    Scoped namespace declarations are not allowed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Non-scoped namespace declaration.">
+        <![CDATA[
+namespace Yoast\Sub<em>;</em>
+        ]]>
+        </code>
+        <code title="Invalid: Scoped namespace declaration.">
+        <![CDATA[
+namespace Yoast\Scoped <em>{</em>
+    // Code.
+<em>}</em>
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    Namespace declarations without a namespace name are not allowed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Named namespace declaration.">
+        <![CDATA[
+namespace <em>Yoast\Sub</em>;
+        ]]>
+        </code>
+        <code title="Invalid: Namespace declaration without a name (=global namespace).">
+        <![CDATA[
+namespace<em></em>;
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    There should be only one namespace declaration per file.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: One named namespace declaration in a file.">
+        <![CDATA[
+namespace Yoast\Sub;
+        ]]>
+        </code>
+        <code title="Invalid: Multiple namespace declarations in a file.">
+        <![CDATA[
+namespace Yoast\Sub\A {
+}
+
+<em>namespace Yoast\Sub\B {
+}</em>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Yoast/Docs/WhiteSpace/FunctionSpacingStandard.xml
+++ b/Yoast/Docs/WhiteSpace/FunctionSpacingStandard.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0"?>
+<documentation title="Function Spacing">
+    <standard>
+    <![CDATA[
+    There should be one blank line before the first function in an OO structure.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: One blank line before the first function.">
+        <![CDATA[
+class MyClass {<em>
+
+</em>    /**
+     * Function docblock.
+     */
+    function func1() {
+    }
+}
+        ]]>
+        </code>
+        <code title="Invalid: No blank line before the first function.">
+        <![CDATA[
+class MyClass {<em>
+</em>    /**
+     * Function docblock.
+     */
+    function func1() {
+    }
+}
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    There should be one blank line between functions in an OO structure.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: One blank line between functions.">
+        <![CDATA[
+class MyClass {
+
+    /**
+     * Function docblock.
+     */
+    function func1() {
+    }<em>
+
+<em>    /**
+     * Function docblock.
+     */
+    function func2() {
+    }
+}
+        ]]>
+        </code>
+        <code title="Invalid: No blank lines or more than one blank line between functions.">
+        <![CDATA[
+class MyClass {
+
+    /**
+     * Function docblock.
+     */
+    function func1() {
+    }<em>
+
+
+<em>    /**
+     * Function docblock.
+     */
+    function func2() {
+    }<em>
+<em>    /**
+     * Function docblock.
+     */
+    function func3() {
+    }
+}
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    There should be no blank line after the last function in an OO structure.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No blank line after the last function.">
+        <![CDATA[
+class MyClass {
+
+    /**
+     * Function docblock.
+     */
+    function func1() {
+    }<em>
+</em>}
+        ]]>
+        </code>
+        <code title="Invalid: Blank line(s) after the last function.">
+        <![CDATA[
+class MyClass {
+
+    /**
+     * Function docblock.
+     */
+    function func1() {
+    }<em>
+
+</em>}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Yoast/Docs/Yoast/AlternativeFunctionsStandard.xml
+++ b/Yoast/Docs/Yoast/AlternativeFunctionsStandard.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<documentation title="Alternative Functions">
+    <standard>
+    <![CDATA[
+    Discourages the use of certain PHP or WP native functions in favour of Yoast native alternatives.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using the Yoast native `WPSEO_Utils:format_json_encode()` function.">
+        <![CDATA[
+$json = <em>WPSEO_Utils:format_json_encode</em>( $in );
+        ]]>
+        </code>
+        <code title="Discouraged: Using the WP native `wp_json_encode()` function.">
+        <![CDATA[
+$json = <em>wp_json_encode</em>( $in );
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
PHP_CodeSniffer offers a build-in mechanism to offer documentation for sniffs.
This build-in mechanism works from the command-line and can generate text, markdown or HTML documentation.

This PR adds the XML documents to provide this documentation for all YoastCS native sniffs.

It also adds an additional check in one of the travis builds to make sure that the XML documents added are valid XML.

To test this PR, view the documentation added by it, by:
1. Checking out this branch of YoastCS.
2. Running the following command from the root of the repo:
    `vendor/bin/phpcs --generator=Text --standard=Yoast --sniffs=Yoast.Commenting.CodeCoverageIgnoreDeprecated,Yoast.Commenting.CoversTag,Yoast.Commenting.Filecomment,Yoast.Commenting.TestsHaveCoversTag,Yoast.ControlStructures.IfElseDeclaration,Yoast.Files.FileName,Yoast.Files.TestDoubles,Yoast.Namespaces.NamespaceDeclaration,Yoast.WhiteSpace.FunctionSpacing,Yoast.Yoast.AlternativeFunctions`
    This will show only the docs of the Yoast native sniffs.
    If you'd run `vendor/bin/phpcs --generator=Text --standard=Yoast`, you not only receive the docs of the Yoast native sniffs, but also the (available) docs for all sniffs included from other standards, such as WPCS and PHPCS upstream.