### PR TITLE
Composer: require WPCS ^2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ php:
 env:
   # Test against the highest/lowest supported PHPCS and WPCS versions.
   - PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
-  - PHPCS_BRANCH="dev-master" WPCS="2.1.1"
+  - PHPCS_BRANCH="dev-master" WPCS="2.2.0"
   - PHPCS_BRANCH="3.4.2" WPCS="dev-develop"
-  - PHPCS_BRANCH="3.4.2" WPCS="2.1.1"
+  - PHPCS_BRANCH="3.4.2" WPCS="2.2.0"
 
 # Define the stages used.
 # For non-PRs, only the sniff, ruleset and quicktest stages are run.
@@ -71,9 +71,9 @@ matrix:
       php: 7.3
       env: PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
     - php: 7.3
-      env: PHPCS_BRANCH="3.3.1" WPCS="2.1.1"
+      env: PHPCS_BRANCH="3.3.1" WPCS="2.2.0"
     - php: 5.4
-      env: PHPCS_BRANCH="dev-master" WPCS="2.1.1" PHPLINT=1
+      env: PHPCS_BRANCH="dev-master" WPCS="2.2.0" PHPLINT=1
     - php: 5.4
       env: PHPCS_BRANCH="3.3.1" WPCS="dev-develop"
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	"require": {
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.4.2",
-		"wp-coding-standards/wpcs": "^2.1.1",
+		"wp-coding-standards/wpcs": "^2.2.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
 	},


### PR DESCRIPTION
WPCS 2.2.0 has been released and includes a few fixes relevant to the Yoast repos.

Most notable:
* The `sanitize_key()` and the `highlight_string()` functions have been added to the `escapingFunctions` list used by the `WordPress.Security.EscapeOutput` sniff.
* The `WordPress.NamingConventions.ValidFunctionName` and the `WordPress.NamingConventions.PrefixAllGlobals` sniff will now ignore functions marked as `@deprecated`.
* Both the `WordPress.NamingConventions.PrefixAllGlobals` sniff as well as the `WordPress.WP.GlobalVariablesOverride` sniff will now take a limited list of WP global variables _which are intended to be overwritten by plugins/themes_ into account.
* `WordPress.NamingConventions.ValidHookName`: will no longer examine a string array access index key as it it were part of the hook name.

Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/2.2.0