### PR TITLE
Ruleset: enforce PHP open tag on a line by itself

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -175,6 +175,10 @@
 	<!-- PHPCS 3.5.0: This sniff may be added to WPCS in due time and can then be removed from this ruleset. -->
 	<rule ref="PSR12.Files.ImportStatement"/>
 
+	<!-- CS: Enforces that a PHP open tag is on a line by itself when used at the start of a PHP-only file. -->
+	<!-- PHPCS 3.5.0: This sniff may be added to WPCS in due time and can then be removed from this ruleset. -->
+	<rule ref="PSR12.Files.OpenTag"/>
+
 	<!-- ##### Documentation Sniffs vs empty index files ##### -->
 
 	<!-- Exclude the 'empty' index files from some documentation checks -->


### PR DESCRIPTION
## Proposal / Rule addition

Enforce PHP open tag on a line by itself in PHP-only files.

This is partially enforced already, this just safeguards it for the edge cases which weren't enforced yet.

### Impact: None

At this moment this would not cause any errors to be thrown, but the sniff will prevent new issues being introduced in the future.