### PR TITLE
New `ObjectNameDepth` sniff

### DIFF
--- a/Yoast/Docs/NamingConventions/ObjectNameDepthStandard.xml
+++ b/Yoast/Docs/NamingConventions/ObjectNameDepthStandard.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<documentation title="Object Name Depth">
+    <standard>
+    <![CDATA[
+    The name of objects - classes, interfaces, traits - declared within a namespace should consist of a maximum of three words.
+
+    Note: the maximum (error) and the recommended (warning) maximum length are configurable.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: long class name in a file without a namespace.">
+        <![CDATA[
+class <em>Non_Namespaced_Long_Class_Name</em> {}
+        ]]>
+        </code>
+        <code title="Invalid: long class name in a namespaced file.">
+        <![CDATA[
+namespace Yoast\WP\Plugin;
+
+class <em>Namespaced_Long_Class_Name</em> {}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: short class name in a namespaced file.">
+        <![CDATA[
+namespace Yoast\WP\Plugin;
+
+class <em>Short_Class_Name</em> {}
+        ]]>
+        </code>
+        <code title="Invalid: long class name in a namespaced file.">
+        <![CDATA[
+namespace Yoast\WP\Plugin;
+
+class <em>Namespaced_Too_Long_Class_Name</em> {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -87,7 +87,7 @@ class ObjectNameDepthSniff extends WPCS_Sniff {
 
 		$comment_end = $this->phpcsFile->findPrevious( $find, ( $stackPtr - 1 ), null, true );
 		if ( $this->tokens[ $comment_end ]['code'] === T_DOC_COMMENT_CLOSE_TAG ) {
-			// Only check is the class has a docblock.
+			// Only check if the class has a docblock.
 			$comment_start = $this->tokens[ $comment_end ]['comment_opener'];
 			foreach ( $this->tokens[ $comment_start ]['comment_tags'] as $tag ) {
 				if ( $this->tokens[ $tag ]['content'] === '@deprecated' ) {

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace YoastCS\Yoast\Sniffs\NamingConventions;
+
+use WordPressCS\WordPress\Sniff as WPCS_Sniff;
+
+/**
+ * Check the number of words in object names declared within a namespace.
+ *
+ * @package Yoast\YoastCS
+ * @author  Juliette Reinders Folmer
+ *
+ * @since   1.4.0
+ */
+class ObjectNameDepthSniff extends WPCS_Sniff {
+
+	/**
+	 * Maximum number of words.
+	 *
+	 * The maximum number of words an object name should consist of, each
+	 * separated by an underscore.
+	 *
+	 * If the name consists of more words, an ERROR will be thrown.
+	 *
+	 * @var int
+	 */
+	public $max_words = 3;
+
+	/**
+	 * Recommended maximum number of words.
+	 *
+	 * The recommended maximum number of words an object name should consist of, each
+	 * separated by an underscore.
+	 *
+	 * If the name consists of more words, a WARNING will be thrown.
+	 *
+	 * @var int
+	 */
+	public $recommended_max_words = 3;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return [
+			T_CLASS,
+			T_INTERFACE,
+			T_TRAIT,
+		];
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token
+	 *                      in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		// Check whether we are in a namespace or not.
+		if ( $this->determine_namespace( $stackPtr ) === '' ) {
+			return;
+		}
+
+		$object_name = $this->phpcsFile->getDeclarationName( $stackPtr );
+		if ( empty( $object_name ) ) {
+			return;
+		}
+
+		$parts      = explode( '_', $object_name );
+		$part_count = count( $parts );
+
+		if ( $part_count <= $this->recommended_max_words && $part_count <= $this->max_words ) {
+			return;
+		}
+
+		// Check if the class is deprecated.
+		$find = [
+			T_ABSTRACT   => T_ABSTRACT,
+			T_FINAL      => T_FINAL,
+			T_WHITESPACE => T_WHITESPACE,
+		];
+
+		$comment_end = $this->phpcsFile->findPrevious( $find, ( $stackPtr - 1 ), null, true );
+		if ( $this->tokens[ $comment_end ]['code'] === T_DOC_COMMENT_CLOSE_TAG ) {
+			// Only check is the class has a docblock.
+			$comment_start = $this->tokens[ $comment_end ]['comment_opener'];
+			foreach ( $this->tokens[ $comment_start ]['comment_tags'] as $tag ) {
+				if ( $this->tokens[ $tag ]['content'] === '@deprecated' ) {
+					// Deprecated class, ignore.
+					return;
+				}
+			}
+		}
+
+		// Active class.
+		$object_type = 'a ' . $this->tokens[ $stackPtr ]['content'];
+		if ( $this->tokens[ $stackPtr ]['code'] === \T_INTERFACE ) {
+			$object_type = 'an ' . $this->tokens[ $stackPtr ]['content'];
+		}
+
+		if ( $part_count > $this->max_words ) {
+			$error = 'The name of %s is not allowed to consist of more than %d words. Words found: %d in %s';
+			$data  = [
+				$object_type,
+				$this->max_words,
+				$part_count,
+				$object_name,
+			];
+
+			$this->phpcsFile->addError( $error, $stackPtr, 'MaxExceeded', $data );
+		}
+		elseif ( $part_count > $this->recommended_max_words ) {
+			$error = 'The name of %s should not consist of more than %d words. Words found: %d in %s';
+			$data  = [
+				$object_type,
+				$this->recommended_max_words,
+				$part_count,
+				$object_name,
+			];
+
+			$this->phpcsFile->addWarning( $error, $stackPtr, 'TooLong', $data );
+		}
+	}
+}

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.1.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.1.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Testing object declarations in a file without a namespace.
+
+class Non_Namespaced_Long_Class_Name {}
+
+interface This_Interface_Name_Is_Long {}
+
+trait This_Trait_Name_Is_Long {}

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
@@ -1,0 +1,65 @@
+<?php
+
+// Testing object declarations in a file with a namespace.
+
+namespace Yoast\Plugin;
+
+/*
+ * All OK.
+ */
+class Admin {}
+class Class_Name {}
+class Three_Part_Name {}
+
+interface My_Interface_Name {}
+trait Some_Trait_Name {}
+
+/*
+ * Too long.
+ */
+
+class Too_Long_Class_Name {} // Error.
+interface This_Interface_Name_Is_Too_Long {} // Error.
+trait Trait_Name_Is_Too_Long {} // Error.
+
+/*
+ * Custom settings.
+ */
+
+// phpcs:set Yoast.NamingConventions.ObjectNameDepth max_words 5
+// phpcs:set Yoast.NamingConventions.ObjectNameDepth recommended_max_words 2
+
+class Three_Part_Name {} // Warning.
+class Six_Part_Class_Name_Too_Long {} // Error.
+
+/*
+ * Incorrect custom settings (soft > max).
+ */
+
+// phpcs:set Yoast.NamingConventions.ObjectNameDepth max_words 2
+// phpcs:set Yoast.NamingConventions.ObjectNameDepth recommended_max_words 5
+
+class Three_Part_ClassName {} // Error.
+class Seven_Part_Class_Name_Too_Long_Too {} // Error.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.ObjectNameDepth max_words 3
+// phpcs:set Yoast.NamingConventions.ObjectNameDepth recommended_max_words 3
+
+/*
+ * Ignore deprecated objects.
+ */
+
+/**
+ * Class description, no @deprecated tag.
+ *
+ * @since x.x.x
+ */
+class Active_Class_With_Too_Long_Class_Name {} // Error.
+
+/**
+ * Class description.
+ *
+ * @deprecated x.x.x
+ */
+class Deprecated_Class_With_Too_Long_Class_Name {} // OK.

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace YoastCS\Yoast\Tests\NamingConventions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the ObjectNameDepth sniff.
+ *
+ * @package Yoast\YoastCS
+ *
+ * @since   1.4.0
+ *
+ * @covers  YoastCS\Yoast\Sniffs\NamingConventions\ObjectNameDepthSniff
+ */
+class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList( $testFile = '' ) {
+
+		switch ( $testFile ) {
+			case 'ObjectNameDepthUnitTest.2.inc':
+				return [
+					21 => 1,
+					22 => 1,
+					23 => 1,
+					33 => 1,
+					42 => 1,
+					43 => 1,
+					58 => 1,
+				];
+
+			default:
+				return [];
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'ObjectNameDepthUnitTest.2.inc':
+				return [
+					32 => 1,
+				];
+
+			default:
+				return [];
+		}
+	}
+}
+


### PR DESCRIPTION
This new sniff checks that the names of declared objects - classes, interfaces, traits - contain no more than three words / two underscores.

This rule is only applied to objects declared in a namespace. For non-namespaced objects the rule does not apply.

The sniff will throw a `warning` when the name consists of more words than `recommended_max_words` and an `error` when the name is longer than `max_words`.

Both `recommended_max_words`, as well as `max_words` are configurable and can be changed from a custom ruleset.

By default, `recommended_max_words` and `max_words` are set to the same value: `3`, i.e. three words.

Note: the sniff currently extends the WPCS `Sniff` class to allow for using one of the utility methods contained in WPCS. Once `PHPCSUtils` comes out and use of `PHPCSUtils` is implemented in YoastCS, this will no longer be necessary and the (improved) utility method in `PHPCSUtils` can be used instead.

Includes unit tests.
Includes documentation.

Fixes #142