### PR TITLE
Ruleset: check spacing around spread operator

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -160,6 +160,11 @@
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.Found"/>
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed"/>
 
+	<!-- CS: Ensure consistent whitespace around spread operators. -->
+	<!-- PHPCS 3.5.0: This sniff will be added to WPCS in due time and can then be removed from this ruleset.
+		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1762 -->
+	<rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter"/>
+
 	<!-- ##### Documentation Sniffs vs empty index files ##### -->
 
 	<!-- Exclude the 'empty' index files from some documentation checks -->


### PR DESCRIPTION
## Proposal / Rule addition

PHPCS 3.5.0 includes a new sniff to check that the spacing between the spread operator and the variable/function call it applies to is consistent.

The default behaviour of this sniff is to not allow whitespace between the spread operator and next token.

It is expected that this sniff will eventually be added to WPCS as well.

Refs:
* squizlabs/PHP_CodeSniffer#2548
* WordPress/WordPress-Coding-Standards#1762

### Impact: None

At this moment this would not cause any errors to be thrown, but will prevent inconsistency creeping in in the future.