### PR TITLE
FileName: rename public properties

### DIFF
--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -39,7 +39,7 @@ class FileNameSniff implements Sniff {
 	 *
 	 * @var string[]
 	 */
-	public $prefixes = [];
+	public $oo_prefixes = [];
 
 	/**
 	 * List of files to exclude from the strict file name check.
@@ -59,7 +59,7 @@ class FileNameSniff implements Sniff {
 	 *
 	 * @var string[]
 	 */
-	public $exclude = [];
+	public $excluded_files_strict_check = [];
 
 	/**
 	 * Object tokens to search for in a file.
@@ -128,7 +128,7 @@ class FileNameSniff implements Sniff {
 				$tokens = $phpcsFile->getTokens();
 				$name   = $phpcsFile->getDeclarationName( $oo_structure );
 
-				$prefixes = $this->clean_custom_array_property( $this->prefixes );
+				$prefixes = $this->clean_custom_array_property( $this->oo_prefixes );
 				if ( ! empty( $prefixes ) ) {
 					// Use reverse natural sorting to get the longest of overlapping prefixes first.
 					rsort( $prefixes, ( SORT_NATURAL | SORT_FLAG_CASE ) );
@@ -210,7 +210,7 @@ class FileNameSniff implements Sniff {
 	 * @return bool
 	 */
 	protected function is_file_excluded( File $phpcsFile, $path_to_file ) {
-		$exclude = $this->clean_custom_array_property( $this->exclude, true, true );
+		$exclude = $this->clean_custom_array_property( $this->excluded_files_strict_check, true, true );
 
 		if ( ! empty( $exclude ) ) {
 			$exclude      = array_map( [ $this, 'normalize_directory_separators' ], $exclude );

--- a/Yoast/Tests/Files/FileNameUnitTests/ExcludedFile.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/ExcludedFile.inc
@@ -1,6 +1,6 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName exclude[] ExcludedFile.inc
+phpcs:set Yoast.Files.FileName excluded_files_strict_check[] ExcludedFile.inc
 
 <?php
 
-// phpcs:set Yoast.Files.FileName exclude[]
+// phpcs:set Yoast.Files.FileName excluded_files_strict_check[]

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/class-wpseo-some-class.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/class-wpseo-some-class.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 class WPSEO_Some_Class {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/excluded-CLASS-file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/excluded-CLASS-file.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName exclude[] classes/excluded-CLASS-file.inc
+phpcs:set Yoast.Files.FileName excluded_files_strict_check[] classes/excluded-CLASS-file.inc
 
 <?php
 
 class Some_Class {}
 
-// phpcs:set Yoast.Files.FileName exclude[]
+// phpcs:set Yoast.Files.FileName excluded_files_strict_check[]

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/some-class.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/some-class.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 class WPSEO_Some_Class {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/wpseo-some-class.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/wpseo-some-class.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 class WPSEO_Some_Class {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/yoast-plugin-some-class.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/yoast-plugin-some-class.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast,yoast-plugin
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast,yoast-plugin
 
 <?php
 
 class Yoast_Plugin_Some_Class {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/excluded-file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/excluded-file.inc
@@ -1,6 +1,6 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName exclude[] excluded-file.inc
+phpcs:set Yoast.Files.FileName excluded_files_strict_check[] excluded-file.inc
 
 <?php
 
-// phpcs:set Yoast.Files.FileName exclude[]
+// phpcs:set Yoast.Files.FileName excluded_files_strict_check[]

--- a/Yoast/Tests/Files/FileNameUnitTests/excluded_file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/excluded_file.inc
@@ -1,6 +1,6 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName exclude[] excluded_file.inc
+phpcs:set Yoast.Files.FileName excluded_files_strict_check[] excluded_file.inc
 
 <?php
 
-// phpcs:set Yoast.Files.FileName exclude[]
+// phpcs:set Yoast.Files.FileName excluded_files_strict_check[]

--- a/Yoast/Tests/Files/FileNameUnitTests/functions/excluded-functions-file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/functions/excluded-functions-file.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName exclude[] functions/excluded-functions-file.inc
+phpcs:set Yoast.Files.FileName excluded_files_strict_check[] functions/excluded-functions-file.inc
 
 <?php
 
 function some_function() {}
 
-// phpcs:set Yoast.Files.FileName exclude[]
+// phpcs:set Yoast.Files.FileName excluded_files_strict_check[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/different-interface.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/different-interface.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 interface Yoast_Outline_Something {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/excluded-interface-file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/excluded-interface-file.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName exclude[] interfaces/excluded-interface-file.inc
+phpcs:set Yoast.Files.FileName excluded_files_strict_check[] interfaces/excluded-interface-file.inc
 
 <?php
 
 interface My_Interface {}
 
-// phpcs:set Yoast.Files.FileName exclude[]
+// phpcs:set Yoast.Files.FileName excluded_files_strict_check[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/no-duplicate-interface.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/no-duplicate-interface.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 interface Yoast_No_Duplicate_Interface {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/outline-something-interface.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/outline-something-interface.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 interface Yoast_Outline_Something {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/outline-something.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/outline-something.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 interface Yoast_Outline_Something {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/interfaces/yoast-outline-something.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/interfaces/yoast-outline-something.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 interface Yoast_Outline_Something {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/no-basepath.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/no-basepath.inc
@@ -1,6 +1,6 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName exclude[] no-basepath.inc
+phpcs:set Yoast.Files.FileName excluded_files_strict_check[] no-basepath.inc
 
 <?php
 
-// phpcs:set Yoast.Files.FileName exclude[]
+// phpcs:set Yoast.Files.FileName excluded_files_strict_check[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/different-trait.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/different-trait.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 trait Yoast_Outline_Something {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/excluded-trait-file.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/excluded-trait-file.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName exclude[] traits/excluded-trait-file.inc
+phpcs:set Yoast.Files.FileName excluded_files_strict_check[] traits/excluded-trait-file.inc
 
 <?php
 
 trait My_Trait {}
 
-// phpcs:set Yoast.Files.FileName exclude[]
+// phpcs:set Yoast.Files.FileName excluded_files_strict_check[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/no-duplicate-trait.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/no-duplicate-trait.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 trait Yoast_No_Duplicate_Trait {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/outline-something-trait.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/outline-something-trait.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 trait Yoast_Outline_Something {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/outline-something.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/outline-something.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 trait Yoast_Outline_Something {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/yoast-outline-something.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/yoast-outline-something.inc
@@ -1,8 +1,8 @@
 <!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
-phpcs:set Yoast.Files.FileName prefixes[] wpseo,yoast
+phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
 trait Yoast_Outline_Something {}
 
-// phpcs:set Yoast.Files.FileName prefixes[]
+// phpcs:set Yoast.Files.FileName oo_prefixes[]


### PR DESCRIPTION
Sniff properties are specific to individual sniffs, but can be set for all sniffs in one go (undocumented PHPCS feature).

The public `$prefixes` property is used by the WPCS `PrefixAllGlobals` sniff to pass on which text strings should be considered "prefixes" for namespaces, class names, hook names, variable names etc for the purposes of that sniff.

Both the new, upcoming `ValidNamespace` sniff (#141) and the Yoast specific `ValidHookName` sniff (#143) will need the `$prefixes` property as well and the content for the property for those sniffs should overlap with the `$prefixes` property for the `PrefixAllGlobals` sniff.

To prevent having to set the same value three times in each custom ruleset, it would be useful to be able to use the "_set the property for all sniffs in one go_" feature.

However, the YoastCS `FileName` sniff also uses a `$prefixes` property which is a distinct, different property which indicates which part at the start of a class name should be removed to get the file name. This property may partially overlap with the `$prefixes` property for the `PrefixAllGlobals` sniff, but not necessarily.
The overlap will become smaller/non-existent once all plugins will start using namespaces.

To prevent confusion between the two types of `$prefixes` properties, I'm changing the property name in the `FileName` sniff to `$oo_prefixes`.

The `FileName` sniff also has an `$exclude` property which is used to indicate which file names should be _excluded_ from the strict file content specific part of the `FileName` sniff checks.

As a number of WPCS sniffs also have an `$exclude` property with a different meaning, this property again can be confusing, so we may as well rename that property now as well.

**Note: This is a backward-compatibility break.**

* This means that the next version will need to be YoastCS 2.0.
* Existing custom rulesets using these properties will need to be adjusted to reflect the change.