### PR TITLE
Ruleset: change minimum versions to PHP 5.6 and WP 5.2

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -31,7 +31,7 @@
 			 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
 		-->
 		<properties>
-			<property name="minimum_supported_version" value="4.9"/>
+			<property name="minimum_supported_version" value="5.2"/>
 		</properties>
 
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>
@@ -113,7 +113,7 @@
 	SNIFF FOR PHP CROSS-VERSION COMPATIBILITY
 	#############################################################################
 	-->
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="5.6-"/>
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php$</include-pattern>
 	</rule>


### PR DESCRIPTION
YoastCS 2.0 is intended for the Yoast plugin after the drop of support for WP < 5.2, which means that the minimum supported PHP version for the plugins will now be PHP 5.6 and the minimum supported WP version will be WP 5.2.