### PR TITLE
CS: use short arrays

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -27,9 +27,17 @@
 
 		<!-- Conflicts with variable names coming from PHPCS itself. -->
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+
+		<!-- YoastCS will demand short arrays once the minimum PHP version allows it.
+			 The minimum PHP version for YoastCS already does. -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+
 	</rule>
 
 	<!-- Enforce PSR1 compatible namespaces. -->
 	<rule ref="PSR1.Classes.ClassDeclaration"/>
+
+	<!-- Enforce PHP 5.4+ short arrays. -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
 </ruleset>

--- a/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
+++ b/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
@@ -23,9 +23,9 @@ class CodeCoverageIgnoreDeprecatedSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_FUNCTION,
-		);
+		];
 	}
 
 	/**

--- a/Yoast/Sniffs/Commenting/CoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/CoversTagSniff.php
@@ -45,9 +45,9 @@ class CoversTagSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_DOC_COMMENT_OPEN_TAG,
-		);
+		];
 	}
 
 	/**
@@ -148,17 +148,17 @@ class CoversTagSniff implements Sniff {
 			// Throw a generic error for all other invalid annotations.
 			$error  = self::ERROR_MSG;
 			$error .= ' Check the PHPUnit documentation to see which annotations are supported. Found: %s';
-			$data   = array( $annotation );
+			$data   = [ $annotation ];
 			$phpcsFile->addError( $error, $next, 'Invalid', $data );
 		}
 
 		$coversNothingCount = count( $coversNothingTags );
 		if ( $firstCoversTag !== false && $coversNothingCount > 0 ) {
 			$error = 'A test can\'t both cover something as well as cover nothing. First @coversNothing tag encountered on line %d; first @covers tag encountered on line %d';
-			$data  = array(
+			$data  = [
 				$tokens[ $coversNothingTags[0] ]['line'],
 				$tokens[ $firstCoversTag ]['line'],
-			);
+			];
 
 			$phpcsFile->addError( $error, $tokens[ $stackPtr ]['comment_closer'], 'Contradictory', $data );
 		}
@@ -167,7 +167,7 @@ class CoversTagSniff implements Sniff {
 			$error      = 'Only one @coversNothing tag allowed per test';
 			$code       = 'DuplicateCoversNothing';
 			$fixable    = true;
-			$removeTags = array();
+			$removeTags = [];
 			foreach ( $coversNothingTags as $position => $ptr ) {
 				$next = ( $ptr + 1 );
 				if ( $tokens[ $next ]['code'] === T_DOC_COMMENT_WHITESPACE
@@ -232,7 +232,7 @@ class CoversTagSniff implements Sniff {
 
 						if ( ! isset( $first ) ) {
 							$first = explode( '-', $ptrs );
-							$data  = array( $tokens[ $first[0] ]['line'] );
+							$data  = [ $tokens[ $first[0] ]['line'] ];
 							continue;
 						}
 
@@ -288,10 +288,10 @@ class CoversTagSniff implements Sniff {
 		}
 
 		$error = self::ERROR_MSG . "\nExpected: `%s`\nFound:    `%s`";
-		$data  = array(
+		$data  = [
 			$expected,
 			$annotation,
-		);
+		];
 
 		$fix = $phpcsFile->addFixableError( $error, $stackPtr, $errorCode, $data );
 		if ( $fix === true ) {

--- a/Yoast/Sniffs/Commenting/TestsHaveCoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/TestsHaveCoversTagSniff.php
@@ -22,10 +22,10 @@ class TestsHaveCoversTagSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_CLASS,
 			T_FUNCTION,
-		);
+		];
 	}
 
 	/**
@@ -182,7 +182,7 @@ class TestsHaveCoversTagSniff implements Sniff {
 			'Each test function should have at least one @covers tag annotating which class/method/function is being tested. Tag missing for function %s()',
 			$stackPtr,
 			'Missing',
-			array( $name )
+			[ $name ]
 		);
 	}
 }

--- a/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Yoast/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -23,10 +23,10 @@ class IfElseDeclarationSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_ELSE,
 			T_ELSEIF,
-		);
+		];
 	}
 
 	/**
@@ -64,7 +64,7 @@ class IfElseDeclarationSniff implements Sniff {
 				'%s statement must be on a new line',
 				$stackPtr,
 				'NewLine',
-				array( ucfirst( $tokens[ $stackPtr ]['content'] ) )
+				[ ucfirst( $tokens[ $stackPtr ]['content'] ) ]
 			);
 		}
 		elseif ( $tokens[ $previous_scope_closer ]['column'] !== $tokens[ $stackPtr ]['column'] ) {
@@ -72,7 +72,7 @@ class IfElseDeclarationSniff implements Sniff {
 				'%s statement not aligned with previous part of the control structure',
 				$stackPtr,
 				'Alignment',
-				array( ucfirst( $tokens[ $stackPtr ]['content'] ) )
+				[ ucfirst( $tokens[ $stackPtr ]['content'] ) ]
 			);
 		}
 
@@ -80,10 +80,10 @@ class IfElseDeclarationSniff implements Sniff {
 
 		if ( $previous_scope_closer !== $previous_non_empty ) {
 			$error = 'Nothing but whitespace and comments allowed between closing bracket and %s statement, found "%s"';
-			$data  = array(
+			$data  = [
 				$tokens[ $stackPtr ]['content'],
 				trim( $phpcsFile->getTokensAsString( ( $previous_scope_closer + 1 ), ( $stackPtr - ( $previous_scope_closer + 1 ) ) ) ),
-			);
+			];
 			$phpcsFile->addError( $error, $stackPtr, 'StatementFound', $data );
 		}
 	}

--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -39,7 +39,7 @@ class FileNameSniff implements Sniff {
 	 *
 	 * @var string[]
 	 */
-	public $prefixes = array();
+	public $prefixes = [];
 
 	/**
 	 * List of files to exclude from the strict file name check.
@@ -59,18 +59,18 @@ class FileNameSniff implements Sniff {
 	 *
 	 * @var string[]
 	 */
-	public $exclude = array();
+	public $exclude = [];
 
 	/**
 	 * Object tokens to search for in a file.
 	 *
 	 * @var array
 	 */
-	private $oo_tokens = array(
+	private $oo_tokens = [
 		T_CLASS,
 		T_INTERFACE,
 		T_TRAIT,
-	);
+	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -78,7 +78,7 @@ class FileNameSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array( T_OPEN_TAG );
+		return [ T_OPEN_TAG ];
 	}
 
 	/**
@@ -189,10 +189,10 @@ class FileNameSniff implements Sniff {
 				$error,
 				0,
 				$error_code,
-				array(
+				[
 					$expected . '.' . $extension,
 					$basename,
-				)
+				]
 			);
 		}
 
@@ -213,7 +213,7 @@ class FileNameSniff implements Sniff {
 		$exclude = $this->clean_custom_array_property( $this->exclude, true, true );
 
 		if ( ! empty( $exclude ) ) {
-			$exclude      = array_map( array( $this, 'normalize_directory_separators' ), $exclude );
+			$exclude      = array_map( [ $this, 'normalize_directory_separators' ], $exclude );
 			$path_to_file = $this->normalize_directory_separators( $path_to_file );
 
 			if ( ! isset( $phpcsFile->config->basepath ) ) {

--- a/Yoast/Sniffs/Files/TestDoublesSniff.php
+++ b/Yoast/Sniffs/Files/TestDoublesSniff.php
@@ -33,9 +33,9 @@ class TestDoublesSniff implements Sniff {
 	 *
 	 * @var array
 	 */
-	public $doubles_path = array(
+	public $doubles_path = [
 		'/tests/doubles',
-	);
+	];
 
 	/**
 	 * Validated absolute target paths for test double/mock classes or an empty array
@@ -51,11 +51,11 @@ class TestDoublesSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_CLASS,
 			T_INTERFACE,
 			T_TRAIT,
-		);
+		];
 	}
 
 	/**
@@ -120,7 +120,7 @@ class TestDoublesSniff implements Sniff {
 		$base_path = rtrim( $base_path, '/' ) . '/'; // Make sure the base_path ends in a single slash.
 
 		if ( ! isset( $this->target_paths ) || defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
-			$this->target_paths = array();
+			$this->target_paths = [];
 
 			foreach ( $this->doubles_path as $doubles_path ) {
 				$target_path  = $base_path;
@@ -134,9 +134,9 @@ class TestDoublesSniff implements Sniff {
 
 		if ( empty( $this->target_paths ) ) {
 			// No valid target paths found.
-			$data = array(
+			$data = [
 				$phpcsFile->config->basepath,
-			);
+			];
 
 			if ( count( $this->doubles_path ) === 1 ) {
 				$data[] = 'directory';
@@ -169,10 +169,10 @@ class TestDoublesSniff implements Sniff {
 			}
 
 			if ( $is_error === true ) {
-				$data = array(
+				$data = [
 					$tokens[ $stackPtr ]['content'],
 					$object_name,
-				);
+				];
 
 				$phpcsFile->addError(
 					'Double/Mock test helper classes should be placed in a dedicated test doubles sub-directory. Found %s: %s',
@@ -189,12 +189,12 @@ class TestDoublesSniff implements Sniff {
 		}
 
 		if ( $more_objects_in_file !== false ) {
-			$data = array(
+			$data = [
 				$tokens[ $stackPtr ]['content'],
 				$object_name,
 				$tokens[ $more_objects_in_file ]['content'],
 				$phpcsFile->getDeclarationName( $more_objects_in_file ),
-			);
+			];
 
 			$phpcsFile->addError(
 				'Double/Mock test helper classes should be in their own file. Found %1$s: %2$s and %3$s: %4$s',

--- a/Yoast/Sniffs/Namespaces/NamespaceDeclarationSniff.php
+++ b/Yoast/Sniffs/Namespaces/NamespaceDeclarationSniff.php
@@ -30,9 +30,9 @@ class NamespaceDeclarationSniff implements Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		return [
 			T_OPEN_TAG,
-		);
+		];
 	}
 
 	/**
@@ -48,7 +48,7 @@ class NamespaceDeclarationSniff implements Sniff {
 
 		$tokens = $phpcsFile->getTokens();
 
-		$statements = array();
+		$statements = [];
 
 		while ( ( $stackPtr = $phpcsFile->findNext( T_NAMESPACE, ( $stackPtr + 1 ) ) ) !== false ) {
 
@@ -91,10 +91,10 @@ class NamespaceDeclarationSniff implements Sniff {
 
 		$count = count( $statements );
 		if ( $count > 1 ) {
-			$data = array(
+			$data = [
 				$count,
 				$tokens[ $statements[0] ]['line'],
-			);
+			];
 
 			for ( $i = 1; $i < $count; $i++ ) {
 				$phpcsFile->addError(

--- a/Yoast/Sniffs/Yoast/AlternativeFunctionsSniff.php
+++ b/Yoast/Sniffs/Yoast/AlternativeFunctionsSniff.php
@@ -20,17 +20,17 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 * @return array
 	 */
 	public function getGroups() {
-		return array(
-			'json_encode' => array(
+		return [
+			'json_encode' => [
 				'type'        => 'error',
 				'message'     => 'Detected a call to %s(). Use %s() instead.',
-				'functions'   => array(
+				'functions'   => [
 					'json_encode',
 					'wp_json_encode',
-				),
+				],
 				'replacement' => 'WPSEO_Utils::format_json_encode',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -54,10 +54,10 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		$message    = $this->groups[ $group_name ]['message'];
 		$is_error   = ( $this->groups[ $group_name ]['type'] === 'error' );
 		$error_code = $this->string_to_errorcode( $group_name . '_' . $matched_content );
-		$data       = array(
+		$data       = [
 			$matched_content,
 			$replacement,
-		);
+		];
 
 		/*
 		 * Deal with specific situations.

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
@@ -21,11 +21,11 @@ class CodeCoverageIgnoreDeprecatedUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			41 => 1,
 			50 => 1,
 			55 => 1,
-		);
+		];
 	}
 
 	/**
@@ -34,6 +34,6 @@ class CodeCoverageIgnoreDeprecatedUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 }

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.php
@@ -21,7 +21,7 @@ class CoversTagUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			34  => 1,
 			35  => 1,
 			36  => 1,
@@ -50,7 +50,7 @@ class CoversTagUnitTest extends AbstractSniffUnitTest {
 			140 => 1,
 			150 => 1,
 			151 => 1,
-		);
+		];
 	}
 
 	/**
@@ -59,6 +59,6 @@ class CoversTagUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 }

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.php
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.php
@@ -27,12 +27,12 @@ class FileCommentUnitTest extends AbstractSniffUnitTest {
 			case 'FileCommentUnitTest.2.inc':
 			case 'FileCommentUnitTest.8.inc':
 			case 'FileCommentUnitTest.10.inc':
-				return array(
+				return [
 					1 => 1,
-				);
+				];
 
 			default:
-				return array();
+				return [];
 		}
 	}
 
@@ -47,12 +47,12 @@ class FileCommentUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'FileCommentUnitTest.4.inc':
 			case 'FileCommentUnitTest.6.inc':
-				return array(
+				return [
 					2 => 1,
-				);
+				];
 
 			default:
-				return array();
+				return [];
 		}
 	}
 }

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
@@ -21,10 +21,10 @@ class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			59 => 1,
 			88 => 1,
-		);
+		];
 	}
 
 	/**
@@ -33,6 +33,6 @@ class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 }

--- a/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Yoast/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -22,7 +22,7 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			22 => 1,
 			28 => 1,
 			30 => 1,
@@ -32,7 +32,7 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 			51 => 1,
 			76 => 1,
 			84 => 2,
-		);
+		];
 	}
 
 	/**
@@ -41,6 +41,6 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 }

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -20,7 +20,7 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @var array
 	 */
-	private $expected_results = array(
+	private $expected_results = [
 
 		/*
 		 * In /FileNameUnitTests.
@@ -74,7 +74,7 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 
 		// Fall-back file in case glob() fails.
 		'FileNameUnitTest.inc'            => 1,
-	);
+	];
 
 	/**
 	 * Set CLI values before the file is tested.
@@ -107,7 +107,7 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 			return $test_files;
 		}
 
-		return array( $testFileBase . '.inc' );
+		return [ $testFileBase . '.inc' ];
 	}
 
 	/**
@@ -120,12 +120,12 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 	public function getErrorList( $testFile = '' ) {
 
 		if ( isset( $this->expected_results[ $testFile ] ) ) {
-			return array(
+			return [
 				1 => $this->expected_results[ $testFile ],
-			);
+			];
 		}
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -137,11 +137,11 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList( $testFile = '' ) {
 		if ( $testFile === 'no-basepath.inc' ) {
-			return array(
+			return [
 				1 => 1,
-			);
+			];
 		}
 
-		return array();
+		return [];
 	}
 }

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -46,7 +46,7 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 			return $test_files;
 		}
 
-		return array( $testFileBase . '.inc' );
+		return [ $testFileBase . '.inc' ];
 	}
 
 	/**
@@ -61,59 +61,59 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			// In tests/.
 			case 'mock-not-in-correct-dir.inc':
-				return array(
+				return [
 					3 => 1,
-				);
+				];
 
 			case 'multiple-objects-in-file.inc':
-				return array(
+				return [
 					5 => 2,
-				);
+				];
 
 			case 'multiple-objects-in-file-reverse.inc':
-				return array(
+				return [
 					7 => 2,
-				);
+				];
 
 			case 'non-existant-doubles-dir.inc':
-				return array(
+				return [
 					4 => 1,
-				);
+				];
 
 			case 'not-in-correct-custom-dir.inc':
-				return array(
+				return [
 					4 => 1,
-				);
+				];
 
 			case 'not-in-correct-dir-double.inc':
-				return array(
+				return [
 					3 => 1,
-				);
+				];
 
 			case 'not-in-correct-dir-mock.inc':
-				return array(
+				return [
 					3 => 1,
-				);
+				];
 
 			// In tests/doubles.
 			case 'multiple-mocks-in-file.inc':
-				return array(
+				return [
 					3 => 1,
 					5 => 1,
-				);
+				];
 
 			// In tests/doubles-not-correct.
 			case 'not-in-correct-subdir.inc':
-				return array(
+				return [
 					3 => 1,
-				);
+				];
 
 			case 'not-double-or-mock.inc': // In tests.
 			case 'correct-dir-double.inc': // In tests/doubles.
 			case 'correct-dir-mock.inc': // In tests/doubles.
 			case 'correct-custom-dir.inc': // In tests/mocks.
 			default:
-				return array();
+				return [];
 		}
 	}
 
@@ -127,17 +127,17 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {
 			case 'no-basepath.inc':
-				return array(
+				return [
 					1 => 1,
-				);
+				];
 
 			case 'no-doubles-path-property.inc':
-				return array(
+				return [
 					1 => 1,
-				);
+				];
 
 			default:
-				return array();
+				return [];
 		}
 	}
 }

--- a/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.php
+++ b/Yoast/Tests/Namespaces/NamespaceDeclarationUnitTest.php
@@ -25,16 +25,16 @@ class NamespaceDeclarationUnitTest extends AbstractSniffUnitTest {
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
 			case 'NamespaceDeclarationUnitTest.2.inc':
-				return array(
+				return [
 					3  => 1,
 					5  => 3,
 					7  => 2,
 					9  => 3,
 					11 => 2,
-				);
+				];
 
 			default:
-				return array();
+				return [];
 		}
 	}
 
@@ -44,6 +44,6 @@ class NamespaceDeclarationUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 }

--- a/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -21,7 +21,7 @@ class FunctionSpacingUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			31 => 1,
 			33 => 1,
 			39 => 1,
@@ -32,7 +32,7 @@ class FunctionSpacingUnitTest extends AbstractSniffUnitTest {
 			74 => 1,
 			87 => 2,
 			88 => 1,
-		);
+		];
 	}
 
 	/**
@@ -41,6 +41,6 @@ class FunctionSpacingUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 }

--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.php
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.php
@@ -19,7 +19,7 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		return [
 			12 => 1,
 			13 => 1,
 			14 => 1,
@@ -27,7 +27,7 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 			17 => 1,
 			21 => 1,
 			22 => 1,
-		);
+		];
 	}
 
 	/**
@@ -36,6 +36,6 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return [];
 	}
 }


### PR DESCRIPTION
WPCS will start forbidding the use of short arrays as of WPCS 2.2.0.

For YoastCS the decision has been taken to not comply with this rule and to enforce short arrays instead.

As the minimum supported PHP version is still PHP 5.2 for most repos, we cannot yet enforce this through the `YoastCS` ruleset.

So, for now, this will only be enforced for PHP 5.4+ directories in those repos which have them.

As YoastCS itself has a minimum PHP requirement of PHP 5.4, we _can_ start enforcing it in the code of YoastCS itself.
This PR implements that.