### PR TITLE
CS: use *un*qualified names in docblocks + add `use` statements

### DIFF
--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace YoastCS\Yoast\Tests\Files;
 
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
@@ -79,8 +80,8 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Set CLI values before the file is tested.
 	 *
-	 * @param string                  $testFile The name of the file being tested.
-	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+	 * @param string $testFile The name of the file being tested.
+	 * @param Config $config   The config data for the test run.
 	 *
 	 * @return void
 	 */

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace YoastCS\Yoast\Tests\Files;
 
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
@@ -18,8 +19,8 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Set CLI values before the file is tested.
 	 *
-	 * @param string                  $testFile The name of the file being tested.
-	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+	 * @param string $testFile The name of the file being tested.
+	 * @param Config $config   The config data for the test run.
 	 *
 	 * @return void
 	 */

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace YoastCS\Yoast\Tests\NamingConventions;
 
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
@@ -19,8 +20,8 @@ class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Set CLI values before the file is tested.
 	 *
-	 * @param string                  $testFile The name of the file being tested.
-	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+	 * @param string $testFile The name of the file being tested.
+	 * @param Config $config   The config data for the test run.
 	 *
 	 * @return void
 	 */

--- a/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace YoastCS\Yoast\Tests\NamingConventions;
 
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
@@ -19,8 +20,8 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Set warnings level to 3 to trigger suggestions as warnings.
 	 *
-	 * @param string                  $filename The name of the file being tested.
-	 * @param \PHP_CodeSniffer\Config $config   The config data for the run.
+	 * @param string $filename The name of the file being tested.
+	 * @param Config $config   The config data for the run.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
Add `use` import statements for classes _only_ used in docblocks, even though PHP doesn't need nor use them.

See #201