### PR TITLE
Travis: fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ before_install:
     # On stable PHPCS versions, allow for PHP deprecation notices.
     # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
     - |
-      if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" && $PHPCS_BRANCH != "dev-master" && $WPCS != "dev-develop" ]]; then
+      if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" && $PHPCS_BRANCH != "dev-master" && $WPCS != "dev-develop" ]]; then
         echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
       fi
 
@@ -100,7 +100,7 @@ before_install:
     # Set the WPCS version to test against.
     - composer require wp-coding-standards/wpcs:${WPCS} --no-update --no-suggest --no-scripts
     - |
-      if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" ]]; then
+      if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" ]]; then
           # For testing the YoastCS native sniffs, the rest of the packages aren't needed.
           composer remove phpcompatibility/phpcompatibility-wp phpcompatibility/php-compatibility --no-update
       fi


### PR DESCRIPTION
The Travis docs say that `$TRAVIS_BUILD_STAGE_NAME` is in "proper case" form:

> TRAVIS_BUILD_STAGE_NAME: The build stage in capitalized form, e.g. Test or Deploy. If a build does not use build stages, this variable is empty ("").

However, it looks like they made an (undocumented) change (probably a bug in their script handling) which means that the `$TRAVIS_BUILD_STAGE_NAME` name is now in the case as given, which in this case is _lowercase_.

This means that some of the comparisons are failing and the wrong things are executed for certain builds.

As I expect this to be a bug in Travis, I'm not changing the case for the comparisons at this time.
Instead I'm fixing this by inline fixing the case of the variable for the comparisons.

Refs:
* https://docs.travis-ci.com/user/environment-variables#default-environment-variables (near the bottom of the list)