### PR TITLE
ValidHookName: minor tweak to tests

### DIFF
--- a/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.inc
+++ b/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.inc
@@ -9,7 +9,7 @@ do_action( $Hook_name ); // OK.
 do_action( "admin_head" ); // OK.
 do_action( 'admin_head_' .  get_ID() . '_action' ); // OK.
 do_action( "admin_head_$Post" ); // OK.
-do_action( 'prefix_block_' . $block['blockname'] ); // OK.
+do_action( 'prefix_block_' . $block['block-Name'] ); // OK.
 
 do_action( "adminHead" ); // Error - use lowercase.
 do_action( 'admin_Head_' . $Type . '_Action' ); // Error - use lowercase.


### PR DESCRIPTION
This minor tweak couldn't be pulled in the ValidHookName sniff PR as at that time, YoastCS still supported WPCS < 2.2.0.

WPCS 2.2.0 contains a bug fix to ignore string array keys which are part of a hook name.

By adjusting this unit test, we safeguard that the YoastCS version of the sniff doesn't undo that fix.

Ref: https://github.com/WordPress/WordPress-Coding-Standards/pull/1712