### PR TITLE
NamingConventions/ObjectNameDepth: various improvements

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -48,6 +48,9 @@
 		<!-- This sniff is irrelevant for a PHPCS standard which follows the PHPCS directory structure. -->
 		<exclude name="Yoast.Files.TestDoubles"/>
 
+		<!-- Conflicts with PHPCS autoloading of sniffs. -->
+		<exclude name="Yoast.NamingConventions.ObjectNameDepth"/>
+
 		<!-- Conflicts with variable names coming from PHPCS itself. -->
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
 

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -85,9 +85,14 @@ class ObjectNameDepthSniff extends WPCS_Sniff {
 			return;
 		}
 
-		$object_name = \ltrim( $object_name, '_' );
+		$snakecase_object_name = \ltrim( $object_name, '_' );
 
-		$parts      = \explode( '_', $object_name );
+		// Handle names which are potentially in CamelCaps.
+		if ( \strpos( $snakecase_object_name, '_' ) === false ) {
+			$snakecase_object_name = self::get_snake_case_name_suggestion( $snakecase_object_name );
+		}
+
+		$parts      = \explode( '_', $snakecase_object_name );
 		$part_count = \count( $parts );
 
 		/*

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -110,13 +110,28 @@ class ObjectNameDepthSniff extends WPCS_Sniff {
 		}
 
 		// Check if the class is deprecated.
-		$find = [
+		$ignore = [
 			\T_ABSTRACT   => \T_ABSTRACT,
 			\T_FINAL      => \T_FINAL,
 			\T_WHITESPACE => \T_WHITESPACE,
 		];
 
-		$comment_end = $this->phpcsFile->findPrevious( $find, ( $stackPtr - 1 ), null, true );
+		$comment_end = $stackPtr;
+		for ( $comment_end = ( $stackPtr - 1 ); $comment_end >= 0; $comment_end-- ) {
+			if ( isset( $ignore[ $this->tokens[ $comment_end ]['code'] ] ) === true ) {
+				continue;
+			}
+
+			if ( $this->tokens[ $comment_end ]['code'] === \T_ATTRIBUTE_END
+				&& isset( $this->tokens[ $comment_end ]['attribute_opener'] ) === true
+			) {
+				$comment_end = $this->tokens[ $comment_end ]['attribute_opener'];
+				continue;
+			}
+
+			break;
+		}
+
 		if ( $this->tokens[ $comment_end ]['code'] === \T_DOC_COMMENT_CLOSE_TAG ) {
 			// Only check if the class has a docblock.
 			$comment_start = $this->tokens[ $comment_end ]['comment_opener'];

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -85,6 +85,8 @@ class ObjectNameDepthSniff extends WPCS_Sniff {
 			return;
 		}
 
+		$object_name = \ltrim( $object_name, '_' );
+
 		$parts      = \explode( '_', $object_name );
 		$part_count = \count( $parts );
 

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
@@ -103,3 +103,14 @@ class Three_Word_Name_Mock extends Some_Class {} // OK.
  */
 class __Three_Word_Name {} // OK.
 class __Four_Four_Word_Name {} // Error.
+
+/*
+ * Make sure CamelCaps class names are also handled by this sniff.
+ */
+class ThreePartName {}
+interface MyInterfaceName {}
+trait SomeACRONYMName {} // Error - false positive, this will be fixed in a later iteration on this sniff.
+
+class TooLongClassName {} // Error.
+interface ThisInterfaceNameIsTooLong {} // Error.
+trait TraitNameIsTooLong {} // Error.

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
@@ -97,3 +97,9 @@ class Three_Word_Name_Mock {} // Error.
 
 class Three_Word_Name_Double extends Three_Word_Name {} // OK.
 class Three_Word_Name_Mock extends Some_Class {} // OK.
+
+/*
+ * Make sure underscore prefixed names have a correct count.
+ */
+class __Three_Word_Name {} // OK.
+class __Four_Four_Word_Name {} // Error.

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
@@ -64,6 +64,23 @@ class Active_Class_With_Too_Long_Class_Name {} // Error.
  */
 class Deprecated_Class_With_Too_Long_Class_Name {} // OK.
 
+/**
+ * Class description, no @deprecated tag.
+ *
+ * @since x.x.x
+ */
+#[Some_Attribute]
+class Active_Class_With_Attribute_With_Too_Long_Class_Name {} // Error.
+
+/**
+ * Class description.
+ *
+ * @deprecated x.x.x
+ */
+#[Attribute_One]
+#[Attribute_Two]
+class Deprecated_Class_With_Attribute_With_Too_Long_Class_Name {} // OK.
+
 /*
  * Allow for a `_Test` suffix in classes within the unit test suite.
  */

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
@@ -34,10 +34,11 @@ class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
 					42 => 1,
 					43 => 1,
 					58 => 1,
-					70 => 1,
-					75 => 1,
-					78 => 1,
-					79 => 1,
+					73 => 1,
+					87 => 1,
+					92 => 1,
+					95 => 1,
+					96 => 1,
 				];
 
 			default:

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
@@ -27,18 +27,19 @@ class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'ObjectNameDepthUnitTest.2.inc':
 				return [
-					21 => 1,
-					22 => 1,
-					23 => 1,
-					33 => 1,
-					42 => 1,
-					43 => 1,
-					58 => 1,
-					73 => 1,
-					87 => 1,
-					92 => 1,
-					95 => 1,
-					96 => 1,
+					21  => 1,
+					22  => 1,
+					23  => 1,
+					33  => 1,
+					42  => 1,
+					43  => 1,
+					58  => 1,
+					73  => 1,
+					87  => 1,
+					92  => 1,
+					95  => 1,
+					96  => 1,
+					105 => 1,
 				];
 
 			default:

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
@@ -40,6 +40,10 @@ class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
 					95  => 1,
 					96  => 1,
 					105 => 1,
+					112 => 1, // False positive due to acronym.
+					114 => 1,
+					115 => 1,
+					116 => 1,
 				];
 
 			default:


### PR DESCRIPTION
### NamingConventions/ObjectNameDepth: prevent false positives with attributes

PHP 8.0+ attributes can be placed between a docblock and the class/function declaration it applies to.

The `Yoast.NamingConventions.ObjectNameDepth` sniff did not yet take this into account.

This could result in false positives when a class is marked as `@deprecated`.

Fixed now.

Includes unit tests.

### NamingConventions/ObjectNameDepth: disregard underscore prefixed class names

While unconventional, underscore prefixed class names are allowed in PHP and should not affect the object name word count.

Fixed now.

Includes unit tests.

### NamingConventions/ObjectNameDepth: allow for class names in CamelCaps

The WP Coding Standards and by extension YoastCS, expects `Snake_Caps` class names.

For non-WP projects, however, `CamelCaps` class names are more common.

This change makes this sniff more code-style independent by allowing for `CamelCaps` class names when examining the word count.

Includes unit tests.

Note: one unit test is failing due to an acronym being used in the class name. This should be fixed at a later point in time.

Also note: as PHPCS has strict directory structure conventions, it is not possible for sniffs to be placed in a deeper subdirectory/namespace (which is what should normally be done for violations against this sniff).
With that in mind, this sniff is disabled for this repository.

