### PR TITLE
Files/FileName: improve tests

### DIFF
--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -58,10 +58,10 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		'excluded-interface-file.inc'     => 0,
 
 		// Trait file names.
-		'outline-something-trait.inc'     => 0,
+		'outline-mything-trait.inc'       => 0,
 		'different-trait.inc'             => 1, // Filename not in line with trait name.
-		'outline-something.inc'           => 1, // Missing '-trait' suffix.
-		'yoast-outline-something.inc'     => 1, // Prefix 'yoast' not needed.
+		'outline-mything.inc'             => 1, // Missing '-trait' suffix.
+		'yoast-outline-mything.inc'       => 1, // Prefix 'yoast' not needed.
 		'no-duplicate-trait.inc'          => 0, // Check that 'Trait' in trait name does not cause duplication in filename.
 		'excluded-trait-file.inc'         => 0,
 

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/outline-mything-trait.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/outline-mything-trait.inc
@@ -3,6 +3,6 @@ phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
-trait Yoast_Outline_Something {}
+trait Yoast_Outline_MyThing {}
 
 // phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/outline-mything.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/outline-mything.inc
@@ -3,6 +3,6 @@ phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
-trait Yoast_Outline_Something {}
+trait Yoast_Outline_MyThing {}
 
 // phpcs:set Yoast.Files.FileName oo_prefixes[]

--- a/Yoast/Tests/Files/FileNameUnitTests/traits/yoast-outline-mything.inc
+++ b/Yoast/Tests/Files/FileNameUnitTests/traits/yoast-outline-mything.inc
@@ -3,6 +3,6 @@ phpcs:set Yoast.Files.FileName oo_prefixes[] wpseo,yoast
 
 <?php
 
-trait Yoast_Outline_Something {}
+trait Yoast_Outline_MyThing {}
 
 // phpcs:set Yoast.Files.FileName oo_prefixes[]


### PR DESCRIPTION
Some tests (interfaces/traits) were using the same file names and as the data provider is an array, that meant that array values were being overwritten.

This wasn't necessarily problematic as the values for those keys were the same in both cases, so all tests were still being run correctly, but is still something which should be fixed for improved future stability.