### PR TITLE
Ruleset: fix links to WPCS repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,7 +285,7 @@ Initial public release as a stand-alone package.
 
 
 [PHP_CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer/releases
-[WordPressCS]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/CHANGELOG.md
+[WordPressCS]: https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/CHANGELOG.md
 [PHPCompatibilityWP]: https://github.com/PHPCompatibility/PHPCompatibilityWP#changelog
 [PHPCompatibility]: https://github.com/PHPCompatibility/PHPCompatibility/blob/master/CHANGELOG.md
 [PHP Mess Detector]: https://github.com/phpmd/phpmd/blob/master/CHANGELOG

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Severity levels:
 ### The YoastCS Standard
 
 The `Yoast` standard for PHP_CodeSniffer is comprised of the following:
-* The `WordPress` ruleset from the [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) implementing the official [WordPress PHP Coding Standards](https://make.wordpress.org/core/handbook/coding-standards/php/), with some [select exclusions](https://github.com/Yoast/yoastcs/blob/develop/Yoast/ruleset.xml#L29-L75).
+* The `WordPress` ruleset from the [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards) implementing the official [WordPress PHP Coding Standards](https://make.wordpress.org/core/handbook/coding-standards/php/), with some [select exclusions](https://github.com/Yoast/yoastcs/blob/develop/Yoast/ruleset.xml#L29-L75).
 * The [`PHPCompatibilityWP`](https://github.com/PHPCompatibility/PHPCompatibilityWP) ruleset which checks code for PHP cross-version compatibility while preventing false positives for functionality polyfilled within WordPress.
 * Select additional sniffs taken from [`PHP_CodeSniffer`](https://github.com/squizlabs/PHP_CodeSniffer).
 * A number of custom Yoast specific sniffs.

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -28,7 +28,7 @@
 	-->
 	<rule ref="WordPress">
 		<!-- Set the minimum supported WP version for all sniff which use it in one go.
-			 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
+			 Ref: https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
 		-->
 		<properties>
 			<property name="minimum_supported_version" value="5.2"/>
@@ -145,18 +145,18 @@
 	<rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
 
 	<!-- Error prevention: Ensure no git conflicts make it into the code base. -->
-	<!-- PHPCS 3.4.0: This sniff will be added to WPCS 2.x in due time and can then be removed from this ruleset.
-		 Related: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1500 -->
+	<!-- PHPCS 3.4.0: This sniff will be added to WPCS in due time and can then be removed from this ruleset.
+		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1500 -->
 	<rule ref="Generic.VersionControl.GitMergeConflict"/>
 
 	<!-- CS: no space between an increment/decrement operator and the variable it applies to. -->
-	<!-- PHPCS 3.4.0: This sniff will be added to WPCS 2.x in due time and can then be removed from this ruleset.
-		 Related: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1511 -->
+	<!-- PHPCS 3.4.0: This sniff will be added to WPCS in due time and can then be removed from this ruleset.
+		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1511 -->
 	<rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
 
 	<!-- QA: Function declarations should not contain parameters which will never be used. -->
-	<!-- PHPCS 3.4.0: This sniff will be added to WPCS 2.x in due time and can then be removed from this ruleset.
-		 Related: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1510 -->
+	<!-- PHPCS 3.4.0: This sniff will be added to WPCS in due time and can then be removed from this ruleset.
+		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1510 -->
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.Found"/>
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed"/>
 


### PR DESCRIPTION
The WPCS repo has moved to the WordPress organization, so the canonical address for the repo has changed.