### PR TITLE
Ruleset: disallow Yoda conditions

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -114,6 +114,9 @@
 	<!-- In contrast to WPCS: demand short arrays. -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
+	<!-- In contrast to WPCS: disallow Yoda conditions. (PHPCS 3.5.0) -->
+	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
+
 
 	<!--
 	#############################################################################


### PR DESCRIPTION
## Proposal / Rule addition

As proposed in #166 and possible now the minimum PHPCS version is 3.5.0, this adds a sniff to disallow Yoda conditions to YoastCS.

Yoda conditions are enforced by WPCS, but this rule has been turned off in YoastCS from the very beginning, however, non-Yoda conditions were not enforced up to now, leading to inconsistency.

Prior to PHPCS 3.5.2 this sniff was still quite buggy, but it looks like most bugs have been addressed in the mean time.

Fixes #166

### Impact: Medium

While the fast majority of conditions in the Yoast plugins do not use Yoda, some have creeped in over time.

Adding this sniff would cause the following number of new errors to be thrown which would need to be fixed:
* I18n: 2
* WHIP: 0
* Search Index Purge: 0
* WooCommerce: 4
* AMP: 11
* ACF: 3
* Clicky: 4
* Premium: 32
* Comment Hacks: 12
* News: 5
* Video: 25
* Local: 149
* Free: 167

Not surprisingly, the biggest are Free and Local.

A tab can be added to the Google Docs spreadsheet with the issues in Free to be fixed whenever there is some time.