### PR TITLE
New `ValidHookName` sniff

### DIFF
--- a/Yoast/Docs/NamingConventions/ValidHookNameStandard.xml
+++ b/Yoast/Docs/NamingConventions/ValidHookNameStandard.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<documentation title="Valid Hook Name">
+    <standard>
+    <![CDATA[
+    Use lowercase letters in action and filter names. Separate words using underscores.
+
+    This only applies to the actual hook name. The Yoast plugin specific prefix is disregarded.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: lowercase hook name.">
+        <![CDATA[
+do_action( <em>'Yoast\WP\Plugin\hook_name'</em>, $var );
+        ]]>
+        </code>
+        <code title="Invalid: mixed case hook name.">
+        <![CDATA[
+do_action( <em>'Yoast\WP\Plugin\Hook_NAME'</em>, $var );
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: words separated by underscores.">
+        <![CDATA[
+apply_filters(
+    <em>'Yoast\WP\Plugin\hook_name'</em>,
+    $var
+);
+        ]]>
+        </code>
+        <code title="Invalid: using non-underscore characters to separate words.">
+        <![CDATA[
+apply_filters(
+    <em>'Yoast\WP\Plugin\some/hook-name'</em>,
+    $var
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Hook names should consist of the plugin specific prefix in `Yoast\WP\Plugin`-style followed by the actual hook name consisting of a maximum of four words.
+
+    Note: the maximum (error) and the recommended (warning) maximum length are configurable.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: three word hook name.">
+        <![CDATA[
+do_action(
+    <em>'Yoast\WP\Plugin\hook_name'</em>
+);
+        ]]>
+        </code>
+        <code title="Invalid: five word hook name.">
+        <![CDATA[
+apply_filters(
+    <em>'Yoast\WP\Plugin\long_hook_name_too_long'</em>
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace YoastCS\Yoast\Sniffs\NamingConventions;
+
+use WordPressCS\WordPress\Sniffs\NamingConventions\ValidHookNameSniff as WPCS_ValidHookNameSniff;
+use YoastCS\Yoast\Utils\CustomPrefixesTrait;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Verify hook names.
+ *
+ * Per the WPCS native sniff:
+ * Use lowercase letters in action and filter names. Separate words via underscores.
+ *
+ * In contrast to the WPCS native sniff, this Yoast specific version of the sniff
+ * allows for a plugin specific prefix in ProperCase, like `Yoast\WP\Plugin\`, while
+ * still demanding lowercase and underscore separators for the rest of the hook name
+ * and for all hooks when no plugin specific prefixes have been passed.
+ *
+ * In addition to the WPCS native sniff:
+ * Check the number of words in hook names and the use of the correct prefix-type,
+ * but only when plugin specific prefixes have been passed.
+ *
+ * {@internal For now allows for an array of both old-style as well as new-style
+ *            prefixes during the transition period.
+ *            Once all plugins have been transitioned over to use the new-style
+ *            namespace-like prefix for hooks, the `WrongPrefix` warning should be
+ *            changed to an error and only namespace-like prefixes should be allowed.}
+ *
+ * @package Yoast\YoastCS
+ * @author  Juliette Reinders Folmer
+ *
+ * @since   2.0.0
+ */
+class ValidHookNameSniff extends WPCS_ValidHookNameSniff {
+
+	use CustomPrefixesTrait;
+
+	/**
+	 * Maximum number of words.
+	 *
+	 * The maximum number of words a hook name should consist of, each
+	 * separated by an underscore.
+	 *
+	 * If the name consists of more words, an ERROR will be thrown.
+	 *
+	 * @var int
+	 */
+	public $max_words = 4;
+
+	/**
+	 * Recommended maximum number of words.
+	 *
+	 * The recommended maximum number of words a hook name should consist of, each
+	 * separated by an underscore.
+	 *
+	 * If the name consists of more words, a WARNING will be thrown.
+	 *
+	 * @var int
+	 */
+	public $recommended_max_words = 4;
+
+	/**
+	 * Whether this is the first text string passed to the `transform()`
+	 * method, i.e. the text string which should have the prefix.
+	 *
+	 * @var bool
+	 */
+	private $remove_prefix = false;
+
+	/**
+	 * The prefix found (if any).
+	 *
+	 * @var string
+	 */
+	private $found_prefix = '';
+
+	/**
+	 * Keep track of the content of first text string which was passed to the `transform()`
+	 * method as it may be repeatedly called for the same token.
+	 *
+	 * @var bool
+	 */
+	private $first_string = '';
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		/*
+		 * The custom prefix should be in the first text passed to `transform()` for each
+		 * matched function call.
+		 *
+		 * Reset the properties which help manage this each time a new function call
+		 * is encountered.
+		 */
+		$this->remove_prefix = true;
+		$this->found_prefix  = '';
+		$this->first_string  = '';
+		$this->validate_prefixes();
+
+		/*
+		 * If any prefixes were passed, check if this is a hook belonging to the plugin being checked.
+		 */
+		if ( empty( $this->validated_prefixes ) === false ) {
+			$param           = $parameters[1];
+			$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param['start'], ( $param['end'] + 1 ), true );
+			$found_prefix    = '';
+
+			if ( isset( Tokens::$stringTokens[ $this->tokens[ $first_non_empty ]['code'] ] ) ) {
+				$content = trim( $this->strip_quotes( $this->tokens[ $first_non_empty ]['content'] ) );
+				foreach ( $this->validated_prefixes as $prefix ) {
+					if ( strpos( $content, $prefix ) === 0 ) {
+						$found_prefix = $prefix;
+						break;
+					}
+				}
+			}
+
+			if ( $found_prefix === '' ) {
+				/*
+				 * Not a hook name with a prefix indicating it belongs to the specific plugin
+				 * being checked. Ignore as it's probably a WP Core or external plugin hook name
+				 * which we cannot change.
+				 */
+				return;
+			}
+		}
+
+		// Do the WPCS native hook name check.
+		parent::process_parameters( $stackPtr, $group_name, $matched_content, $parameters );
+
+		if ( $this->found_prefix === '' ) {
+			return;
+		}
+
+		// Do the YoastCS specific hook name length and prefix check.
+		$this->verify_yoast_hook_name( $stackPtr, $parameters );
+	}
+
+	/**
+	 * Transform an arbitrary string to lowercase and replace punctuation and spaces with underscores.
+	 *
+	 * This overloads the parent to prevent errors being triggered on the Yoast specific
+	 * plugin prefix for hook names and remembers whether a prefix was found to allow
+	 * checking whether it was the correct one.
+	 *
+	 * @param string $string         The target string.
+	 * @param string $regex          The punctuation regular expression to use.
+	 * @param string $transform_type Whether to a partial or complete transform.
+	 *                               Valid values are: 'full', 'case', 'punctuation'.
+	 * @return string
+	 */
+	protected function transform( $string, $regex, $transform_type = 'full' ) {
+
+		if ( empty( $this->validated_prefixes ) ) {
+			$this->remove_prefix = false;
+			return parent::transform( $string, $regex, $transform_type );
+		}
+
+		// Not the first text string.
+		if ( $this->remove_prefix === false
+			&& $string !== $this->first_string
+		) {
+			return parent::transform( $string, $regex, $transform_type );
+		}
+
+		// Repeated call for the first text string.
+		if ( $this->remove_prefix === false
+			&& $string === $this->first_string
+		) {
+			if ( $this->found_prefix !== '' ) {
+				$string = substr( $string, strlen( $this->found_prefix ) );
+			}
+
+			return $this->found_prefix . parent::transform( $string, $regex, $transform_type );
+		}
+
+		// First call for first text string.
+		if ( $this->remove_prefix === true ) {
+			$this->first_string = $string;
+
+			foreach ( $this->validated_prefixes as $prefix ) {
+				if ( strpos( $string, $prefix ) === 0 ) {
+					$string             = substr( $string, strlen( $prefix ) );
+					$this->found_prefix = $prefix;
+
+					/*
+					 * Handle case where the prefix is the only content in a single quoted string,
+					 * which would necessitate an extra backslash to escape the end backslash.
+					 * I.e. 'Yoast\WP\Plugin\\'.
+					 */
+					if ( $string === '\\' ) {
+						$string              = '';
+						$this->found_prefix .= '\\';
+					}
+
+					break;
+				}
+			}
+
+			// Don't do this again until the next time the sniff gets triggered.
+			$this->remove_prefix = false;
+		}
+
+		return $this->found_prefix . parent::transform( $string, $regex, $transform_type );
+	}
+
+	/**
+	 * Additional YoastCS specific hook name checks.
+	 *
+	 * @param int   $stackPtr   The position of the current token in the stack.
+	 * @param array $parameters Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function verify_yoast_hook_name( $stackPtr, $parameters ) {
+
+		$param           = $parameters[1];
+		$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param['start'], ( $param['end'] + 1 ), true );
+
+		/*
+		 * Check that the namespace-like prefix is used for hooks.
+		 */
+		if ( strpos( $this->found_prefix, '\\' ) === false ) {
+			/*
+			 * Find which namespace-based prefix should have been used.
+			 * Loop till the end as the shortest prefix will be last.
+			 */
+			$namespace_prefix = '';
+			foreach ( $this->validated_prefixes as $prefix ) {
+				if ( strpos( $prefix, '\\' ) !== false ) {
+					$namespace_prefix = $prefix;
+				}
+			}
+
+			$this->phpcsFile->addWarning(
+				'Wrong prefix type used. Hook names should use the "%s" namespace-like prefix. Found prefix: %s',
+				$first_non_empty,
+				'WrongPrefix',
+				[
+					$namespace_prefix,
+					$this->found_prefix,
+				]
+			);
+		}
+
+		/*
+		 * Check if the hook name is a single quoted string.
+		 */
+		$allow  = [ \T_CONSTANT_ENCAPSED_STRING ];
+		$allow += Tokens::$emptyTokens;
+
+		$has_non_string = $this->phpcsFile->findNext( $allow, $param['start'], ( $param['end'] + 1 ), true );
+		if ( $has_non_string !== false ) {
+			/*
+			 * Double quoted string or a hook name concatenated together, checking the word count for the
+			 * hook name can not be done in a reliable manner.
+			 *
+			 * Throwing a warning to allow for examining these if desired.
+			 * Severity 3 makes sure that this warning will normally be invisible and will only
+			 * be thrown when PHPCS is explicitly requested to check with a lower severity.
+			 */
+			$this->phpcsFile->addWarning(
+				'Hook name could not reliably be examined for maximum word count. Please verify this hook name manually. Found: %s',
+				$first_non_empty,
+				'NonString',
+				[ $param['raw'] ],
+				3
+			);
+
+			return;
+		}
+
+		/*
+		 * Check the hook name depth.
+		 */
+		$hook_ptr  = $first_non_empty; // If no other tokens were found, the first non empty will be the hook name.
+		$hook_name = $this->strip_quotes( $this->tokens[ $hook_ptr ]['content'] );
+		$hook_name = substr( $hook_name, strlen( $this->found_prefix ) );
+
+		$parts      = explode( '_', $hook_name );
+		$part_count = count( $parts );
+
+		if ( $part_count <= $this->recommended_max_words && $part_count <= $this->max_words ) {
+			return;
+		}
+
+		if ( $part_count > $this->max_words ) {
+			$error = 'A hook name is not allowed to consist of more than %d words after the plugin prefix. Words found: %d in %s';
+			$data  = [
+				$this->max_words,
+				$part_count,
+				$this->tokens[ $hook_ptr ]['content'],
+			];
+
+			$this->phpcsFile->addError( $error, $hook_ptr, 'MaxExceeded', $data );
+		}
+		elseif ( $part_count > $this->recommended_max_words ) {
+			$error = 'A hook name should not consist of more than %d words after the plugin prefix. Words found: %d in %s';
+			$data  = [
+				$this->recommended_max_words,
+				$part_count,
+				$this->tokens[ $hook_ptr ]['content'],
+			];
+
+			$this->phpcsFile->addWarning( $error, $hook_ptr, 'TooLong', $data );
+		}
+	}
+}

--- a/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.inc
+++ b/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.inc
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * Verify that the original functionality of the upstream sniff is still working as expected.
+ * Functionality when no prefixes have been passed, should be unchanged.
+ */
+
+do_action( $Hook_name ); // OK.
+do_action( "admin_head" ); // OK.
+do_action( 'admin_head_' .  get_ID() . '_action' ); // OK.
+do_action( "admin_head_$Post" ); // OK.
+do_action( 'prefix_block_' . $block['blockname'] ); // OK.
+
+do_action( "adminHead" ); // Error - use lowercase.
+do_action( 'admin_Head_' . $Type . '_Action' ); // Error - use lowercase.
+do_action( "admin_head-$hook_suffix" ); // Warning - use underscore.
+apply_filters( 'adminHead', $variable ); // Error - use lowercase.
+do_action( "admin_Head_{$post->ID}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{$obj->Values[3]->name}-Action_{$obj->Values[3]->name}_Action" ); // Error - use lowercase + warning about dash.
+
+/*
+ * Verify the Yoast specific changes to allow for the plugin prefix, while still checking
+ * that the rest of the hook name is lowercase and underscore separated.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ValidHookName.WrongPrefix
+ */
+
+// phpcs:set Yoast.NamingConventions.ValidHookName prefixes[] Yoast\WP\Plugin,yoast_plugin
+
+apply_filters_ref_array( 'yoast_plugin_some_hook_name', $var ); // OK.
+apply_filters( 'Yoast\WP\Plugin\some_hook_name', $var ); // OK.
+
+do_action_ref_array( 'Yoast\WP\Plugin\some-hook\name', $var ); // Warning - disallowed word separators (after prefix).
+apply_filters( 'Yoast\WP\Plugin\some_HookName', $var ); // Error - uppercase chars (after prefix).
+apply_filters_ref_array( 'yoast_plugin_Some-Hook-Name', $var ); // Error + warning, uppercase chars + dashes (after prefix).
+
+// OK, ignored. Hooks do not start with correct prefix, while valid prefixes have been passed.
+do_action( 'Yoast\WP\AnotherPlugin\some_hook_name', $var );
+apply_filters( 'some_hook_name_yoast_plugin_Prefix_not-at_start', $var );
+
+// Second use of the prefix (correctly) not taken into account as not found at the start of the hook name.
+do_action( 'Yoast\WP\Plugin\hook_' . $type . 'Yoast\WP\Plugin\hook' ); // Error + warning x 2, prefix repeated, compound name.
+
+// Test handing of compound hook names with the prefix as stand-alone string.
+apply_filters( 'Yoast\WP\Plugin\\' . $type . '_' . $sub, $var ); // Warning at severity 3 compound name.
+
+// Test handling of escaped slash in double quotes string.
+$var = apply_filters( "Yoast\WP\Plugin\\{$obj->prop['type']}_details", $var ); // Warning at severity 3 compound name.
+
+// phpcs:enable
+
+/*
+ * Test Yoast specific sniff additions for checking hook name length and such.
+ *
+ * These checks are only in effect if a prefix is found.
+ * The WPCS PrefixAllGlobals sniff checks that a prefix is used, that's outside the scope of this sniff.
+ */
+
+/*
+ * Simple strings, no prefix. Includes testing handling of comments.
+ */
+do_action(
+	// phpcs:ignore Stnd.Cat.Sniff -- For reasons.
+	'some_hook_name_too_long' /* comment */
+); // OK. Plugin prefix not found, so ignored.
+
+/*
+ * Non simple strings.
+ */
+// phpcs:set Yoast.NamingConventions.ValidHookName prefixes[] Yoast\WP\Plugin,yoast_plugin
+
+do_action( "Yoast\WP\Plugin\some_{$variable}_hook_name"); // Warning at severity 3.
+do_action( 'yoast_plugin_some_' . 'hook_' . 'name' ); // Warning at severity 3 + warning wrong prefix.
+
+/*
+ * Test passing "unclean" prefixes property.
+ */
+// phpcs:set Yoast.NamingConventions.ValidHookName prefixes[] \Yoast\WP\Plugin\,_yoast_plugin_
+
+apply_filters( 'Yoast\WP\Plugin\some_hook_name', $var ); // OK.
+apply_filters_ref_array( 'yoast_plugin_some_hook_name', $var ); // Warning - wrong prefix.
+
+apply_filters( 'Yoast\WP\Plugin\some_hook_name_too_long', $var ); // Error - too long.
+do_action_ref_array( "yoast_plugin_some_hook_name_too_long", $var ); // Error - too long + warning - wrong prefix.
+
+/*
+ * Testing with clean prefixes.
+ *
+ * Passing both old-style and new-style prefixes during the transition period.
+ */
+// phpcs:set Yoast.NamingConventions.ValidHookName prefixes[] Yoast\WP\Plugin,Yoast\WP\Plugin\Test,yoast_plugin
+
+do_action( 'Yoast\WP\Plugin\Test\some_hook_name', $var ); // OK.
+do_action_ref_array( "yoast_plugin_some_hook_name", $var ); // Warning - wrong prefix.
+
+apply_filters( 'Yoast\WP\Plugin\some_hook_name_too_long', $var ); // Error - too long.
+do_action_ref_array( "yoast_plugin_some_hook_name_too_long", $var ); // Error - too long + warning - wrong prefix.
+
+/*
+ * Custom word maximums.
+ */
+// phpcs:set Yoast.NamingConventions.ValidHookName max_words 5
+// phpcs:set Yoast.NamingConventions.ValidHookName recommended_max_words 2
+
+apply_filters( 'Yoast\WP\Plugin\some_hook', $var ); // OK.
+
+do_action( 'Yoast\WP\Plugin\some_hook_name', $var ); // Warning - over recommended length.
+do_action_ref_array( 'Yoast\WP\Plugin\some_hook_name_which_is_too_long', $var ); // Error.
+
+do_action( 'yoast_plugin_some_hook_name', $var ); // Warning x 2 - over recommended length + wrong prefix.
+do_action_ref_array( 'yoast_plugin_some_hook_name_which_is_too_long', $var ); // Error - length + warning - wrong prefix..
+
+/*
+ * Incorrect custom settings (soft > max).
+ */
+// phpcs:set Yoast.NamingConventions.ValidHookName max_words 2
+// phpcs:set Yoast.NamingConventions.ValidHookName recommended_max_words 5
+
+do_action( 'Yoast\WP\Plugin\some_hook_name', $var ); // Error.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.ValidHookName prefixes[]
+// phpcs:set Yoast.NamingConventions.ValidHookName max_words 4
+// phpcs:set Yoast.NamingConventions.ValidHookName recommended_max_words 4

--- a/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace YoastCS\Yoast\Tests\NamingConventions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the ValidHookName sniff.
+ *
+ * @package Yoast\YoastCS
+ *
+ * @since   2.0.0
+ *
+ * @covers  YoastCS\Yoast\Sniffs\NamingConventions\ValidHookNameSniff
+ * @covers  YoastCS\Yoast\Utils\CustomPrefixesTrait
+ */
+class ValidHookNameUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Set warnings level to 3 to trigger suggestions as warnings.
+	 *
+	 * @param string                  $filename The name of the file being tested.
+	 * @param \PHP_CodeSniffer\Config $config   The config data for the run.
+	 *
+	 * @return void
+	 */
+	public function setCliValues( $filename, $config ) {
+		$config->warningSeverity = 3;
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+
+		return [
+			14  => 1,
+			15  => 1,
+			17  => 1,
+			18  => 1,
+			19  => 1,
+			34  => 1,
+			35  => 1,
+			42  => 1,
+			83  => 1,
+			84  => 1,
+			96  => 1,
+			97  => 1,
+			108 => 1,
+			111 => 1,
+			119 => 1,
+		];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [
+			16  => 1,
+			19  => 1,
+			33  => 1,
+			35  => 1,
+			42  => 2,
+			45  => 1, // Severity: 3.
+			48  => 1, // Severity: 3.
+			72  => 1, // Severity: 3.
+			73  => 2, // Severity: 3 + 5.
+			81  => 1,
+			84  => 1,
+			94  => 1,
+			97  => 1,
+			107 => 1,
+			110 => 2,
+			111 => 1,
+		];
+	}
+}
+

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -45,6 +45,9 @@
 		<!-- Excluded in favour of the YoastCS native Filename sniff. -->
 		<exclude name="WordPress.Files.FileName"/>
 
+		<!-- Excluded in favour of the YoastCS ValidHookName sniff which extends the WPCS version. -->
+		<exclude name="WordPress.NamingConventions.ValidHookName"/>
+
 		<!-- Excluded in favour of the YoastCS native FileComment sniff (which extends this sniff). -->
 		<exclude name="Squiz.Commenting.FileComment"/>
 		<!-- As the Yoast sniff extends the upstream sniff, we need to exclude the same error codes


### PR DESCRIPTION
This new sniff extends the upstream WPCS `ValidHookName` sniff and overloads the `transform()` method to allow for the new Yoast specific hook prefix requirements as per issue #143.

Hooks in the Yoast plugins should still comply with the "_hook names should be lowercase with words separated by underscores_" rule, but the `Yoast\WP\PluginName` prefix should be exempt.

The overload of the `transform()` method prevents the upstream sniff from throwing errors for the prefix, while still allowing it to throw errors for the actual hook name.

Also, and in contrast to the WPCS native sniff, when the YoastCS version of this sniff has received valid prefix(es), the hook name checks will only be executed for hooks which have a valid prefix.
Non-prefixed hooks or hooks with another prefix will be ignored to prevent errors being thrown about hook names which are outside of our control.

The sniff uses the `CustomPrefixesTrait` to allow setting the `public` `$prefixes` property and to validate the input received for this property.

In addition to this, the new/extended sniff adds a couple of new checks:
- A check that the "namespace"-style prefix is used.
    The sniff allows for passing both "namespace"-like, as well as "old-style" prefixes to allow for a transition period.
    However, if an "old-style" prefix is used, rather than the "namespace"-like prefix, a `warning` will be thrown.
- A check to verify that hook names contain no more than four words / three underscores, after the plugin specific prefix.
    - The sniff will throw a `warning` when the name consists of more words than `soft_maximum_depth` and an `error` when the name is longer than `maximum_depth`.
    - Both `soft_maximum_depth`, as well as `maximum_depth` are configurable and can be changed from a custom ruleset.
        By default, `soft_maximum_depth` and `maximum_depth` are set to the same value: `4`, i.e. four words.

Note:
For dynamic hook names where the hook name length can not reliably be determined, the sniff will throw a `warning` at severity `3` suggesting the hook name be inspected manually.

As the default severity for PHPCS is `5`, this `warning` at severity `3` will normally not be shown. It is there to allow for intermittently checking of the dynamic hook names. To trigger it, `--severity=3` should be passed on the command line.

Also note:
Just like the lowercase/underscore hook name checks, the hook name length check will only be executed when the hook name starts with (one of) the plugin specific prefix.

Includes unit tests.
Includes documentation.

Fixes #143


----

This PR includes adding a `CustomPrefixes` trait.

This trait can be used by sniffs which need access to the custom plugin prefixes.

The trait contains the `public` property to allow for setting the `$prefixes` from within a custom ruleset, as well as a couple of utility methods to validate and clean the received `$prefixes` so they are usable by the sniffs.

The trait is tested via the sniffs using it.

Both this sniff as well as the upcoming `NamespaceName` sniff will use this trait.


