### PR TITLE
Commenting/CoversTag: make more code-style independent

### DIFF
--- a/Yoast/Sniffs/Commenting/CoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/CoversTagSniff.php
@@ -24,11 +24,9 @@ class CoversTagSniff implements Sniff {
 	/**
 	 * Regex to check for valid content of a @covers tags.
 	 *
-	 * Takes the WP naming conventions into account (up to a point).
-	 *
 	 * @var string
 	 */
-	const VALID_CONTENT_REGEX = '(?:\\\\?(?:(?<OOName>[A-Z][a-zA-Z0-9_\x7f-\xff]*)\\\\)*(?P>OOName)(?:<extended>|::<[!]?(?:public|protected|private)>|::(?<functionName>(?!public$|protected$|private$)[a-z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*))?|::(?P>functionName)|\\\\?(?:(?P>OOName)\\\\)+(?P>functionName))';
+	const VALID_CONTENT_REGEX = '(?:\\\\?(?:(?<OOName>[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)\\\\)*(?P>OOName)(?:<extended>|::<[!]?(?:public|protected|private)>|::(?<functionName>(?!public$|protected$|private$)(?P>OOName)))?|::(?P>functionName)|\\\\?(?:(?P>OOName)\\\\)+(?P>functionName))';
 
 	/**
 	 * Base error message.

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.inc
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.inc
@@ -29,13 +29,13 @@ class ClassNameTest {
 	 * @covers \Class_name::method_name
 	 * @covers Name\Space\Class_Name::method_name
 	 * @covers \Name\Space\Class_name::method_name
+	 * @covers global_function
+	 * @covers self::method_name
 	 *
 	 * Incorrect:
-	 * @covers global_function
 	 * @covers ::global_func()
 	 * @covers Name\Space\func_name()
 	 * @covers My_Class {}
-	 * @covers self::method_name
 	 * @covers My_Class::another_method_name()
 	 * @covers Name\Space\My_Class::another_method_name()
 	 */
@@ -153,4 +153,15 @@ class ClassNameTest {
 	 * @param int $int Description.
 	 */
 	public function testDuplicateCoversTagFixable($int) {}
+
+	/**
+	 * Docblock.
+	 *
+	 * Correct:
+	 * @covers ::GlobalFunction
+	 * @covers ClassName::MethodName
+	 * @covers \Classname::MethodName
+	 * @covers \Name\Space\ClassName::MethodName
+	 */
+	public function testRecognizingNamesNotFollowingWPNamingConventions() {}
 }

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.inc.fixed
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.inc.fixed
@@ -29,13 +29,13 @@ class ClassNameTest {
 	 * @covers \Class_name::method_name
 	 * @covers Name\Space\Class_Name::method_name
 	 * @covers \Name\Space\Class_name::method_name
+	 * @covers global_function
+	 * @covers self::method_name
 	 *
 	 * Incorrect:
-	 * @covers global_function
 	 * @covers ::global_func
 	 * @covers Name\Space\func_name
 	 * @covers My_Class
-	 * @covers self::method_name
 	 * @covers My_Class::another_method_name
 	 * @covers Name\Space\My_Class::another_method_name
 	 */
@@ -152,4 +152,15 @@ class ClassNameTest {
 	 * @param int $int Description.
 	 */
 	public function testDuplicateCoversTagFixable($int) {}
+
+	/**
+	 * Docblock.
+	 *
+	 * Correct:
+	 * @covers ::GlobalFunction
+	 * @covers ClassName::MethodName
+	 * @covers \Classname::MethodName
+	 * @covers \Name\Space\ClassName::MethodName
+	 */
+	public function testRecognizingNamesNotFollowingWPNamingConventions() {}
 }

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.php
@@ -22,8 +22,6 @@ class CoversTagUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return [
-			34  => 1,
-			35  => 1,
 			36  => 1,
 			37  => 1,
 			38  => 1,


### PR DESCRIPTION
The regex used in the `Yoast.Commenting.CoversTag` sniff was - in part - based on the known naming conventions used in WP projects.

As the Yoast standard will now also be used outside of WP projects (special projects team), the assumption that the WP naming conventions will be used needs to be removed.

Fixed now.

Includes updated and additional unit tests which would not pass without this fix.