### PR TITLE
Ruleset: disallow "// end" comments

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -144,6 +144,9 @@
 	<!-- CS: ensure exactly one blank line before each property declaration. -->
 	<rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
 
+	<!-- CS: don't allow "// end class" comments and the likes. -->
+	<rule ref="PSR12.Classes.ClosingBrace"/>
+
 	<!-- Error prevention: Ensure no git conflicts make it into the code base. -->
 	<!-- PHPCS 3.4.0: This sniff will be added to WPCS 2.x in due time and can then be removed from this ruleset.
 		 Related: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1500 -->


### PR DESCRIPTION
## Proposal / Rule addition

In the olden days, before there were good IDEs, it was often customary to have `// End class`/`// End function` etc comments on the line of a class/function/control structure closing brace to make its easier to find the end of such a structure.

As modern IDEs are perfectly capable of handling this and handle this well, those type of comments are no longer necessary and can be considered unnecessary "noise".

The sniff which is proposed to be added via this PR enforces that closing braces of classes/interfaces/traits/functions are not followed by a comment or statement, in line with PSR-12.

### Impact: Low

There are some repos which have some stray end comments, but all together not that many.