### PR TITLE
GH Actions: auto-cancel previous builds for same branch

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkcs:
     name: 'Basic CS and QA checks'

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### QUICK TEST STAGE ####
   # This is a much quicker test which only runs the unit tests and linting against low/high

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### TEST STAGE ####
   test:


### PR DESCRIPTION
Previously, in Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a `concurrency` configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency