### PR TITLE
Composer: use different version of PHP Parallel Lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
 		"phpcompatibility/php-compatibility": "^9.2.0",
 		"roave/security-advisories": "dev-master",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"jakub-onderka/php-parallel-lint": "^1.0",
-		"jakub-onderka/php-console-highlighter": "^0.4",
+		"php-parallel-lint/php-parallel-lint": "^1.0",
+		"php-parallel-lint/php-console-highlighter": "^0.4",
 		"phpcsstandards/phpcsdevtools": "^1.0"
 	},
 	"minimum-stability": "dev",
@@ -44,7 +44,7 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
 		],
 		"lint": [
-			"@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor"
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor"
 		],
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.4-"


### PR DESCRIPTION
The `jakub-onderka/php-parallel-lint` package has been abandoned and the `php-parallel-lint/php-parallel-lint` is now the "official" canonical fork which has taken over.

Refs:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint