### PR TITLE
NamespaceName: add metrics for level depth

### DIFF
--- a/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
@@ -182,6 +182,8 @@ class NamespaceNameSniff implements Sniff {
 			$parts      = \explode( '\\', $namespace_for_level_check );
 			$part_count = \count( $parts );
 
+			$phpcsFile->recordMetric( $stackPtr, 'Nr of levels in namespace name', $part_count );
+
 			if ( $part_count > $this->max_levels ) {
 				$error = 'A namespace name is not allowed to be more than %d levels deep (excluding the prefix). Level depth found: %d in %s';
 				$data  = [


### PR DESCRIPTION
Metrics are a way to get statistics about a code base and can inform the values to use in the custom properties.

The metrics can be seen by running PHPCS with the `--report=info` option.

Example output for Yoast SEO Free:
```
PHP CODE SNIFFER INFORMATION REPORT
----------------------------------------------------------------------
Nr of levels in namespace name:
        2     =>  238 ( 52.89%)
        1     =>  212 ( 47.11%)
        ------------------------
        total =>  450 (100.00%)
```