### PR TITLE
ValidHookName: add metrics for old/new style and word count

### DIFF
--- a/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -250,6 +250,11 @@ class ValidHookNameSniff extends WPCS_ValidHookNameSniff {
 					$this->found_prefix,
 				]
 			);
+
+			$this->phpcsFile->recordMetric( $stackPtr, 'Hook name prefix type', 'old_style' );
+		}
+		else {
+			$this->phpcsFile->recordMetric( $stackPtr, 'Hook name prefix type', 'new\style' );
 		}
 
 		/*
@@ -276,6 +281,8 @@ class ValidHookNameSniff extends WPCS_ValidHookNameSniff {
 				3
 			);
 
+			$this->phpcsFile->recordMetric( $stackPtr, 'Nr of words in hook name', 'undetermined' );
+
 			return;
 		}
 
@@ -288,6 +295,8 @@ class ValidHookNameSniff extends WPCS_ValidHookNameSniff {
 
 		$parts      = \explode( '_', $hook_name );
 		$part_count = \count( $parts );
+
+		$this->phpcsFile->recordMetric( $stackPtr, 'Nr of words in hook name', $part_count );
 
 		if ( $part_count <= $this->recommended_max_words && $part_count <= $this->max_words ) {
 			return;


### PR DESCRIPTION
Metrics are a way to get statistics about a code base and can inform the values to use in the custom properties.

The metrics can be seen by running PHPCS with the `--report=info` option.

This PR adds two metricss to the sniff:
* Whether old-style `plugin_prefix` or new-style `plugin\prefix` prefixes are used.
* Word count in the hook name _after_ the prefix.

Notes:
* The metrics only look at the hooks using one of the allowed plugin prefixes.
    Hooks using a different prefix are disregarded (as not belonging to this plugin).
* The metrics for "word count" only apply to hooks using the new-style namespace based prefix.