### PR TITLE
Composer: allow the PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,11 @@
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
 		"phpcsstandards/phpcsdevtools": "^1.0"
 	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"scripts": {


### PR DESCRIPTION
The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution