### PR TITLE
Composer: update PHPCS version constraint

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -30,13 +30,13 @@ jobs:
             phpcs_version: 'dev-master'
             wpcs_version: 'dev-master'
           - php_version: 'latest'
-            phpcs_version: '3.6.0'
+            phpcs_version: '3.6.2'
             wpcs_version: '2.3.0'
           - php_version: '5.4'
             phpcs_version: 'dev-master'
             wpcs_version: '2.3.0'
           - php_version: '5.4'
-            phpcs_version: '3.6.0'
+            phpcs_version: '3.6.2'
             wpcs_version: 'dev-master'
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - PHPCS ${{ matrix.phpcs_version }} - WPCS ${{ matrix.wpcs_version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         # Once it has been released and YoastCS has been made compatible, the matrix should switch (back)
         # WPCS `dev-master` to `dev-develop`.
         php_version: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
-        phpcs_version: ['3.6.0', 'dev-master']
+        phpcs_version: ['3.6.2', 'dev-master']
         wpcs_version: ['2.3.0', 'dev-master']
         experimental: [false]
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	},
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.6.0",
+		"squizlabs/php_codesniffer": "^3.6.2",
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7",


### PR DESCRIPTION
PHPCS has released version 3.6.1 and 3.6.2 which contain improved support for PHP 8.0 and 8.1.

Includes:
* Updating the minimum required PHPCS version for the Composer version constraint.
* Updating the test workflow matrixes.

Note: the branch protection conditions will need to be updated for this PR to become mergable.

Ref:
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.6.1
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.6.2