### PR TITLE
Ruleset: enforce consistent placement of boolean operators in multi-line control structure conditions

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -160,6 +160,15 @@
 		</properties>
 	</rule>
 
+	<!-- CS: enforce that boolean operators between conditions in multi-line control structures are
+		 consistently at the start or end of the line, not a mix of both. -->
+	<rule ref="PSR12.ControlStructures.BooleanOperatorPlacement">
+		<properties>
+			<!-- Only allow them at the start of the line. -->
+			<property name="allowOnly" value="first"/>
+		</properties>
+	</rule>
+
 	<!-- Error prevention: Ensure no git conflicts make it into the code base. -->
 	<!-- PHPCS 3.4.0: This sniff will be added to WPCS in due time and can then be removed from this ruleset.
 		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1500 -->


### PR DESCRIPTION
When a control structure has multiple conditions, it is often formatted over multiple lines.
```php
if ( isset( $foo, $bar )
    && $foo !== $bar
) {}
```

The boolean operators in such a multi-line set of conditions can be freely placed. I.e. the below is perfectly valid PHP, but not great for readability:
```php
if ( isset( $foo, $bar ) && $foo
    !== $bar
) {}
```

The sniff addition proposed in this PR enforces that the boolean operators between conditions in multi-line control structures are consistently at the start òr at the end of the line, but not a mix of both.
I.e. this would be valid:
```php
if ( isset( $foo, $bar )
    && $foo !== $bar
    && $foo > $baz
) {}
```

... while this wouldn't be:
```php
if ( isset( $foo, $bar )
    && $foo !== $bar &&
    $foo > $baz
) {}
```

Multiple conditions on the same line will still be allowed:
```php
if ( isset( $foo, $bar ) && $foo !== $bar ) {}
```

In addition to that, the PHPCS 3.5.4 property `$allowOnly` gives us the chance to enforce that the operators are always at the start or at the end of the line.

I'm proposing for only allowing them at the start of the line as that will generally make for a smaller diff if/when a new condition is added to the control structure or when a condition is removed, which makes for easier code reviews.


Refs:
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.5.4
* https://github.com/squizlabs/PHP_CodeSniffer/pull/2680