### PR TITLE
Files/FileName: allow for classes which are named the same as a prefix

### DIFF
--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -147,7 +147,7 @@ class FileNameSniff implements Sniff {
 						break;
 
 					case \T_INTERFACE:
-						$error      = 'Interface file names should be based on the interface name without the plugin prefix and should have "-interface" as a suffix. Expected %s, but found %s.';
+						$error      = 'Interface file names should be based on the interface name without the plugin prefix and should have "-interface" as a suffix. Expected "%s", but found "%s".';
 						$error_code = 'InvalidInterfaceFileName';
 
 						// Don't duplicate "interface" in the filename.
@@ -157,7 +157,7 @@ class FileNameSniff implements Sniff {
 						break;
 
 					case \T_TRAIT:
-						$error      = 'Trait file names should be based on the trait name without the plugin prefix and should have "-trait" as a suffix. Expected %s, but found %s.';
+						$error      = 'Trait file names should be based on the trait name without the plugin prefix and should have "-trait" as a suffix. Expected "%s", but found "%s".';
 						$error_code = 'InvalidTraitFileName';
 
 						// Don't duplicate "trait" in the filename.
@@ -170,7 +170,7 @@ class FileNameSniff implements Sniff {
 			else {
 				$has_function = $phpcsFile->findNext( \T_FUNCTION, $stackPtr );
 				if ( $has_function !== false && $file_name !== 'functions' ) {
-					$error      = 'Files containing function declarations should have "-functions" as a suffix. Expected %s, but found %s.';
+					$error      = 'Files containing function declarations should have "-functions" as a suffix. Expected "%s", but found "%s".';
 					$error_code = 'InvalidFunctionsFileName';
 
 					if ( \substr( $expected, -10 ) !== '-functions' ) {
@@ -181,7 +181,7 @@ class FileNameSniff implements Sniff {
 		}
 
 		// Throw the error.
-		if ( $file_name !== $expected ) {
+		if ( $expected !== '' && $file_name !== $expected ) {
 			$phpcsFile->addError(
 				$error,
 				0,

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -45,6 +45,7 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		'some-class.inc'                  => 0,
 		'wpseo-some-class.inc'            => 1, // Prefix 'wpseo' not necessary.
 		'yoast-plugin-some-class.inc'     => 1, // Prefix 'yoast-plugin' not necessary.
+		'yoast.inc'                       => 0, // Class name = prefix, so there would be nothing left otherwise.
 		'class-wpseo-some-class.inc'      => 1, // Prefixes 'class' and 'wpseo' not necessary.
 		'excluded-CLASS-file.inc'         => 1, // Lowercase expected.
 

--- a/Yoast/Tests/Files/FileNameUnitTests/classes/yoast.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/classes/yoast.inc
@@ -1,0 +1,8 @@
+<!-- Annotation must be on line 2 as this sniff throws issues on line 1 and PHPCS ignores errors on annotation lines. -->
+phpcs:set Yoast.Files.FileName oo_prefixes[] yoast
+
+<?php
+
+class Yoast {}
+
+// phpcs:set Yoast.Files.FileName oo_prefixes[]


### PR DESCRIPTION
When a class would be called `Yoast` and `yoast` would be one of the "forbidden" prefixes, the error message would recommend for the file to be called ".php".

This fix prevents that from happening and will leave classes which are called _exactly_ the same as a prefix alone.

Includes unit test.

Includes minor tweak for error message readability.