### PR TITLE
Composer: update PHPCompatibilityWP requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.4.2",
 		"wp-coding-standards/wpcs": "^2.2.0",
-		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
+		"phpcompatibility/phpcompatibility-wp": "^2.1.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
The PHPCompatibilityWP 2.1.0 release contains an updated ruleset to account for changes in WP 5.2, which will be the new minimum supported WP version for the Yoast plugins.

Ref: https://github.com/PHPCompatibility/PHPCompatibilityWP#210---2019-08-29