### PR TITLE
GH Actions: adjustments as PHP 8.1 has been released

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -84,5 +84,12 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: composer lint
 
-      - name: Run the unit tests
+      - name: Run the unit tests - PHP 5.4 - 8.0
+        if: ${{ matrix.php_version < '8.1' && matrix.php_version != 'latest' }}
         run: composer test
+
+      - name: Run the unit tests - PHP 8.1+
+        if: ${{ matrix.php_version >= '8.1' || matrix.php_version == 'latest'}}
+        run: composer test -- --no-configuration --dont-report-useless-tests
+        env:
+          PHPCS_IGNORE_TESTS: 'PHPCompatibility,WordPress'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         # Note: while WPCS 3.0.0 is under development, the matrix will use `dev-master`.
         # Once it has been released and YoastCS has been made compatible, the matrix should switch (back)
         # WPCS `dev-master` to `dev-develop`.
-        php_version: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php_version: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         phpcs_version: ['3.6.0', 'dev-master']
         wpcs_version: ['2.3.0', 'dev-master']
         experimental: [false]
@@ -37,7 +37,7 @@ jobs:
           # Experimental builds. These are allowed to fail.
 
           # PHP nightly
-          - php_version: '8.1'
+          - php_version: '8.2'
             phpcs_version: 'dev-master'
             wpcs_version: 'dev-master'
             experimental: true
@@ -125,11 +125,11 @@ jobs:
         run: composer lint -- --checkstyle | cs2pr
 
       - name: Run the unit tests - PHP 5.4 - 8.0
-        if: ${{ matrix.php_version != '8.1' }}
+        if: ${{ matrix.php_version < '8.1' }}
         run: composer test
 
       - name: Run the unit tests - PHP 8.1
-        if: ${{ matrix.php_version == '8.1' }}
+        if: ${{ matrix.php_version >= '8.1' }}
         run: composer test -- --no-configuration --dont-report-useless-tests
         env:
           PHPCS_IGNORE_TESTS: 'PHPCompatibility,WordPress'


### PR DESCRIPTION
PHP 8.1 was released last Thursday.

This means that:
* PHP `latest` in `setup-php` has now become PHP 8.1, which means that the "quicktest" workflow needs to special case `latest` due to the use of PHPUnit 7.x (enforced via PHPCS).
* The test builds against PHP 8.1 should no longer be allowed to fail.
* PHP 8.2 is the new "nightly" and builds against it should be allowed to fail (until the release in a years time).