### PR TITLE
Ruleset: disallow leading backslashes for import use statements

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -171,6 +171,10 @@
 		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1762 -->
 	<rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter"/>
 
+	<!-- CS: Disallow a leading backslash at the start of an import use statement. -->
+	<!-- PHPCS 3.5.0: This sniff may be added to WPCS in due time and can then be removed from this ruleset. -->
+	<rule ref="PSR12.Files.ImportStatement"/>
+
 	<!-- ##### Documentation Sniffs vs empty index files ##### -->
 
 	<!-- Exclude the 'empty' index files from some documentation checks -->


### PR DESCRIPTION
## Proposal / Rule addition

An import `use` statement must always be fully qualified, so a leading backslash is redundant and discouraged by PHP itself.

This sniff addition enforces this and is expected to go into WPCS at some point in the future.

Correct:
```php
namespace A\B;

use B\C;
```

Incorrect:
```php
namespace A\B;

use \B\C;
```

### Impact: None

At this moment this would not cause any errors to be thrown as any previously introduced issues have already been fixed (and there have been numerous), but the sniff will prevent new issues being introduced in the future.