### PR TITLE
FileName: allow for a functions file to be called `functions.php`

### DIFF
--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -169,7 +169,7 @@ class FileNameSniff implements Sniff {
 			}
 			else {
 				$has_function = $phpcsFile->findNext( \T_FUNCTION, $stackPtr );
-				if ( $has_function !== false ) {
+				if ( $has_function !== false && $file_name !== 'functions' ) {
 					$error      = 'Files containing function declarations should have "-functions" as a suffix. Expected %s, but found %s.';
 					$error_code = 'InvalidFunctionsFileName';
 

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -65,6 +65,7 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		'excluded-trait-file.inc'         => 0,
 
 		// Functions file names.
+		'functions.inc'                   => 0,
 		'some-functions.inc'              => 0,
 		'some-file.inc'                   => 1, // Missing '-functions' suffix.
 		'excluded-functions-file.inc'     => 0,

--- a/Yoast/Tests/Files/FileNameUnitTests/functions/functions.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/functions/functions.inc
@@ -1,0 +1,5 @@
+<?php
+
+function some_function() {}
+
+function another_function() {}


### PR DESCRIPTION
Normally a `-functions` suffix is expected. This change allows for the file to be called `functions.php` without further specification.

This is intended specifically for _namespaced_ function files, though the sniff does not check for the file being namespaced. (can be added if so desired)

Includes unit test.