### PR TITLE
Commenting/CodeCoverageIgnoreDeprecated: prevent false negatives with PHP 8.0 attributes

### DIFF
--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc
@@ -53,4 +53,18 @@ class SomeThing {
 	 * @deprecated x.x
 	 */
 	public function missingCodeCoverageIgnore() {}
+
+	/**
+	 * @deprecated x.x
+	 * @codeCoverageIgnore
+	 */
+	#[ReturnTypeWillChange]
+	private static function withAttributeCorrectDocblock() {}
+
+	/**
+	 * @deprecated x.x
+	 */
+	#[ReturnTypeWillChange]
+	#[AnotherAttribute]
+	public function withAttributesMissingCodeCoverageIgnore() {}
 }

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc
@@ -67,4 +67,25 @@ class SomeThing {
 	#[ReturnTypeWillChange]
 	#[AnotherAttribute]
 	public function withAttributesMissingCodeCoverageIgnore() {}
+
+	/**
+	 * Docblock which can't be found as the inline comments for the attribute confuse the sniff.
+	 */
+	#[fietsbel] // added a fietsbel decorator
+	public function unreachableDocblockTrailingComment() {}
+
+	/**
+	 * Docblock which can't be found as the inline comments for the attribute confuse the sniff.
+	 */
+	// I added a fietsbel decorator
+	#[fietsbel]
+	public function unreachableDocblockInlineCommentAboveAttribute() {}
+
+	/**
+	 * Docblock which is found as the comment is within the attribute itself.
+	 *
+	 * @deprecated x.x
+	 */
+	#[fietsbel /*comment*/]
+	public function inlineCommentWithinAttribute() {}
 }

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc.fixed
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc.fixed
@@ -53,4 +53,18 @@ class SomeThing {
 	 * @deprecated x.x
 	 */
 	public function missingCodeCoverageIgnore() {}
+
+	/**
+	 * @deprecated x.x
+	 * @codeCoverageIgnore
+	 */
+	#[ReturnTypeWillChange]
+	private static function withAttributeCorrectDocblock() {}
+
+	/**
+	 * @deprecated x.x
+	 */
+	#[ReturnTypeWillChange]
+	#[AnotherAttribute]
+	public function withAttributesMissingCodeCoverageIgnore() {}
 }

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc.fixed
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc.fixed
@@ -67,4 +67,25 @@ class SomeThing {
 	#[ReturnTypeWillChange]
 	#[AnotherAttribute]
 	public function withAttributesMissingCodeCoverageIgnore() {}
+
+	/**
+	 * Docblock which can't be found as the inline comments for the attribute confuse the sniff.
+	 */
+	#[fietsbel] // added a fietsbel decorator
+	public function unreachableDocblockTrailingComment() {}
+
+	/**
+	 * Docblock which can't be found as the inline comments for the attribute confuse the sniff.
+	 */
+	// I added a fietsbel decorator
+	#[fietsbel]
+	public function unreachableDocblockInlineCommentAboveAttribute() {}
+
+	/**
+	 * Docblock which is found as the comment is within the attribute itself.
+	 *
+	 * @deprecated x.x
+	 */
+	#[fietsbel /*comment*/]
+	public function inlineCommentWithinAttribute() {}
 }

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
@@ -26,6 +26,7 @@ class CodeCoverageIgnoreDeprecatedUnitTest extends AbstractSniffUnitTest {
 			50 => 1,
 			55 => 1,
 			69 => 1,
+			90 => 1,
 		];
 	}
 

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
@@ -25,6 +25,7 @@ class CodeCoverageIgnoreDeprecatedUnitTest extends AbstractSniffUnitTest {
 			41 => 1,
 			50 => 1,
 			55 => 1,
+			69 => 1,
 		];
 	}
 


### PR DESCRIPTION
PHP 8.0+ attributes can be placed between a docblock and the function declaration it applies to.

The `Yoast.Commenting.CodeCoverageIgnoreDeprecated` sniff did not yet take this into account.

This would result in a false negatives as the sniff would bow out for not finding a docblock, even when the docblock contained a `@deprecated` tag.

Fixed now.

Includes unit tests.