### PR TITLE
Composer: update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7"
 	},
 	"require-dev": {
-		"phpcompatibility/php-compatibility": "^9.2.0",
+		"phpcompatibility/php-compatibility": "^9.3.5",
 		"roave/security-advisories": "dev-master",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"php-parallel-lint/php-parallel-lint": "^1.2",
+		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"php-parallel-lint/php-console-highlighter": "^0.5",
 		"phpcsstandards/phpcsdevtools": "^1.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
 	},
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.5.0",
-		"wp-coding-standards/wpcs": "^2.2.0",
+		"squizlabs/php_codesniffer": "^3.6.0",
+		"wp-coding-standards/wpcs": "^2.3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7"
 	},


### PR DESCRIPTION
### Composer: update runtime dependencies

PHP_CodeSniffer has released version 3.6.0
Highlights:
* First version which supports all PHP 8.0 syntaxes, though not all utilities and sniffs have been fully updated yet.
* Large range of bugfixes.

WPCS 2.3.0 was released quite while back and while it as was already allowed via the version constraints and in practice used, let's formalize it as the minimum WPCS requirement.

Refs:
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.6.0
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/2.3.0

### Composer: update dev dependencies

Update version constraints for PHPCompatibility and PHP Parallel Lint.

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility/releases/
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.0

