### PR TITLE
Add a custom "Threshold" report for use with PHPCS

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -50,6 +50,10 @@
 
 		<!-- Conflicts with variable names coming from PHPCS itself. -->
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+
+		<!-- Sniffs are not run in the context of WordPress. -->
+		<exclude name="WordPress.Security"/>
+		<exclude name="WordPress.WP"/>
 	</rule>
 
 	<!-- Enforce PSR1 compatible namespaces. -->

--- a/Yoast/Reports/Threshold.php
+++ b/Yoast/Reports/Threshold.php
@@ -23,6 +23,41 @@ use PHP_CodeSniffer\Reports\Report;
 class Threshold implements Report {
 
 	/**
+	 * Escape sequence for making text white on the command-line.
+	 *
+	 * @var string
+	 */
+	const WHITE = "\033[1m";
+
+	/**
+	 * Escape sequence for making text red on the command-line.
+	 *
+	 * @var string
+	 */
+	const RED = "\033[31m";
+
+	/**
+	 * Escape sequence for making text green on the command-line.
+	 *
+	 * @var string
+	 */
+	const GREEN = "\033[32m";
+
+	/**
+	 * Escape sequence for making text orange/yellow on the command-line.
+	 *
+	 * @var string
+	 */
+	const YELLOW = "\033[33m";
+
+	/**
+	 * Escape sequence for resetting the text colour.
+	 *
+	 * @var string
+	 */
+	const RESET = "\033[0m";
+
+	/**
 	 * Generate a partial report for a single processed file.
 	 *
 	 * Function should return TRUE if it printed or stored data about the file
@@ -78,45 +113,45 @@ class Threshold implements Report {
 		$error_threshold   = (int) \getenv( 'YOASTCS_THRESHOLD_ERRORS' );
 		$warning_threshold = (int) \getenv( 'YOASTCS_THRESHOLD_WARNINGS' );
 
-		echo \PHP_EOL . "\033[1m" . 'PHP CODE SNIFFER THRESHOLD COMPARISON' . "\033[0m" . \PHP_EOL;
-		echo \str_repeat( '-', $width ) . \PHP_EOL;
+		echo \PHP_EOL, self::WHITE, 'PHP CODE SNIFFER THRESHOLD COMPARISON', self::RESET, \PHP_EOL;
+		echo \str_repeat( '-', $width ), \PHP_EOL;
 
-		$color = "\033[32m"; // Green.
+		$color = self::GREEN;
 		if ( $totalErrors > $error_threshold ) {
-			$color = "\033[31m"; // Red.
+			$color = self::RED;
 		}
-		echo "{$color}Coding standards ERRORS: $totalErrors/$error_threshold.\033[0m" . \PHP_EOL;
+		echo "{$color}Coding standards ERRORS: $totalErrors/$error_threshold.", self::RESET, \PHP_EOL;
 
-		$color = "\033[32m";
+		$color = self::GREEN;
 		if ( $totalWarnings > $warning_threshold ) {
-			$color = "\033[33m"; // Orange.
+			$color = self::YELLOW;
 		}
-		echo "{$color}Coding standards WARNINGS: $totalWarnings/$warning_threshold.\033[0m" . \PHP_EOL;
+		echo "{$color}Coding standards WARNINGS: $totalWarnings/$warning_threshold.", self::RESET, \PHP_EOL;
 		echo \PHP_EOL;
 
 		$above_threshold = false;
 
 		if ( $totalErrors > $error_threshold ) {
-			echo "\033[31mPlease fix any errors introduced in your code and run PHPCS again to verify.\033[0m" . \PHP_EOL;
+			echo self::RED, 'Please fix any errors introduced in your code and run PHPCS again to verify.', self::RESET, \PHP_EOL;
 			$above_threshold = true;
 		}
 		elseif ( $totalErrors < $error_threshold ) {
-			echo "\033[32mFound less errors than the threshold, great job!\033[0m" . \PHP_EOL;
-			echo "Please update the ERRORS threshold in the composer.json file to \033[32m$totalErrors\033[0m." . \PHP_EOL;
+			echo self::GREEN, 'Found less errors than the threshold, great job!', self::RESET, \PHP_EOL;
+			echo 'Please update the ERRORS threshold in the composer.json file to ', self::GREEN, $totalErrors, '.', self::RESET, \PHP_EOL;
 		}
 
 		if ( $totalWarnings > $warning_threshold ) {
-			echo "\033[33mPlease fix any warnings introduced in your code and run PHPCS again to verify.\033[0m" . \PHP_EOL;
+			echo self::YELLOW, 'Please fix any warnings introduced in your code and run PHPCS again to verify.', self::RESET, \PHP_EOL;
 			$above_threshold = true;
 		}
 		elseif ( $totalWarnings < $warning_threshold ) {
-			echo "\033[32mFound less warnings than the threshold, great job!\033[0m" . \PHP_EOL;
-			echo "Please update the WARNINGS threshold in the composer.json file to \033[32m$totalWarnings\033[0m." . \PHP_EOL;
+			echo self::GREEN, 'Found less warnings than the threshold, great job!', self::RESET, \PHP_EOL;
+			echo 'Please update the WARNINGS threshold in the composer.json file to ', self::GREEN, $totalWarnings, '.', self::RESET, \PHP_EOL;
 		}
 
 		if ( $above_threshold === false ) {
 			echo \PHP_EOL;
-			echo 'Coding standards checks have passed!' . \PHP_EOL;
+			echo 'Coding standards checks have passed!', \PHP_EOL;
 		}
 
 		// Make the threshold comparison outcome available to the calling script.

--- a/Yoast/Reports/Threshold.php
+++ b/Yoast/Reports/Threshold.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace YoastCS\Yoast\Reports;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Reports\Report;
+
+/**
+ * Threshold Report for PHP_CodeSniffer.
+ *
+ * This report expects the following environment variables to be set
+ * to compare the scan results against:
+ * - YOASTCS_THRESHOLD_ERRORS
+ * - YOASTCS_THRESHOLD_WARNINGS
+ *
+ * To use this report, call PHPCS with the `--report=YoastCS\Yoast\Reports\Threshold` argument.
+ *
+ * After the report has run, a global `YOASTCS_ABOVE_THRESHOLD` constant (boolean) will be
+ * available which can be used in calling scripts.
+ *
+ * @since 2.2.0
+ */
+class Threshold implements Report {
+
+	/**
+	 * Generate a partial report for a single processed file.
+	 *
+	 * Function should return TRUE if it printed or stored data about the file
+	 * and FALSE if it ignored the file. Returning TRUE indicates that the file and
+	 * its data should be counted in the grand totals.
+	 *
+	 * @param array $report      Prepared report data.
+	 * @param File  $phpcsFile   The file being reported on.
+	 * @param bool  $showSources Whether to show the source codes.
+	 * @param int   $width       Maximum allowed line width.
+	 *
+	 * @return bool
+	 */
+	public function generateFileReport( $report, File $phpcsFile, $showSources = false, $width = 80 ) {
+		if ( \PHP_CODESNIFFER_VERBOSITY === 0
+			&& $report['errors'] === 0
+			&& $report['warnings'] === 0
+		) {
+			// Nothing to do.
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Generates a summary of all errors and warnings compares against preset thresholds.
+	 *
+	 * @param string $cachedData    Any partial report data that was returned from
+	 *                              generateFileReport during the run.
+	 * @param int    $totalFiles    Total number of files processed during the run.
+	 * @param int    $totalErrors   Total number of errors found during the run.
+	 * @param int    $totalWarnings Total number of warnings found during the run.
+	 * @param int    $totalFixable  Total number of problems that can be fixed.
+	 * @param bool   $showSources   Whether to show the source codes.
+	 * @param int    $width         Maximum allowed line width.
+	 * @param bool   $interactive   Whether PHPCS is being run in interactive mode.
+	 * @param bool   $toScreen      Whether the report is being printed to screen.
+	 *
+	 * @return void
+	 */
+	public function generate(
+		$cachedData,
+		$totalFiles,
+		$totalErrors,
+		$totalWarnings,
+		$totalFixable,
+		$showSources = false,
+		$width = 80,
+		$interactive = false,
+		$toScreen = true
+	) {
+		$error_threshold   = (int) \getenv( 'YOASTCS_THRESHOLD_ERRORS' );
+		$warning_threshold = (int) \getenv( 'YOASTCS_THRESHOLD_WARNINGS' );
+
+		echo \PHP_EOL . "\033[1m" . 'PHP CODE SNIFFER THRESHOLD COMPARISON' . "\033[0m" . \PHP_EOL;
+		echo \str_repeat( '-', $width ) . \PHP_EOL;
+
+		$color = "\033[32m"; // Green.
+		if ( $totalErrors > $error_threshold ) {
+			$color = "\033[31m"; // Red.
+		}
+		echo "{$color}Coding standards ERRORS: $totalErrors/$error_threshold.\033[0m" . \PHP_EOL;
+
+		$color = "\033[32m";
+		if ( $totalWarnings > $warning_threshold ) {
+			$color = "\033[33m"; // Orange.
+		}
+		echo "{$color}Coding standards WARNINGS: $totalWarnings/$warning_threshold.\033[0m" . \PHP_EOL;
+		echo \PHP_EOL;
+
+		$above_threshold = false;
+
+		if ( $totalErrors > $error_threshold ) {
+			echo "\033[31mPlease fix any errors introduced in your code and run PHPCS again to verify.\033[0m" . \PHP_EOL;
+			$above_threshold = true;
+		}
+		elseif ( $totalErrors < $error_threshold ) {
+			echo "\033[32mFound less errors than the threshold, great job!\033[0m" . \PHP_EOL;
+			echo "Please update the ERRORS threshold in the composer.json file to \033[32m$totalErrors\033[0m." . \PHP_EOL;
+		}
+
+		if ( $totalWarnings > $warning_threshold ) {
+			echo "\033[33mPlease fix any warnings introduced in your code and run PHPCS again to verify.\033[0m" . \PHP_EOL;
+			$above_threshold = true;
+		}
+		elseif ( $totalWarnings < $warning_threshold ) {
+			echo "\033[32mFound less warnings than the threshold, great job!\033[0m" . \PHP_EOL;
+			echo "Please update the WARNINGS threshold in the composer.json file to \033[32m$totalWarnings\033[0m." . \PHP_EOL;
+		}
+
+		if ( $above_threshold === false ) {
+			echo \PHP_EOL;
+			echo 'Coding standards checks have passed!' . \PHP_EOL;
+		}
+
+		// Make the threshold comparison outcome available to the calling script.
+		\define( 'YOASTCS_ABOVE_THRESHOLD', $above_threshold );
+	}
+}


### PR DESCRIPTION
### Context

The addition of this report will make checking based on threshold available to all repos using YoastCS and will allow for removing some duplicate code from the YoastSEO and PremiumSEO `Composer/Actions` classes.

### Commit details

This commit adds a custom report for use with PHPCS to compare the run results with "threshold" settings.

The report will look in the runtime environment for the following two environment variables:
* `YOASTCS_THRESHOLD_ERRORS`
* `YOASTCS_THRESHOLD_WARNINGS`

... and will take the values of those as the thresholds to compare the PHPCS run results against.

If the environment variables are not set, they will default to `0` for both, i.e. no errors or warnings allowed.

To use this report, run PHPCS with the following command-line argument: `--report=YoastCS\Yoast\Reports\Threshold`.

After the report has run, a global `YOASTCS_ABOVE_THRESHOLD` constant (boolean) will be available which can be used in calling scripts, to, for instance, exit with a different exit code if the thresholds were not matched.

The report will respect the PHPCS native `colors` setting.
If `colors` is turned on, the information about a mismatched _errors_ threshold will be presented in red and for _warnings_ in yellow/orange.

Output example:
![image](https://user-images.githubusercontent.com/663378/120050678-0cb9ff00-c01e-11eb-8439-39f43d9805f7.png)

Note: the messaging in the report - _"update the threshold in the composer.json"_ - is strongly based on existing practices in the Yoast environment.

Includes minor tweaks to the CS rules applied to the YoastCS repo itself as this code is not run within the context of WordPress and therefore doesn't have to (and often can't) comply with WordPress specific rules.

### Testing this PR

The easiest way to test this PR is by introducing some CS errors in the code in this repo and then running the following command:
```bash
vendor/bin/phpcs --report=YoastCS\Yoast\Reports\Threshold
```

After resetting the introduced errors, run the same command again to see the "clean" report.