### PR TITLE
Travis: retry composer install on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,20 +140,20 @@ before_install:
     - export PHPCS_DIR=$(pwd)/vendor/squizlabs/php_codesniffer
     - export PHPCS_BIN=$(pwd)/vendor/bin/phpcs
     # Set the PHPCS version to test against.
-    - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --no-update --no-suggest --no-scripts
+    - travis_retry composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --no-update --no-suggest --no-scripts
     # Set the WPCS version to test against.
-    - composer require wp-coding-standards/wpcs:${WPCS} --no-update --no-suggest --no-scripts
+    - travis_retry composer require wp-coding-standards/wpcs:${WPCS} --no-update --no-suggest --no-scripts
     - |
       if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" ]]; then
-          # For testing the YoastCS native sniffs, the rest of the packages aren't needed.
-          composer remove phpcompatibility/phpcompatibility-wp phpcompatibility/php-compatibility --no-update
+        # For testing the YoastCS native sniffs, the rest of the packages aren't needed.
+        travis_retry composer remove phpcompatibility/phpcompatibility-wp phpcompatibility/php-compatibility --no-update
       fi
 
     - |
       if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
-        composer install --prefer-dist --no-interaction --ignore-platform-reqs
+        travis_retry composer install --prefer-dist --no-interaction --ignore-platform-reqs
       else
-        composer install --prefer-dist --no-interaction
+        travis_retry composer install --prefer-dist --no-interaction
       fi
 
     # The DealerDirect Composer plugin script takes care of the installed_paths.


### PR DESCRIPTION
The builds are failing a little too often for my taste on the below error.
```
[Composer\Downloader\TransportException]
Peer fingerprint did not match
```

I'm prefixing the `composer install` commands now with `travis_retry` in an attempt to get round this problem.

Ref:
* https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies