### PR TITLE
Travis: change from "trusty" to "xenial" and test against WPCS `master`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ php:
 
 env:
   # Test against the highest/lowest supported PHPCS and WPCS versions.
-  - PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
+  # Using WPCS 'master' for the last stable release.
+  - PHPCS_BRANCH="dev-master" WPCS="dev-master" PHPLINT=1
   - PHPCS_BRANCH="dev-master" WPCS="2.2.0"
-  - PHPCS_BRANCH="3.5.0" WPCS="dev-develop"
+  - PHPCS_BRANCH="3.5.0" WPCS="dev-master"
   - PHPCS_BRANCH="3.5.0" WPCS="2.2.0"
 
 # Define the stages used.
@@ -70,7 +71,7 @@ jobs:
     # supported PHP/PHPCS/WPCS combinations.
     - stage: quicktest
       php: 7.4
-      env: PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
+      env: PHPCS_BRANCH="dev-master" WPCS="dev-master" PHPLINT=1
     - php: 7.4
       env: PHPCS_BRANCH="3.5.0" WPCS="2.2.0"
     - php: 5.4
@@ -78,32 +79,32 @@ jobs:
       env: PHPCS_BRANCH="dev-master" WPCS="2.2.0" PHPLINT=1
     - php: 5.4
       dist: trusty
-      env: PHPCS_BRANCH="3.5.0" WPCS="dev-develop"
+      env: PHPCS_BRANCH="3.5.0" WPCS="dev-master"
 
     #### TEST STAGE ####
     # Additional builds against PHP versions which need a different distro.
     - stage: test
       php: 5.5
       dist: trusty
-      env: PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
+      env: PHPCS_BRANCH="dev-master" WPCS="dev-master" PHPLINT=1
     - php: 5.5
       dist: trusty
       env: PHPCS_BRANCH="dev-master" WPCS="2.2.0"
     - php: 5.5
       dist: trusty
-      env: PHPCS_BRANCH="3.5.0" WPCS="dev-develop"
+      env: PHPCS_BRANCH="3.5.0" WPCS="dev-master"
     - php: 5.5
       dist: trusty
       env: PHPCS_BRANCH="3.5.0" WPCS="2.2.0"
     - php: 5.4
       dist: trusty
-      env: PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
+      env: PHPCS_BRANCH="dev-master" WPCS="dev-master" PHPLINT=1
     - php: 5.4
       dist: trusty
       env: PHPCS_BRANCH="dev-master" WPCS="2.2.0"
     - php: 5.4
       dist: trusty
-      env: PHPCS_BRANCH="3.5.0" WPCS="dev-develop"
+      env: PHPCS_BRANCH="3.5.0" WPCS="dev-master"
     - php: 5.4
       dist: trusty
       env: PHPCS_BRANCH="3.5.0" WPCS="2.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,20 @@ jobs:
       dist: trusty
       env: PHPCS_BRANCH="3.5.0" WPCS="2.2.0"
 
+    # Test against WPCS unstable.
+    - php: 7.4
+      env: PHPCS_BRANCH="dev-master" WPCS="dev-develop"
+
+    # Test against PHP nightly.
+    - php: "nightly"
+      env: PHPCS_BRANCH="dev-master" WPCS="dev-master" PHPLINT=1
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
+    - env: PHPCS_BRANCH="dev-master" WPCS="dev-develop"
+
+
 before_install:
     # Speed up build time by disabling Xdebug.
     # https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,14 @@ before_install:
           # For testing the YoastCS native sniffs, the rest of the packages aren't needed.
           composer remove phpcompatibility/phpcompatibility-wp phpcompatibility/php-compatibility --no-update
       fi
-    - composer install --dev --no-suggest
+
+    - |
+      if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+        composer install --prefer-dist --no-interaction --ignore-platform-reqs
+      else
+        composer install --prefer-dist --no-interaction
+      fi
+
     # The DealerDirect Composer plugin script takes care of the installed_paths.
     - $PHPCS_BIN -i
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: php
+os: linux
 
-dist: trusty
+language: php
 
 cache:
   apt: true
@@ -12,8 +12,6 @@ cache:
     - $HOME/.cache/composer/files
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
@@ -40,12 +38,12 @@ stages:
   - name: test
     if: branch IN (master, develop)
 
-matrix:
+jobs:
   fast_finish: true
   include:
     #### SNIFF STAGE ####
     - stage: sniff
-      php: 7.3
+      php: 7.4
       env: PHPCS_BRANCH="dev-master" WPCS="dev-master"
       addons:
         apt:
@@ -76,9 +74,39 @@ matrix:
     - php: 7.4
       env: PHPCS_BRANCH="3.5.0" WPCS="2.2.0"
     - php: 5.4
+      dist: trusty
       env: PHPCS_BRANCH="dev-master" WPCS="2.2.0" PHPLINT=1
     - php: 5.4
+      dist: trusty
       env: PHPCS_BRANCH="3.5.0" WPCS="dev-develop"
+
+    #### TEST STAGE ####
+    # Additional builds against PHP versions which need a different distro.
+    - stage: test
+      php: 5.5
+      dist: trusty
+      env: PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
+    - php: 5.5
+      dist: trusty
+      env: PHPCS_BRANCH="dev-master" WPCS="2.2.0"
+    - php: 5.5
+      dist: trusty
+      env: PHPCS_BRANCH="3.5.0" WPCS="dev-develop"
+    - php: 5.5
+      dist: trusty
+      env: PHPCS_BRANCH="3.5.0" WPCS="2.2.0"
+    - php: 5.4
+      dist: trusty
+      env: PHPCS_BRANCH="dev-master" WPCS="dev-develop" PHPLINT=1
+    - php: 5.4
+      dist: trusty
+      env: PHPCS_BRANCH="dev-master" WPCS="2.2.0"
+    - php: 5.4
+      dist: trusty
+      env: PHPCS_BRANCH="3.5.0" WPCS="dev-develop"
+    - php: 5.4
+      dist: trusty
+      env: PHPCS_BRANCH="3.5.0" WPCS="2.2.0"
 
 before_install:
     # Speed up build time by disabling Xdebug.


### PR DESCRIPTION
### Travis: change from "trusty" to "xenial"

As the "trusty" environment is no longer officially supported by Travis, let's remove the key which will let the script use the default distro - currently `xenial`.

This updates the Travis config to:
* Use the `xenial` distro, which at this time is the default.
* Sets the distro for low PHP versions explicitly to `trusty`.
* Makes the expected OS explicit (linux).
* Updates the `matrix` key to `jobs`, which is the canonical for which `matrix` is an alias.
* Run the "sniff" stage on PHP 7.4 instead of PHP 7.3.

### Travis: test against WPCS `master` not `develop`

The WordPressCS `master` branch contains the last stable release, which is the highest YoastCS supported WPCS version.

As development on WPCS 3.0.0 has started and WPCS 3.0.0 will contain breaking changes, testing against WPCS `develop` would currently fail.

This will be addressed once WPCS 3.0.0 has stabilized and an RC has been released.

### Travis: add test builds against unstable dependencies

This adds two additional test builds:
* One against WPCS `develop`.
* One against PHP `nightly` (PHP 8).

Both are allowed to fail and are intended to provide early warning for upcoming changes we need to account for.

### Travis: ignore platform requirements for nightly

To allow the most recent supported PHPUnit version to install on PHP nightly, the `composer install` needs to run with `--ignore-platform-reqs`.