### PR TITLE
Travis: minor tweak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-language:
-    - php
+language: php
 
 dist: trusty
 


### PR DESCRIPTION
The travis linter does not like lists of languages. This should always be a singular value.