### PR TITLE
YoastCS ruleset: set the minimum supported WP version to 5.4

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -31,7 +31,7 @@
 			 Ref: https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
 		-->
 		<properties>
-			<property name="minimum_supported_version" value="5.3"/>
+			<property name="minimum_supported_version" value="5.4"/>
 		</properties>
 
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>


### PR DESCRIPTION
.. in line with the change made to the signalled minimum supported WP version in the plugins.