### PR TITLE
NamespaceName: allow for non-conventional test directory setup

### DIFF
--- a/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
@@ -170,12 +170,19 @@ class NamespaceNameSniff implements Sniff {
 		 */
 		if ( $namespace_name_no_prefix !== '' ) {
 			$namespace_for_level_check = $namespace_name_no_prefix;
+
 			// Allow for `Tests\` and `Tests\Doubles\` after the prefix.
-			if ( \strpos( $namespace_for_level_check, 'Tests\\' ) === 0 ) {
+			$starts_with_tests = ( \strpos( $namespace_for_level_check, 'Tests\\' ) === 0 );
+			if ( $starts_with_tests === true ) {
 				$namespace_for_level_check = \substr( $namespace_for_level_check, 6 );
-				if ( \strpos( $namespace_for_level_check, 'Doubles\\' ) === 0 ) {
-					$namespace_for_level_check = \substr( $namespace_for_level_check, 8 );
-				}
+			}
+
+			if ( ( $starts_with_tests === true
+				// Allow for non-conventional test directory layout, like in YoastSEO Free.
+				|| \strpos( $found_prefix, '\\Tests\\' ) !== false )
+				&& \strpos( $namespace_for_level_check, 'Doubles\\' ) === 0
+			) {
+				$namespace_for_level_check = \substr( $namespace_for_level_check, 8 );
 			}
 
 			$parts      = \explode( '\\', $namespace_for_level_check );


### PR DESCRIPTION
The tests in the Yoast repos are expected to live in a `tests` directory of the project root and the namespace should reflect that , i.e. `[Prefix]\Tests\NamespaceName`.

In the YoastSEO Free repo, however, the tests are split into two additional subdirectories, `unit` and `integration` and the ruleset configuration is setup to allow for this.

This did however mean that the allowance for an extra namespace level for `Doubles` directories did not carry through.

This small fix changes that and will prevent unwarranted namespace level depth errors for classes in the `tests\unit\doubles` directory.