### PR TITLE
NamingConventions/NamespaceName: minor stability fix

### DIFF
--- a/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
@@ -132,7 +132,7 @@ class NamespaceNameSniff implements Sniff {
 
 		// Get the complete namespace name.
 		$namespace_name = $tokens[ $next_non_empty ]['content'];
-		for ( $i = ( $next_non_empty + 1 ); ; $i++ ) {
+		for ( $i = ( $next_non_empty + 1 ); $i < $phpcsFile->numTokens; $i++ ) {
 			if ( isset( Tokens::$emptyTokens[ $tokens[ $i ]['code'] ] ) ) {
 				continue;
 			}
@@ -143,6 +143,11 @@ class NamespaceNameSniff implements Sniff {
 			}
 
 			$namespace_name .= $tokens[ $i ]['content'];
+		}
+
+		if ( $i === $phpcsFile->numTokens ) {
+			// Live coding.
+			return;
 		}
 
 		$this->validate_prefixes();

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/live-coding.inc
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/live-coding.inc
@@ -1,0 +1,7 @@
+<?php
+
+/*
+ * Test sniff behaviour during live coding.
+ */
+
+namespace Foo


### PR DESCRIPTION
Prevent potential _"Undefined index"_ notices during live coding.

Includes unit test.


### Test instructions

* While on `develop`, save the unit test file being added by this PR.
* Run `phpcs ./yoast/tests/namingconventions/namespacenameunittests/live-coding.inc --standard=yoast --sniffs=yoast.namingconventions.namespacename` and take note of the error being thrown:
    ```
     1 | ERROR | An error occurred during processing; checking has been aborted. The error message was: Undefined offset: 11 in FILE on line 136
    ```
* Check out this branch and run the same command again and see the run finish without errors.