### PR TITLE
PHPCS: enhance the YoastCS project ruleset 

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -5,6 +5,13 @@
 
 	<description>The Coding standard for the YoastCS Coding Standard itself.</description>
 
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
+	-->
+
 	<!-- Scan all files. -->
 	<file>.</file>
 
@@ -13,6 +20,19 @@
 
 	<!-- Show progress, show the error codes for each message (source). -->
 	<arg value="sp"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+
+	<!--
+	#############################################################################
+	USE THE YoastCS RULESET
+	#############################################################################
+	-->
 
 	<!-- YoastCS supports PHP 5.4 or higher. -->
 	<config name="testVersion" value="5.4-"/>
@@ -32,11 +52,19 @@
 	<!-- Enforce PSR1 compatible namespaces. -->
 	<rule ref="PSR1.Classes.ClassDeclaration"/>
 
+
+	<!--
+	#############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	#############################################################################
+	-->
+
 	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
 			<property name="prefixes" type="array">
 				<element value="YoastCS\Yoast"/>
 			</property>
+			<property name="src_directory" value="Yoast"/>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
* Add `basepath` and `parallel` CLI arguments to the ruleset.
* Add the same delimiters as used by other project specific rulesets.
* Add `src_directory` for the namespace name sniff as it will kick in now the `basepath` is declared.