### PR TITLE
Travis/QA: always check that all sniffs are feature complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,9 @@ matrix:
         # Check the code-style consistency of the xml files.
         - diff -B --tabsize=4 ./Yoast/ruleset.xml <(xmllint --format "./Yoast/ruleset.xml")
 
+        # Check that the sniffs available are feature complete.
+        - composer check-complete
+
     #### QUICK TEST STAGE ####
     # This is a much quicker test which only runs the unit tests and linting against low/high
     # supported PHP/PHPCS/WPCS combinations.

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
 		"roave/security-advisories": "dev-master",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
 		"jakub-onderka/php-parallel-lint": "^1.0",
-		"jakub-onderka/php-console-highlighter": "^0.4"
+		"jakub-onderka/php-console-highlighter": "^0.4",
+		"phpcsstandards/phpcsdevtools": "^1.0"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
@@ -53,6 +54,9 @@
 		],
 		"test": [
 			"@php ./vendor/phpunit/phpunit/phpunit --filter Yoast --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+		],
+		"check-complete": [
+			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./Yoast"
 		]
 	}
 }


### PR DESCRIPTION
The new `phpcsstandards/phpcsdevtools` package includes a script which can check whether sniffs are feature complete, i.e. whether all sniffs have unit tests and documentation.

By adding this check to the Travis script, we prevent untested and/or undocumented sniffs from entering the repo.

Ref: https://github.com/PHPCSStandards/PHPCSDevTools#checking-whether-all-sniffs-in-a-phpcs-standard-are-feature-complete

P.S.: the `PHPCSDevTools` package contains a few more goodies, have a look at the [readme](https://github.com/PHPCSStandards/PHPCSDevTools) for more information.