### PR TITLE
Travis: don't allow builds against PHP 7.4 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,10 +78,6 @@ matrix:
     - php: 5.4
       env: PHPCS_BRANCH="3.3.1" WPCS="dev-develop"
 
-  allow_failures:
-    # Allow failures for unstable builds.
-    - php: "7.4snapshot"
-
 before_install:
     # Speed up build time by disabling Xdebug.
     # https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/


### PR DESCRIPTION
While PHPCS itself is only fully compatible with PHP 7.4 as of PHPCS 3.5.0, the issues in PHPCS don't affect the YoastCS code, so YoastCS builds against PHP 7.4 should not be allowed to fail anymore now PHP 7.4 is about to come out.