### PR TITLE
GH Actions: always use --no-interaction for Composer

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -43,11 +43,11 @@ jobs:
       - name: 'Composer: adjust dependencies'
         run: |
           # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
-          composer remove --no-update --dev phpunit/phpunit --no-scripts
+          composer remove --no-update --dev phpunit/phpunit --no-scripts --no-interaction
           # Using PHPCS `master` as an early detection system for bugs upstream.
-          composer require --no-update --no-scripts squizlabs/php_codesniffer:"dev-master"
+          composer require --no-update --no-scripts squizlabs/php_codesniffer:"dev-master" --no-interaction
           # Using WPCS `master` (=stable). This can be changed back to `dev-develop` after the WPCS 3.0.0 release.
-          composer require --no-update --no-scripts wp-coding-standards/wpcs:"dev-master"
+          composer require --no-update --no-scripts wp-coding-standards/wpcs:"dev-master" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -66,9 +66,9 @@ jobs:
       - name: 'Composer: adjust dependencies'
         run: |
           # Set the PHPCS version to test against.
-          composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
+          composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
           # Set the WPCS version to test against.
-          composer require --no-update --no-scripts wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}"
+          composer require --no-update --no-scripts wp-coding-standards/wpcs:"${{ matrix.wpcs_version }}" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies


### PR DESCRIPTION
Follow up to #270

Adding `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

(missed a few in the previous commit)