### PR TITLE
TestDoubles: add check that all double/mock classes are so named

### DIFF
--- a/Yoast/Docs/Files/TestDoublesStandard.xml
+++ b/Yoast/Docs/Files/TestDoublesStandard.xml
@@ -36,5 +36,25 @@ class Test_Original_Class extends TestCase {
         ]]>
         </code>
     </code_comparison>
-
+    <standard>
+    <![CDATA[
+    Double/Mock test helper classes should have "Double" or "Mock" in their class name.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Test double suffixed with 'Double'.">
+        <![CDATA[
+class <em>Test_Double</em> extends Original_Class {
+    // Code.
+}
+        ]]>
+        </code>
+        <code title="Invalid: Test double without 'Double' or 'Mock' in the class name.">
+        <![CDATA[
+class <em>Foo_Class<em> extends Original_Foo_Class {
+    // Code.
+}
+        ]]>
+        </code>
+    </code_comparison>
 </documentation>

--- a/Yoast/Sniffs/Files/TestDoublesSniff.php
+++ b/Yoast/Sniffs/Files/TestDoublesSniff.php
@@ -8,6 +8,9 @@ use PHP_CodeSniffer\Files\File;
 /**
  * Check that all mock/doubles classes are in their own file and in a `doubles` directory.
  *
+ * Additionally, checks that all classes in the `doubles` directory/directories
+ * have `Double` or `Mock` in the class name.
+ *
  * @package Yoast\YoastCS
  *
  * @since   1.0.0
@@ -75,15 +78,6 @@ class TestDoublesSniff implements Sniff {
 			return;
 		}
 
-		$object_name = $phpcsFile->getDeclarationName( $stackPtr );
-		if ( empty( $object_name ) ) {
-			return;
-		}
-
-		if ( \stripos( $object_name, 'mock' ) === false && \stripos( $object_name, 'double' ) === false ) {
-			return;
-		}
-
 		if ( ! isset( $phpcsFile->config->basepath ) ) {
 			$phpcsFile->addWarning(
 				'For the TestDoubles sniff to be able to function, the --basepath needs to be set.',
@@ -131,48 +125,61 @@ class TestDoublesSniff implements Sniff {
 			}
 		}
 
-		if ( empty( $this->target_paths ) ) {
-			// No valid target paths found.
-			$data = [
-				$phpcsFile->config->basepath,
-			];
+		$object_name = $phpcsFile->getDeclarationName( $stackPtr );
+		if ( empty( $object_name ) ) {
+			return;
+		}
 
-			if ( \count( $this->doubles_path ) === 1 ) {
-				$data[] = 'directory';
-				$data[] = \implode( '', $this->doubles_path );
+		$name_contains_double_or_mock = false;
+		if ( \stripos( $object_name, 'mock' ) !== false || \stripos( $object_name, 'double' ) !== false ) {
+			$name_contains_double_or_mock = true;
+		}
+
+
+		if ( empty( $this->target_paths ) === true ) {
+			if ( $name_contains_double_or_mock === true ) {
+				// No valid target paths found.
+				$data = [
+					$phpcsFile->config->basepath,
+				];
+
+				if ( \count( $this->doubles_path ) === 1 ) {
+					$data[] = 'directory';
+					$data[] = \implode( '', $this->doubles_path );
+				}
+				else {
+					$all_paths = \implode( '", "', $this->doubles_path );
+					$all_paths = \substr_replace( $all_paths, ' and', \strrpos( $all_paths, ',' ), 1 );
+
+					$data[] = 'directories';
+					$data[] = $all_paths;
+				}
+
+				$phpcsFile->addError(
+					'Double/Mock test helper class detected, but no test doubles sub-%2$s found in "%1$s". Expected: "%3$s". Please create the sub-%2$s.',
+					$stackPtr,
+					'NoDoublesDirectory',
+					$data
+				);
 			}
-			else {
-				$all_paths = \implode( '", "', $this->doubles_path );
-				$all_paths = \substr_replace( $all_paths, ' and', \strrpos( $all_paths, ',' ), 1 );
-
-				$data[] = 'directories';
-				$data[] = $all_paths;
-			}
-
-			$phpcsFile->addError(
-				'Double/Mock test helper class detected, but no test doubles sub-%2$s found in "%1$s". Expected: "%3$s". Please create the sub-%2$s.',
-				$stackPtr,
-				'NoDoublesDirectory',
-				$data
-			);
 		}
 		else {
-			$path_to_file = $this->normalize_directory_separators( $file );
-			$is_error     = true;
+			$path_to_file  = $this->normalize_directory_separators( $file );
+			$is_double_dir = false;
 
 			foreach ( $this->target_paths as $target_path ) {
 				if ( \stripos( $path_to_file, $target_path ) !== false ) {
-					$is_error = false;
+					$is_double_dir = true;
 					break;
 				}
 			}
 
-			if ( $is_error === true ) {
-				$data = [
-					$tokens[ $stackPtr ]['content'],
-					$object_name,
-				];
+			$data = [
+				$tokens[ $stackPtr ]['content'],
+				$object_name,
+			];
 
+			if ( $name_contains_double_or_mock === true && $is_double_dir === false ) {
 				$phpcsFile->addError(
 					'Double/Mock test helper classes should be placed in a dedicated test doubles sub-directory. Found %s: %s',
 					$stackPtr,
@@ -180,27 +187,37 @@ class TestDoublesSniff implements Sniff {
 					$data
 				);
 			}
+			elseif ( $name_contains_double_or_mock === false && $is_double_dir === true ) {
+				$phpcsFile->addError(
+					'Double/Mock test helper classes should contain "Double" or "Mock" in the class name. Found %s: %s',
+					$stackPtr,
+					'InvalidClassName',
+					$data
+				);
+			}
 		}
 
-		$more_objects_in_file = $phpcsFile->findNext( $this->register(), ( $stackPtr + 1 ) );
-		if ( $more_objects_in_file === false ) {
-			$more_objects_in_file = $phpcsFile->findPrevious( $this->register(), ( $stackPtr - 1 ) );
-		}
+		if ( $name_contains_double_or_mock === true ) {
+			$more_objects_in_file = $phpcsFile->findNext( $this->register(), ( $stackPtr + 1 ) );
+			if ( $more_objects_in_file === false ) {
+				$more_objects_in_file = $phpcsFile->findPrevious( $this->register(), ( $stackPtr - 1 ) );
+			}
 
-		if ( $more_objects_in_file !== false ) {
-			$data = [
-				$tokens[ $stackPtr ]['content'],
-				$object_name,
-				$tokens[ $more_objects_in_file ]['content'],
-				$phpcsFile->getDeclarationName( $more_objects_in_file ),
-			];
+			if ( $more_objects_in_file !== false ) {
+				$data = [
+					$tokens[ $stackPtr ]['content'],
+					$object_name,
+					$tokens[ $more_objects_in_file ]['content'],
+					$phpcsFile->getDeclarationName( $more_objects_in_file ),
+				];
 
-			$phpcsFile->addError(
-				'Double/Mock test helper classes should be in their own file. Found %1$s: %2$s and %3$s: %4$s',
-				$stackPtr,
-				'OneObjectPerFile',
-				$data
-			);
+				$phpcsFile->addError(
+					'Double/Mock test helper classes should be in their own file. Found %1$s: %2$s and %3$s: %4$s',
+					$stackPtr,
+					'OneObjectPerFile',
+					$data
+				);
+			}
 		}
 	}
 

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -97,6 +97,11 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 				];
 
 			// In tests/doubles.
+			case 'correct-dir-not-double-or-mock.inc':
+				return [
+					3 => 1,
+				];
+
 			case 'multiple-mocks-in-file.inc':
 				return [
 					3 => 1,
@@ -105,6 +110,12 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 
 			// In tests/doubles-not-correct.
 			case 'not-in-correct-subdir.inc':
+				return [
+					3 => 1,
+				];
+
+			// In tests/mocks.
+			case 'correct-custom-dir-not-mock.inc':
 				return [
 					3 => 1,
 				];

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/doubles/correct-dir-not-double-or-mock.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/doubles/correct-dir-not-double-or-mock.inc
@@ -1,0 +1,3 @@
+<?php
+
+class Prefix_ClassName {}

--- a/Yoast/Tests/Files/TestDoublesUnitTests/tests/mocks/correct-custom-dir-not-mock.inc
+++ b/Yoast/Tests/Files/TestDoublesUnitTests/tests/mocks/correct-custom-dir-not-mock.inc
@@ -1,0 +1,6 @@
+phpcs:set Yoast.Files.TestDoubles doubles_path[] /tests/mocks,/tests/assets
+<?php
+
+class Prefix_ClassName {}
+
+// phpcs:set Yoast.Files.TestDoubles doubles_path[] /tests/doubles


### PR DESCRIPTION
As discussed with @herregroen  via Slack, all classes in test double directories should have `Double` or `Mock` as part of the class name.

Originally, the `TestDoubles` sniff checked if classes which contained `Double` or `Mock` in the class name were correctly placed in a `tests/doubles` directory.

With this commit, the sniff is adjusted to also check that all classes in the `tests/doubles` directory contain `Double` or `Mock` in the class name.

Notes:
1. If additional directories have been added to the `doubles_path` property, the files in these additional directories will also be checked.
2. It is not enforced for `Double` or `Mock` to be a class name suffix, so `Mock_Some_Class` will also be accepted (at this time).

Includes unit tests covering this change.
Includes updated documentation.