### PR TITLE
Tests: improve code coverage registration

### DIFF
--- a/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
+++ b/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
@@ -7,7 +7,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
- * Verifies functions which are marked as `@deprecated` have a `@codeCoverageIgnore` tag
+ * Verifies functions which are marked as `deprecated` have a `codeCoverageIgnore` tag
  * in their docblock.
  *
  * @package Yoast\YoastCS

--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.php
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.php
@@ -10,6 +10,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package Yoast\YoastCS
  *
  * @since   1.3.0
+ *
+ * @covers  YoastCS\Yoast\Sniffs\Yoast\AlternativeFunctionsSniff
  */
 class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,21 @@
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
 	backupGlobals="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
-	colors="true">
+	colors="true"
+	forceCoversAnnotation="true"
+	>
+
+	<testsuites>
+		<testsuite name="YoastCS">
+			<directory suffix="UnitTest.php">./Yoast/Tests/</directory>
+		</testsuite>
+	</testsuites>
+
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
+			<directory suffix=".php">Yoast/Sniffs/</directory>
+		</whitelist>
+	</filter>
 
 	<php>
 		<env name="PHPCS_IGNORE_TESTS" value="PHPCompatibility,WordPress"/>


### PR DESCRIPTION
### AlternativeFunctions: add missing test `@covers` tag

### CodeCoverageIgnoreDeprecated: prevent the sniff from being ignored

Even though the `@CodeCoverageIgnore` annotation was not used as a stand-alone tag, PHPUnit was still ignoring the sniff for recording code coverage.

Fixed by removing the `@`s.

### PHPUnit: add code coverage configuration 