### PR TITLE
ObjectNameDepth: add metrics for word count

### DIFF
--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -105,6 +105,7 @@ class ObjectNameDepthSniff extends WPCS_Sniff {
 		}
 
 		if ( $part_count <= $this->recommended_max_words && $part_count <= $this->max_words ) {
+			$this->phpcsFile->recordMetric( $stackPtr, 'Nr of words in object name', $part_count );
 			return;
 		}
 
@@ -126,6 +127,8 @@ class ObjectNameDepthSniff extends WPCS_Sniff {
 				}
 			}
 		}
+
+		$this->phpcsFile->recordMetric( $stackPtr, 'Nr of words in object name', $part_count );
 
 		// Active class.
 		$object_type = 'a ' . $this->tokens[ $stackPtr ]['content'];


### PR DESCRIPTION
Metrics are a way to get statistics about a code base and can inform the values to use in the custom properties.

The metrics can be seen by running PHPCS with the `--report=info` option.

Example output for Yoast SEO Free:
```
PHP CODE SNIFFER INFORMATION REPORT
----------------------------------------------------------------------
Nr of words in object name:
        2     =>  185 ( 40.93%)
        3     =>  123 ( 27.21%)
        1     =>   82 ( 18.14%)
        4     =>   40 (  8.85%)
        5     =>   21 (  4.65%)
        6     =>    1 (  0.22%)
        ------------------------
        total =>  452 (100.00%)
```