### PR TITLE
Composer: update Parallel Lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"phpcompatibility/php-compatibility": "^9.3.5",
 		"roave/security-advisories": "dev-master",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"php-parallel-lint/php-parallel-lint": "^1.3",
+		"php-parallel-lint/php-parallel-lint": "^1.3.1",
 		"php-parallel-lint/php-console-highlighter": "^0.5",
 		"phpcsstandards/phpcsdevtools": "^1.0"
 	},


### PR DESCRIPTION
Update the Parallel Lint `dev` dependency to use v `1.3.1` as a minimum. The new release has improved PHP 8.1 support.

Ref: https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.1