### PR TITLE
GH: add pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/dependency_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dependency_change.md
@@ -1,0 +1,19 @@
+---
+name: Dependency change
+about: Update one or more of the YoastCS dependencies
+labels: "yoast cs/qa"
+---
+
+## Description
+
+*
+
+Refs:
+<!-- Add relevant links to, for instance, the changelog of the updated dependency. -->
+*
+
+<!--
+If the dependency update involves PHP_CodeSniffer or the WordPress Coding Standards,
+please make sure that the `.travis.yml` script is also updated to reflect this change,
+so the unit tests are run against the relevant supported versions of these repos.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/generic.md
+++ b/.github/PULL_REQUEST_TEMPLATE/generic.md
@@ -1,0 +1,6 @@
+---
+name: General
+about: Change which doesn't fit any of the other categories
+labels: "yoast cs/qa"
+---
+

--- a/.github/PULL_REQUEST_TEMPLATE/sniff_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/sniff_change.md
@@ -1,0 +1,41 @@
+---
+name: Sniff change
+about: Introduce a new sniff or update an existing sniff
+labels: "yoast cs/qa"
+---
+
+## Description
+
+*
+
+
+Refs:
+<!-- Add relevant links to, for instance, related upstream issues. -->
+*
+
+
+## Test instructions
+<!--
+Please follow these guidelines when creating test instructions:
+- Please provide step-by-step instructions how to reproduce the issue, if applicable.
+- Write step-by-step instructions to test that the change fixes the issue.
+
+For changes which depend on a change in one of the external dependencies, don't forget to mention the following as the first steps:
+* Throw away an existing `vendor` directory and `composer.lock` file.
+* Run `composer install`.
+-->
+This PR can be tested by following these steps:
+
+*
+
+
+## Sniff feature completeness
+
+* [ ] **Documentation**: I have added/updated the sniff `Standard.xml` documentation to match this change.
+    * [ ] Not applicable.
+* [ ] **Functionality**: This change adds auto-fixer(s).
+    * [ ] Not applicable.
+* [ ] **Unit tests**: I have added unit tests to verify the code works as intended.
+* [ ] **End-to-end tests**: I have run the new/updated sniff against one or more of the Yoast plugin repositories to find false positives/negatives.
+
+Fixes #


### PR DESCRIPTION
This adds three different pull request templates:
1. A dependency change template.
2. A sniff change template.
3. A generic template for anything that doesn't fit in the above two categories.