### PR TITLE
Ruleset: enforce consistent indentation of chained method calls

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -150,6 +150,13 @@
 	<!-- CS: don't allow "// end class" comments and the likes. -->
 	<rule ref="PSR12.Classes.ClosingBrace"/>
 
+	<!-- CS: enforce consistent indentation of chained object method calls. -->
+	<rule ref="PEAR.WhiteSpace.ObjectOperatorIndent">
+		<properties>
+			<property name="multilevel" value="true"/>
+		</properties>
+	</rule>
+
 	<!-- Error prevention: Ensure no git conflicts make it into the code base. -->
 	<!-- PHPCS 3.4.0: This sniff will be added to WPCS in due time and can then be removed from this ruleset.
 		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1500 -->


### PR DESCRIPTION
## Proposal / Rule addition

When object method calls are chained over multiple lines, indentation should always be one more or less than the previous and always at least one in from the start of the chain.

This addition enforces that.

Example of correct chain indentation:
```php
$obj->method()
    ->foo()
        ->bar()
    ->select();
```

Example of incorrect chain indentation
```php
$obj->method()
    ->foo()
                    ->bar()
        ->select();
```

### Impact: Low

There are some repos which have some chained method calls which don't comply, but all together not that many.