### PR TITLE
Composer: update minimum PHPCS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ env:
   # Test against the highest/lowest supported PHPCS and WPCS versions.
   - PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
   - PHPCS_BRANCH="dev-master" WPCS="2.2.0"
-  - PHPCS_BRANCH="3.4.2" WPCS="dev-develop"
-  - PHPCS_BRANCH="3.4.2" WPCS="2.2.0"
+  - PHPCS_BRANCH="3.5.0" WPCS="dev-develop"
+  - PHPCS_BRANCH="3.5.0" WPCS="2.2.0"
 
 # Define the stages used.
 # For non-PRs, only the sniff, ruleset and quicktest stages are run.
@@ -70,11 +70,11 @@ matrix:
       php: 7.3
       env: PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
     - php: 7.3
-      env: PHPCS_BRANCH="3.3.1" WPCS="2.2.0"
+      env: PHPCS_BRANCH="3.5.0" WPCS="2.2.0"
     - php: 5.4
       env: PHPCS_BRANCH="dev-master" WPCS="2.2.0" PHPLINT=1
     - php: 5.4
-      env: PHPCS_BRANCH="3.3.1" WPCS="dev-develop"
+      env: PHPCS_BRANCH="3.5.0" WPCS="dev-develop"
 
 before_install:
     # Speed up build time by disabling Xdebug.

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	},
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.4.2",
+		"squizlabs/php_codesniffer": "^3.5.0",
 		"wp-coding-standards/wpcs": "^2.2.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"


### PR DESCRIPTION
PHP_CodeSniffer has released version `3.5.2` in the mean time.

The `3.5.0` release contained a lot of new sniffs, mostly related to PSR12 and a number of which we may want to use for YoastCS.

Sniff additions to the ruleset will be pulled separately.
Updating the minimum supported PHPCS version will allow for that.

Note, this also makes the option `--filter=gitstaged` available which can be used in git pre-commit hooks to only check staged files.


Refs:
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.5.0
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.5.1
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.5.2