### PR TITLE
PHPCS: minor ruleset tweak

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -64,7 +64,9 @@
 			<property name="prefixes" type="array">
 				<element value="YoastCS\Yoast"/>
 			</property>
-			<property name="src_directory" value="Yoast"/>
+			<property name="src_directory" type="array">
+				<element value="Yoast"/>
+			</property>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
The `src_directory` property for the `Yoast.NamingConventions.NamespaceName` sniff changed from a string value to an array value, but this hadn't been adjusted yet in the YoastCS native project ruleset ;-)

(wasn't problematic as the sniff maintains backward-compatibility for the property, but still)