### PR TITLE
ValidHookName: improve handling of escaped slashes in prefixes

### DIFF
--- a/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.inc
+++ b/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.inc
@@ -45,7 +45,7 @@ do_action( 'Yoast\WP\Plugin\hook_' . $type . 'Yoast\WP\Plugin\hook' ); // Error 
 apply_filters( 'Yoast\WP\Plugin\\' . $type . '_' . $sub, $var ); // Warning at severity 3 compound name.
 
 // Test handling of escaped slash in double quotes string.
-$var = apply_filters( "Yoast\WP\Plugin\\{$obj->prop['type']}_details", $var ); // Warning at severity 3 compound name.
+$var = apply_filters( "Yoast\\WP\\Plugin\\{$obj->prop['type']}_details", $var ); // Warning at severity 3 compound name.
 
 // phpcs:enable
 
@@ -69,7 +69,7 @@ do_action(
  */
 // phpcs:set Yoast.NamingConventions.ValidHookName prefixes[] Yoast\WP\Plugin,yoast_plugin
 
-do_action( "Yoast\WP\Plugin\some_{$variable}_hook_name"); // Warning at severity 3.
+do_action( "Yoast\\WP\\Plugin\\some_{$variable}_hook_name"); // Warning at severity 3.
 do_action( 'yoast_plugin_some_' . 'hook_' . 'name' ); // Warning at severity 3 + warning wrong prefix.
 
 /*
@@ -118,7 +118,27 @@ do_action_ref_array( 'yoast_plugin_some_hook_name_which_is_too_long', $var ); //
 
 do_action( 'Yoast\WP\Plugin\some_hook_name', $var ); // Error.
 
-// Reset to default settings.
-// phpcs:set Yoast.NamingConventions.ValidHookName prefixes[]
+// Reset word maximums.
 // phpcs:set Yoast.NamingConventions.ValidHookName max_words 4
 // phpcs:set Yoast.NamingConventions.ValidHookName recommended_max_words 4
+
+/*
+ * Test handling of double slashes in prefixes.
+ * - Double slashes in single quoted strings are generally not needed, but will not cause problems.
+ * - Single slashed in double quoted strings could be problematic, so escaping the slashes is recommended.
+ */
+
+// Correct (single quoted).
+apply_filters( 'Yoast\WP\Plugin\hookname', $var); // OK.
+apply_filters( 'Yoast\\WP\\Plugin\\hookname', $var); // OK.
+
+// Correct (double quoted).
+apply_filters( "Yoast\\WP\\Plugin\\hook{$name}", $var); // OK, warning at severity 3 for word count.
+apply_filters( "Yoast\\WP\\Plugin\\hookname", $var); // OK.
+
+// Incorrect (double quoted - the `\` needs to be escaped).
+apply_filters( "Yoast\WP\Plugin\hookname", $var); // Warning, missing escaping x 3.
+apply_filters( "Yoast\WP\\Plugin\hook{$name}", $var); // Warning, missing escaping x 2 + warning at severity 3 for word count.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.ValidHookName prefixes[]

--- a/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -78,6 +78,9 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 			107 => 1,
 			110 => 2,
 			111 => 1,
+			136 => 1, // Severity: 3.
+			140 => 1,
+			141 => 2, // Severity: 3 + 5.
 		];
 	}
 }


### PR DESCRIPTION
This commit is the result of a review of the sniff for correct handling of double slashes in hook names.

When the "namespace-like" prefix type is used and the hook name is in double quotes, the "namespace separator" slash should be escaped to prevent it from accidentally escaping the **next** character.

To that end:
* Slash-escaped backslashes in prefixes will now be properly recognized and handled by the sniff and will not lead to false positives due to unrecognized prefixes.
* If the hook name is passed as a double quoted string, an extra check will be executed to verify that all backslashes are slash-escaped.
    If this is not the case, a warning will be thrown.

Includes a minor efficiency fix as the prefix is now only checked and saved to the property earlier instead of the hook name being analyzed twice for this.

Includes unit tests for the functionality and some minor adjustments to the existing unit tests.

Fixes #242

In a further iteration on this sniff, the new warning could potentially be made auto-fixable.