### PR TITLE
ObjectNameDepth: allow for extra word for test/double/mock classes

### DIFF
--- a/Yoast/Docs/NamingConventions/ObjectNameDepthStandard.xml
+++ b/Yoast/Docs/NamingConventions/ObjectNameDepthStandard.xml
@@ -4,6 +4,8 @@
     <![CDATA[
     The name of objects - classes, interfaces, traits - declared within a namespace should consist of a maximum of three words.
 
+    A partial exception is made for test, mock and double classes. These can have a `_Test`, `_Mock` or `_Double` class name suffix, which won't be counted.
+
     Note: the maximum (error) and the recommended (warning) maximum length are configurable.
     ]]>
     </standard>
@@ -34,6 +36,28 @@ class <em>Short_Class_Name</em> {}
 namespace Yoast\WP\Plugin;
 
 class <em>Namespaced_Too_Long_Class_Name</em> {}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: test class in a namespaced file.">
+        <![CDATA[
+namespace Yoast\WP\Plugin\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class <em>Short_Class_Name_Test</em>
+    extends TestCase {}
+        ]]>
+        </code>
+        <code title="Invalid: long test class name in a namespaced file.">
+        <![CDATA[
+namespace Yoast\WP\Plugin\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class <em>Namespaced_Too_Long_Class_Name_Test</em>
+    extends TestCase {}
         ]]>
         </code>
     </code_comparison>

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
@@ -63,3 +63,20 @@ class Active_Class_With_Too_Long_Class_Name {} // Error.
  * @deprecated x.x.x
  */
 class Deprecated_Class_With_Too_Long_Class_Name {} // OK.
+
+/*
+ * Allow for a `_Test` suffix in classes within the unit test suite.
+ */
+class Three_Word_Name_Test {} // Error.
+
+class Three_Word_Name_Test extends TestCase {} // OK.
+class Three_Word_Name_Test extends WP_UnitTestCase {} // OK.
+
+class Four_Word_Long_Name_Test extends TestCase {} // Error.
+
+// Similarly for Double/Mock classes.
+class Three_Word_Name_Double {} // Error.
+class Three_Word_Name_Mock {} // Error.
+
+class Three_Word_Name_Double extends Three_Word_Name {} // OK.
+class Three_Word_Name_Mock extends Some_Class {} // OK.

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
@@ -9,7 +9,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @package Yoast\YoastCS
  *
- * @since   1.4.0
+ * @since   2.0.0
  *
  * @covers  YoastCS\Yoast\Sniffs\NamingConventions\ObjectNameDepthSniff
  */
@@ -34,6 +34,10 @@ class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
 					42 => 1,
 					43 => 1,
 					58 => 1,
+					70 => 1,
+					75 => 1,
+					78 => 1,
+					79 => 1,
 				];
 
 			default:


### PR DESCRIPTION
## Description

As discussed in the #yoastcs Slack channel.

The new `ObjectNameDepth` sniff has a hard limit of "3 words".

Unit test classes often reflect the name of the class being tested + `_Test`.
Example:
Class `Post_Data_Service` would be tested in a test class called `Post_Data_Service_Test`.

Along the same vein, mock/double classes often reflect the name of the original class with a `_Mock` or `_Double` suffix.

That meant that for plugins with unit tests which adhere to that practice, the word limit effectively was 2 instead of 3 as otherwise they'd run into problems with the naming of the unit test classes.

This PR adjusts the sniff to take unit tests and test doubles/mocks into account.

For classes with a `_Mock` or `_Double` suffix, the sniff checks that this is an `extend`ed class and if so, will disregard the suffix when determining the word length of the class name.

For classes with a `_Test` suffix, the sniff will check that the class extends a known unit test class and if so, will disregard the suffix when determining the word length of the class name.

Includes unit tests.
Includes updated documentation.

Also:
* Updated the version nrs for the sniff to be in line with the release in which this new sniff will be contained.




## Test instructions

This PR can be tested by following these steps:

* Take the unit test case file from this PR and run the following command against it using the `develop` branch:
    ```bash
    phpcs ./ObjectNameDepthUnitTest.2.inc --standard=Yoast --sniffs=Yoast.NamingConventions.ObjectNameDepth
    ```
* The sniff will throw errors on line 72, 73, 81 and 82.
* Now run the same command using this branch and confirm that those errors are no longer being thrown.

For more extensive testing: come up with some additional test cases, add those to the test case file and verify that the sniff behaves like you'd expect based on the above specs.


* To check the updated docs, run:
    ```bash
    phpcs --standard=Yoast --generator=Text --sniffs=Yoast.NamingConventions.ObjectNameDepth
    ```
    


## Sniff feature completeness

* [x] **Documentation**: I have added/updated the sniff `Standard.xml` documentation to match this change.
    * [ ] Not applicable.
* [ ] **Functionality**: This change adds auto-fixer(s).
    * [x] Not applicable.
* [x] **Unit tests**: I have added unit tests to verify the code works as intended.
* [x] **End-to-end tests**: I have run the new/updated sniff against one or more of the Yoast plugin repositories to find false positives/negatives.
