### PR TITLE
Commenting/TestsHaveCoversTag: various improvements

### DIFF
--- a/Yoast/Sniffs/Commenting/TestsHaveCoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/TestsHaveCoversTagSniff.php
@@ -64,7 +64,10 @@ class TestsHaveCoversTagSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 		$name   = $phpcsFile->getDeclarationName( $stackPtr );
 
-		if ( \substr( $name, -4 ) !== 'Test' ) {
+		if ( \substr( $name, -4 ) !== 'Test'
+			&& \substr( $name, -8 ) !== 'TestCase'
+			&& \substr( $name, 0, 4 ) !== 'Test'
+		) {
 			// Not a test class.
 			if ( isset( $tokens[ $stackPtr ]['scope_closer'] ) ) {
 				// No need to examine the methods in this class.

--- a/Yoast/Sniffs/Commenting/TestsHaveCoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/TestsHaveCoversTagSniff.php
@@ -189,6 +189,12 @@ class TestsHaveCoversTagSniff implements Sniff {
 			return;
 		}
 
+		$method_props = $phpcsFile->getMethodProperties( $stackPtr );
+		if ( $method_props['is_abstract'] === true ) {
+			// Abstract test method, not implemented.
+			return;
+		}
+
 		if ( $foundCovers === true || $foundCoversNothing === true ) {
 			// Docblock contains one or more @covers tags.
 			return;

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.inc
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.inc
@@ -103,3 +103,33 @@ class ClassNameTest {
 	 */
 	public function annotatedTestHasCoversTag() {}
 }
+
+/**
+ * @covers ClassName
+ */
+#[Some_Attribute]
+class ClassLevelCoversWithAttributeTest {
+
+	/**
+	 * Docblock.
+	 */
+	public function testMissingCoversTag() {}
+}
+
+class ClassWithMethodsWithAttributesTest {
+
+	/**
+	 * Docblock.
+	 */
+	#[AttributeA]
+	#[AttributeB]
+	public function testMissingCoversTag() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers ::globalFunction
+	 */
+	#[AttributeA]
+	public function testHasCoversTag() {}
+}

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.inc
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.inc
@@ -148,4 +148,9 @@ abstract class ContainsTestMethodsTestCase {
 	 * Docblock - this concrete test should have a covers tag.
 	 */
 	function testSomething() {}
+
+	/**
+	 * Docblock - this abstract method can be ignored.
+	 */
+	abstract function testToBeImplementedInChildClass();
 }

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.inc
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.inc
@@ -133,3 +133,19 @@ class ClassWithMethodsWithAttributesTest {
 	#[AttributeA]
 	public function testHasCoversTag() {}
 }
+
+class TestPrefixNotSuffix {
+
+	/**
+	 * Docblock.
+	 */
+	function testSomething() {}
+}
+
+abstract class ContainsTestMethodsTestCase {
+
+	/**
+	 * Docblock - this concrete test should have a covers tag.
+	 */
+	function testSomething() {}
+}

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
@@ -22,8 +22,9 @@ class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return [
-			59 => 1,
-			88 => 1,
+			59  => 1,
+			88  => 1,
+			126 => 1,
 		];
 	}
 

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
@@ -22,6 +22,7 @@ class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return [
+			49  => 1,
 			59  => 1,
 			88  => 1,
 			126 => 1,

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
@@ -26,6 +26,8 @@ class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
 			59  => 1,
 			88  => 1,
 			126 => 1,
+			142 => 1,
+			150 => 1,
 		];
 	}
 


### PR DESCRIPTION
### Commenting/TestsHaveCoversTag: prevent false negatives with attributes

PHP 8.0+ attributes can be placed between a docblock and the class/function declaration it applies to.

The `Yoast.Commenting.TestsHaveCoversTag` sniff did not yet take this into account.

This could result in both false positives as well as false negatives:
* False positives for individual functions not having a `@covers` tag if the sniff did not find a class docblock containing a `@covers` tag.
* False negatives for functions which do have a docblock, but without a `@covers` tag in either the function or the class docblock, where the sniff did not find function docblock due to the attribute.

Fixed now.

Includes unit tests.

### Commenting/TestsHaveCoversTag: report missing covers tag when docblock is missing

The sniff as it was, contained an assumption that all methods should have a docblock, as per the WordPress Coding Standards.

For a `@covers` tag to be found, a docblock is necessary, but as-it-was, if the docblock was not found, the sniff would bow out and defer to the WPCS Docs sniff to report the missing docblock.

For the sniff to be properly independent of other sniffs, it should not bow out when there is no docblock, but report the missing `@covers` tag.

Fixed now.

Includes adjusting the expected result for one of the existing unit tests (which already covered this case).

### Commenting/TestsHaveCoversTag: allow for different test class naming conventions

PHPUnit has strict naming conventions for test methods:
* The method has to start with `test`;
* Or have a `@test` docblock annotation.

However, for test classes, no such naming conventions exist. though it is customary to have the class either prefixed or suffixed with the word `Test`.
Additionally, it is customary for abstract classes in test suites to be suffixed with `TestCase`.

The `Yoast.Commenting.TestsHaveCoversTag` sniff only took test classes suffixed with `Test` into account, which complies with the naming conventions adhered to in most Yoast projects.

However, for the sniff to be code-style independent, other conventions, like using a `Test` prefix (WordPress Core) should also be taken into account.
Similarly, abstract test classes can contain concrete tests - which would then be run for each child test class -, so this sniff should also allow for a `TestCase` suffix and search those classes for test methods.

Fixed now.

Includes additional unit tests.

### Commenting/TestsHaveCoversTag: allow for abstract test methods in TestCases

Now, `TestCase` classes are taken into account, we also need to account for the possibility of those containing `abstract` test methods.

In that case, no `@covers` tag is needed as the method is not implemented (yet) and the `@covers` tag should only be added with the concrete implementation in the child class.

Fixed now.

Includes additional unit test.

