### PR TITLE
CI: minor tweak to the file linting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
 		"phpcompatibility/php-compatibility": "^9.2.0",
 		"roave/security-advisories": "dev-master",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"php-parallel-lint/php-parallel-lint": "^1.0",
-		"php-parallel-lint/php-console-highlighter": "^0.4",
+		"php-parallel-lint/php-parallel-lint": "^1.2",
+		"php-parallel-lint/php-console-highlighter": "^0.5",
 		"phpcsstandards/phpcsdevtools": "^1.0"
 	},
 	"minimum-stability": "dev",
@@ -44,7 +44,7 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
 		],
 		"lint": [
-			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor"
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
 		],
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.4-"


### PR DESCRIPTION
* Exclude the `.git` directory for a minor speed-bump.
* Raise the minimum versions to be used.

Ref:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.2.0
* https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v0.5