### PR TITLE
Commenting/FileComment: efficiency tweak + bug fix

### DIFF
--- a/Yoast/Sniffs/Commenting/FileCommentSniff.php
+++ b/Yoast/Sniffs/Commenting/FileCommentSniff.php
@@ -82,7 +82,7 @@ class FileCommentSniff extends Squiz_FileCommentSniff {
 
 		$comment_start = $phpcsFile->findNext( \T_WHITESPACE, ( $stackPtr + 1 ), $namespace_token, true );
 
-		if ( $tokens[ $comment_start ]['code'] === \T_DOC_COMMENT_OPEN_TAG ) {
+		if ( $comment_start !== false && $tokens[ $comment_start ]['code'] === \T_DOC_COMMENT_OPEN_TAG ) {
 			$phpcsFile->addWarning(
 				'A file containing a (named) namespace declaration does not need a file docblock',
 				$comment_start,

--- a/Yoast/Sniffs/Commenting/FileCommentSniff.php
+++ b/Yoast/Sniffs/Commenting/FileCommentSniff.php
@@ -39,13 +39,35 @@ class FileCommentSniff extends Squiz_FileCommentSniff {
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
 
-		$namespace_token = $phpcsFile->findNext( \T_NAMESPACE, $stackPtr );
-		if ( $namespace_token === false ) {
-			// No namespace found, fall through to parent sniff.
-			return parent::process( $phpcsFile, $stackPtr );
-		}
-
 		$tokens = $phpcsFile->getTokens();
+
+		$namespace_token = $stackPtr;
+		do {
+			$namespace_token = $phpcsFile->findNext( Tokens::$emptyTokens, ( $namespace_token + 1 ), null, true );
+			if ( $namespace_token === false ) {
+				// No non-empty token found, fall through to parent sniff.
+				return parent::process( $phpcsFile, $stackPtr );
+			}
+
+			if ( $tokens[ $namespace_token ]['code'] === \T_DECLARE ) {
+				// Declare statement found. Find the end of it and skip over it.
+				$end = $phpcsFile->findNext( [ \T_SEMICOLON, \T_OPEN_CURLY_BRACKET ], ( $namespace_token + 1 ), null, false, null, true );
+
+				if ( $end !== false ) {
+					$namespace_token = $end;
+				}
+
+				continue;
+			}
+
+			if ( $tokens[ $namespace_token ]['code'] !== \T_NAMESPACE ) {
+				// No namespace found, fall through to parent sniff.
+				return parent::process( $phpcsFile, $stackPtr );
+			}
+
+			// Stop searching if the next non-empty token wasn't a namespace token.
+			break;
+		} while ( true );
 
 		$next_non_empty = $phpcsFile->findNext( Tokens::$emptyTokens, ( $namespace_token + 1 ), null, true );
 		if ( $next_non_empty === false

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.11.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.11.inc
@@ -1,0 +1,24 @@
+<?php
+/**
+ * File Comment for a file without a namespace, but with a declare statement.
+ *
+ * For the purposes of the unit test, the docblock here needs to comply with the
+ * complete Squiz file comment rules as the ruleset is not taken into account
+ * when unit testing sniffs.
+ *
+ * @package    Some\Package
+ * @subpackage Something\Else
+ * @author     Squiz Pty Ltd <products@squiz.net>
+ * @copyright  2018 Squiz Pty Ltd (ABN 77 084 670 600)
+ */
+
+declare(strict_types=1);
+
+/**
+ * Class docblock.
+ */
+class Testing {
+	public function test() {
+		echo namespace\SomeClass::$static_property; // This is not a namespace declaration, but use of the namespace operator.
+	}
+}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.12.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.12.inc
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Class docblock. Declare statement, no namespace, file comment is needed, but missing.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.13.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.13.inc
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoast\Plugin\Sub;
+
+/**
+ * Class docblock. A file docblock is not needed in a namespaced file.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.14.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.14.inc
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File Comment for a file WITH a namespace. This should be flagged as unnecessary.
+ *
+ * @package Some\Package
+ */
+
+declare(strict_types=1) {
+
+	namespace Yoast\Plugin\Sub;
+	
+	/**
+	 * Class docblock.
+	 */
+	class Testing {}
+
+}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.php
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.php
@@ -27,6 +27,7 @@ class FileCommentUnitTest extends AbstractSniffUnitTest {
 			case 'FileCommentUnitTest.2.inc':
 			case 'FileCommentUnitTest.8.inc':
 			case 'FileCommentUnitTest.10.inc':
+			case 'FileCommentUnitTest.12.inc':
 				return [
 					1 => 1,
 				];
@@ -47,6 +48,7 @@ class FileCommentUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'FileCommentUnitTest.4.inc':
 			case 'FileCommentUnitTest.6.inc':
+			case 'FileCommentUnitTest.14.inc':
 				return [
 					2 => 1,
 				];


### PR DESCRIPTION
### Commenting/FileComment: efficiency tweak

While reviewing the sniffs for WP-code style independence (for use in special projects), I noticed that the `FileComment` sniff may walk all the way to the end of a file before deciding to pass off to the parent sniff.

While for namespaced files, this will never happen as a namespace declaration will (normally) be the first statement in a file, for non-namespaced files, this made the sniff highly inefficient as, especially for long files, it would have to walk through all the tokens in the file before deciding it is a non-namespaced file.

Fixed now by only walking as far as the first non-empty (not whitespace, not comment) token and deciding based on that.

While a file _may_ contain a namespace declaration later on in the file (multi-namespace files), this rule is not intended for those type of files anyway, so it is correct for the "must-have file comment" rule to be applied in that case.

This change is already covered by the existing unit tests.

### Commenting/FileComment: minor bug fix

The PHPCS `File::findNext()` function will return the stack pointer to the token found or `false` if no matching token is found.

The check for the `$comment_start` token could therefore return `false` when no comment token is found between a PHP open tag and the first namespace token, which would mean that the `$tokens[ $comment_start ]['code']` check in the condition would effectively look at `$tokens[ false ]['code']`, which (in most cases) would translate to the PHP open tag.

While this doesn't lead to any problems in practice, it is still wrong, so a check against `false` has been added to the condition now.

