### PR TITLE
Composer: provide Parallel Lint via YoastCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ composer require --dev yoast/yoastcs:^2.0
 
 Composer will automatically install dependencies and register the YoastCS and other external standards with PHP_CodeSniffer.
 
+## Tools provided via YoastCS
+
+* PHP Parallel Lint
+* PHP_CodeSniffer and select standards for PHP_CodeSniffer, including a number of Yoast native sniffs.
+
+
+## PHP Parallel Lint
+
+[PHP Parallel Lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint/) is a tool to lint PHP files against parse errors.
+
+PHP Parallel Lint does not use a configuration file, so [command-line options](https://github.com/php-parallel-lint/PHP-Parallel-Lint/#command-line-options) need to be passed to configure what files to scan.
+
+It is best practice within the Yoast projects, to add a script to the `composer.json` file which encapsules the command with the appropriate command-line options to ensure that running the tool will yield the same results each time.
+
+Typically, (a variation on) the following snippet would be added to the `composer.json` file for a project:
+```json
+    "scripts" : {
+        "lint": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+        ]
+    }
+```
+
+
 ## PHP Code Sniffer
 
 Set of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) rules.

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,14 @@
 		"squizlabs/php_codesniffer": "^3.6.0",
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7",
+		"php-parallel-lint/php-parallel-lint": "^1.3.1",
+		"php-parallel-lint/php-console-highlighter": "^0.5.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",
 		"roave/security-advisories": "dev-master",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"php-parallel-lint/php-parallel-lint": "^1.3.1",
-		"php-parallel-lint/php-console-highlighter": "^0.5",
 		"phpcsstandards/phpcsdevtools": "^1.0"
 	},
 	"minimum-stability": "dev",


### PR DESCRIPTION
This moves the dependency on PHP Parallel Lint and the associated Console Highlighter library from `require-dev` to `require` as most Yoast projects already use and have a dependency on PHP Parallel Lint.

Providing PHP Parallel Lint via YoastCS means that all projects using YoastCS will automatically inherit the dependency and that the version constraints will only need to be managed in one place as of now.

Includes adding a section about PHP Parallel Lint to the README.