### PR TITLE
PHPCS: use PHPCompatibility proper, not PHPCompatibilityWP

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -56,6 +56,14 @@
 		<exclude name="WordPress.WP"/>
 	</rule>
 
+	<!-- While PHPCompatibility is already included in the Yoast ruleset, it uses
+		 the PHPCompatibilityWP ruleset, which excludes rules polyfilled by WP.
+		 Setting the severity for all PHPCompatibility rules to 5 prevents WP
+		 polyfilled functionality from not being flagged in this repo. -->
+	<rule ref="PHPCompatibility">
+		<severity>5</severity>
+	</rule>
+
 	<!-- Enforce PSR1 compatible namespaces. -->
 	<rule ref="PSR1.Classes.ClassDeclaration"/>
 


### PR DESCRIPTION
The YoastCS code is not run in the context of WP, but the Yoast standard uses the `PHPCompatibilityWP` ruleset which excludes PHP features polyfilled in WP from being flagged.

By setting the `severity` of all the sniffs in the `PHPCompatibilility` ruleset back to `5`, the `exclude`s from the `PHPCompatibilityWP` ruleset are effectively "undone" and we are back to using `PHPCompatibility` proper.