### PR TITLE
Travis: run the code style related checks in separate stages and other improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language:
     - php
 
@@ -30,16 +28,55 @@ env:
   - PHPCS_BRANCH="3.4.2" WPCS="dev-develop"
   - PHPCS_BRANCH="3.4.2" WPCS="2.1.1"
 
+# Define the stages used.
+# For non-PRs, only the sniff, ruleset and quicktest stages are run.
+# For pull requests and merges, the full script is run (skipping quicktest).
+# Note: for pull requests, "develop" should be the base branch name.
+# See: https://docs.travis-ci.com/user/conditions-v1
+stages:
+  - name: sniff
+  - name: rulesets
+  - name: quicktest
+    if: type = push AND branch NOT IN (master, develop)
+  - name: test
+    if: branch IN (master, develop)
+
 matrix:
   fast_finish: true
   include:
-    # Extra build to check for XML codestyle.
-    - php: 7.1
-      env: PHPCS_BRANCH="dev-master" WPCS="^2.1.1" SNIFF=1
+    #### SNIFF STAGE ####
+    - stage: sniff
+      php: 7.3
+      env: PHPCS_BRANCH="dev-master" WPCS="dev-master"
       addons:
-          apt:
-              packages:
-                - libxml2-utils
+        apt:
+          packages:
+            - libxml2-utils
+      script:
+        # Check the codestyle of the files within YoastCS.
+        - composer check-cs
+
+        # Validate the xml files.
+        # @link http://xmlsoft.org/xmllint.html
+        # For the build to properly error when validating against a scheme, these each have to be in their own condition.
+        - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./Yoast/ruleset.xml
+        - xmllint --noout ./Yoast/Docs/*/*Standard.xml
+
+        # Check the code-style consistency of the xml files.
+        - diff -B --tabsize=4 ./Yoast/ruleset.xml <(xmllint --format "./Yoast/ruleset.xml")
+
+    #### QUICK TEST STAGE ####
+    # This is a much quicker test which only runs the unit tests and linting against low/high
+    # supported PHP/PHPCS/WPCS combinations.
+    - stage: quicktest
+      php: 7.3
+      env: PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
+    - php: 7.3
+      env: PHPCS_BRANCH="3.3.1" WPCS="2.1.1"
+    - php: 5.4
+      env: PHPCS_BRANCH="dev-master" WPCS="2.1.1" PHPLINT=1
+    - php: 5.4
+      env: PHPCS_BRANCH="3.3.1" WPCS="dev-develop"
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -54,11 +91,9 @@ before_install:
     # On stable PHPCS versions, allow for PHP deprecation notices.
     # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
     - |
-      if [[ $PHPCS_BRANCH != "dev-master" && $WPCS != "dev-develop" ]]; then
+      if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" && $PHPCS_BRANCH != "dev-master" && $WPCS != "dev-develop" ]]; then
         echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
       fi
-    - php -r "echo ini_get('error_reporting');"
-
 
     - export XMLLINT_INDENT="	"
     - export PHPCS_DIR=$(pwd)/vendor/squizlabs/php_codesniffer
@@ -68,7 +103,7 @@ before_install:
     # Set the WPCS version to test against.
     - composer require wp-coding-standards/wpcs:${WPCS} --no-update --no-suggest --no-scripts
     - |
-      if [[ "$SNIFF" == "1" ]]; then
+      if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Sniff" ]]; then
           composer install --dev --no-suggest
           # The DealerDirect Composer plugin script takes care of the installed_paths.
       else
@@ -83,21 +118,17 @@ before_install:
     - $PHPCS_BIN -i
 
 script:
+    # Lint the PHP files against parse errors.
     - if [[ "$PHPLINT" == "1" ]]; then if find . -path ./vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
+
+    # Run the unit tests.
     - |
       if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
         vendor/bin/phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
       else
         phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
       fi
-    # Check the codestyle of the files within YoastCS.
-    - if [[ "$SNIFF" == "1" ]]; then composer check-cs; fi
-    # Validate the xml files.
-    # @link http://xmlsoft.org/xmllint.html
-    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./Yoast/ruleset.xml; fi
-    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./Yoast/Docs/*/*Standard.xml; fi
-    # Check the code-style consistency of the xml files.
-    - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./Yoast/ruleset.xml <(xmllint --format "./Yoast/ruleset.xml"); fi
+
     # Validate the composer.json file.
     # @link https://getcomposer.org/doc/03-cli.md#validate
     - if [[ "$PHPLINT" == "1" ]]; then composer validate --no-check-all --strict; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,31 +103,20 @@ before_install:
     # Set the WPCS version to test against.
     - composer require wp-coding-standards/wpcs:${WPCS} --no-update --no-suggest --no-scripts
     - |
-      if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Sniff" ]]; then
-          composer install --dev --no-suggest
-          # The DealerDirect Composer plugin script takes care of the installed_paths.
-      else
+      if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" ]]; then
           # For testing the YoastCS native sniffs, the rest of the packages aren't needed.
-          composer remove phpcompatibility/phpcompatibility-wp --no-update
-          # The Travis images for PHP >= 7.2 ship with PHPUnit 8, but the unit test suite is not compatible with that.
-          if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then composer require phpunit/phpunit:^7.0 --no-update --no-suggest --no-scripts;fi
-          # This will now only install the version of PHPCS/WPCS to test against.
-          composer install --no-dev --no-suggest
-          # The DealerDirect PHPCS Composer plugin takes care of the installed_paths.
+          composer remove phpcompatibility/phpcompatibility-wp phpcompatibility/php-compatibility --no-update
       fi
+    - composer install --dev --no-suggest
+    # The DealerDirect Composer plugin script takes care of the installed_paths.
     - $PHPCS_BIN -i
 
 script:
     # Lint the PHP files against parse errors.
-    - if [[ "$PHPLINT" == "1" ]]; then if find . -path ./vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
+    - if [[ "$PHPLINT" == "1" ]]; then composer lint; fi
 
     # Run the unit tests.
-    - |
-      if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
-        vendor/bin/phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
-      else
-        phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
-      fi
+    - vendor/bin/phpunit --filter Yoast --bootstrap="$PHPCS_DIR/tests/bootstrap.php" $PHPCS_DIR/tests/AllTests.php
 
     # Validate the composer.json file.
     # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,9 @@
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.2.0",
 		"roave/security-advisories": "dev-master",
-		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+		"jakub-onderka/php-parallel-lint": "^1.0",
+		"jakub-onderka/php-console-highlighter": "^0.4"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
@@ -39,6 +41,9 @@
 		"config-yoastcs" : [
 			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
+		],
+		"lint": [
+			"@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor"
 		],
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.4-"


### PR DESCRIPTION
### Travis: run the code style related checks in separate stages

Travis now offers stages. Using stages we can:
- Run the code style related checks before running any unit tests and stop the build early if any are detected.
- Remove the duplicate unit test runs - i.e. previously we had an extra (third) build against PHP 7.1 (now changed to 7.3) which would run the code style related checks, but would also re-run the unit tests. This extra build will now no longer run the unit tests.
- Add a separate "quicktest" stage for non-PR/merge builds.
    The "quicktest" stage will only run a CS check, ruleset check, linting and the unit tests against low/high PHP/PHPCS/WPCS combinations. This should catch most issues.
    The more comprehensive complete build against a larger combination of PHP/PHPCS/WPCS combination will now only be run on PRs and merges to `develop`/`master`.

While this does mean that the unit tests will run with a slight delay (the `Sniff` stage has to finish before they start), it also means that we:
* Get code style errors reported earlier as it's been moved to be the first stage and the build will just stop if any are found.
* We won't be wasting Travis's resources on builds which will have to be re-run anyway.

Ref: https://docs.travis-ci.com/user/build-stages/

Note that `Allowed failures` is no longer listed as a separate block in the Travis result overview, but is _is_ respected.

For more discussion about this:
* https://github.com/travis-ci/travis-ci/issues/7789
* https://travis-ci.community/t/always-show-allow-failures-allowed-failures-when-build-stages-are-used/217
* https://travis-ci.community/t/work-out-kinks-in-interactions-between-stages-allow-fail-and-fast-finish/1090
* https://github.com/travis-ci/travis-ci/issues/9677

## Travis/Composer: switch over to parallel linting of PHP files

## Composer

This installs two additional PHP packages in `require-dev`:
* [`php-parallel-lint`](https://packagist.org/packages/jakub-onderka/php-parallel-lint) which allows for linting PHP files in parallel (faster), as well as automatically recursively walking directories.
* [`php-console-highlighter`](https://packagist.org/packages/jakub-onderka/php-console-highlighter) which provides PHP code highlighting in the command line console, allowing the linter to display the results in a more meaningful manner.

## Travis

* Switch out the script part in the Travis script which did the linting the "old-fashioned" way to use the new Parallel linting option.
* Adjust the `composer install` commands in the `before_install` section and the `phpunit` command in the `script` section.
    As the above mentioned packages are `require-dev`, we'll now always need to run a full dev `composer install`.
    We can make it a tiny bit faster by removing a few packages which aren't needed in the test stage, but that shouldn't matter much anyway as the packages are installed from the cache.
    Also: as a full dev `composer install` is run now anyway, we don't need to have the special conditions related to the unsupported PHPUnit 8 package.
