### PR TITLE
New `BrainMonkeyRaceCondition` sniff

### DIFF
--- a/Yoast/Docs/Tools/BrainMonkeyRaceConditionStandard.xml
+++ b/Yoast/Docs/Tools/BrainMonkeyRaceConditionStandard.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<documentation title="BrainMonkey Race Condition">
+    <standard>
+    <![CDATA[
+    When writing tests using the BrainMonkey test utilities, either mock and set an expectation for calls to WP hook functions using `Monkey\Functions\expect()` or set the expectation using `Monkey\Filters\expectApplied()` or `Monkey\Actions\expectDone()`.
+    
+    Do not mix the use of these two types of setting expectations within the same test method as that will cause the tests to fail.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: using either of the function, but not mixing them in the same test.">
+        <![CDATA[
+class MyTest extends TestCase {
+  public function test_using_only_expect() {
+    expect( 'apply_filters' )->once();
+    Functions\expect( "apply_filters" )
+      ->once();
+    Monkey\Functions\expect( 'do_action' )
+      ->once();
+
+    // Do something to satisfy expectations.
+  }
+
+  public function test_expectApplied_Done() {
+    Monkey\Filters\expectApplied( 'filter' )
+      ->with( true );
+
+    Actions\expectDone( "yoast\action_name" )
+      ->with( $param );
+
+    expectDone( 'yoast\action_name' )
+      ->with( $param );
+
+    // Do something to satisfy expectations.
+  }
+}
+        ]]>
+        </code>
+        <code title="Invalid: mixing the functions in the same test.">
+        <![CDATA[
+class MyTest extends TestCase {
+  public function test_mixing_filter_expects() {
+    Functions\expect( "apply_filters" )->once();
+
+    Filters\ExpectApplied( 'filter_name' )
+      ->with( true );
+
+    // Do something to satisfy expectations.
+  }
+
+  public function test_mixing_action_expects() {
+     Expect( 'do_action' /*comment*/)->once();
+
+     Actions\expectDone( 'yoast\action_name' )
+       ->with( $param );
+
+     // Do something to satisfy expectations.
+  }
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Yoast/Sniffs/Tools/BrainMonkeyRaceConditionSniff.php
+++ b/Yoast/Sniffs/Tools/BrainMonkeyRaceConditionSniff.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace YoastCS\Yoast\Sniffs\Tools;
+
+use PHP_CodeSniffer\Util\Tokens;
+use WordPressCS\WordPress\Sniff;
+
+/**
+ * Sniff to detect a particular nasty race condition which can occur in tests using the BrainMonkey utilities.
+ *
+ * @link https://github.com/Yoast/yoastcs/issues/264
+ *
+ * @since 2.3.0
+ *
+ * @package Yoast\YoastCS
+ * @author  Juliette Reinders Folmer
+ */
+class BrainMonkeyRaceConditionSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return [ \T_STRING ];
+	}
+
+	/**
+	 * Processes a sniff when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		if ( \strtolower( $this->tokens[ $stackPtr ]['content'] ) !== 'expect' ) {
+			return;
+		}
+
+		$nextNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		if ( $nextNonEmpty === false || $this->tokens[ $nextNonEmpty ]['code'] !== \T_OPEN_PARENTHESIS ) {
+			// Definitely not a function call.
+			return;
+		}
+
+		$prevNonEmpty = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+		if ( $prevNonEmpty === false
+			|| $this->tokens[ $prevNonEmpty ]['code'] === \T_DOUBLE_COLON
+			|| $this->tokens[ $prevNonEmpty ]['code'] === \T_OBJECT_OPERATOR
+			|| $this->tokens[ $prevNonEmpty ]['type'] === 'T_NULLSAFE_OBJECT_OPERATOR'
+			|| $this->tokens[ $prevNonEmpty ]['code'] === \T_FUNCTION
+		) {
+			// Method call or function declaration, not a function call.
+			return;
+		}
+
+		// Make sure the token is in a class method.
+		if ( empty( $this->tokens[ $stackPtr ]['conditions'] ) ) {
+			return;
+		}
+
+		$conditions = $this->tokens[ $stackPtr ]['conditions'];
+		$conditions = \array_reverse( $conditions, true );
+
+		$seenOO        = false;
+		$seenFn        = false;
+		$functionToken = false;
+
+		foreach ( $conditions as $token => $condition ) {
+			if ( $seenFn === true ) {
+				// First condition after the function condition MUST be OO, otherwise it's not a method.
+				$seenOO = isset( Tokens::$ooScopeTokens[ $condition ] );
+				break;
+			}
+
+			if ( $condition === \T_FUNCTION ) {
+				$functionToken = $token;
+				$seenFn        = true;
+			}
+		}
+
+		if ( $seenFn === false || $seenOO === false || $functionToken === false ) {
+			return;
+		}
+
+		// Check that this is an expect() for one of the hook functions.
+		$params = $this->get_function_call_parameters( $stackPtr );
+		if ( empty( $params ) ) {
+			return;
+		}
+
+		$expected   = Tokens::$emptyTokens;
+		$expected[] = \T_CONSTANT_ENCAPSED_STRING;
+
+		$hasUnexpected = $this->phpcsFile->findNext( $expected, $params[1]['start'], ( $params[1]['end'] + 1 ), true );
+		if ( $hasUnexpected !== false ) {
+			return;
+		}
+
+		$text        = $this->phpcsFile->findNext( Tokens::$emptyTokens, $params[1]['start'], ( $params[1]['end'] + 1 ), true );
+		$textContent = $this->strip_quotes( $this->tokens[ $text ]['content'] );
+		if ( $textContent !== 'apply_filters' && $textContent !== 'do_action' ) {
+			return;
+		}
+
+		// Now walk the contents of the function declaration to see if we can find the other function call.
+		if ( isset( $this->tokens[ $functionToken ]['scope_opener'], $this->tokens[ $functionToken ]['scope_closer'] ) === false ) {
+			// We don't know the start or end of the function.
+			return;
+		}
+
+		$targetContent = 'expectdone';
+		if ( $textContent === 'apply_filters' ) {
+			$targetContent = 'expectapplied';
+		}
+
+		$start = $this->tokens[ $functionToken ]['scope_opener'];
+		$end   = $this->tokens[ $functionToken ]['scope_closer'];
+
+		for ( $i = $start; $i < $end; $i++ ) {
+			if ( $this->tokens[ $i ]['code'] !== \T_STRING ) {
+				continue;
+			}
+
+			if ( \strtolower( $this->tokens[ $i ]['content'] ) !== $targetContent ) {
+				continue;
+			}
+
+			// Make sure it is a function call.
+			$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $i + 1 ), null, true );
+			if ( $next === false || $this->tokens[ $next ]['code'] !== \T_OPEN_PARENTHESIS ) {
+				continue;
+			}
+
+			// Okay, we have found the race condition. Throw error.
+			$message = 'The %s() test method contains both a call to Monkey\Functions\expect( %s ), as well as a call to %s(). This causes a race condition which will cause the tests to fail. Only use one of these in a test.';
+			$data    = [
+				$this->phpcsFile->getDeclarationName( $functionToken ),
+				$this->tokens[ $text ]['content'],
+				( $targetContent === 'expectdone' ) ? 'Monkey\Actions\expectDone' : 'Monkey\Filters\expectApplied',
+			];
+
+			$this->phpcsFile->addError( $message, $functionToken, 'Found', $data );
+			break;
+		}
+	}
+}

--- a/Yoast/Tests/Tools/BrainMonkeyRaceConditionUnitTest.inc
+++ b/Yoast/Tests/Tools/BrainMonkeyRaceConditionUnitTest.inc
@@ -1,0 +1,139 @@
+<?php
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Actions;
+
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Filters\expectApplied;
+use function Brain\Monkey\Actions\expectDone;
+
+// Code outside of a class method should be disregarded.
+Functions\expect( "apply_filters" )->once();
+
+if ($something) {
+    Functions\expect( "apply_filters" )->once();
+	Filters\ExpectApplied( 'filter_name' )
+		->with( true );
+}
+
+function NOT_race_condition_as_outside_class() {
+	Functions\expect( "apply_filters" )->once();
+
+	Filters\ExpectApplied( 'filter_name' )
+		->with( true );
+
+	// Do something to satisfy expectations.
+}
+
+class Expect implements Something {}
+
+class BrainMonkeyBasedTest extends TestCase {
+
+	// Not a function call.
+	const EXPECT = 'something';
+
+	// Function declaration, not call.
+	function expect() {}
+
+	public function test_NOT_race_condition_not_the_expect_we_are_looking_for() {
+		// Static method call.
+		My::expect( 'apply_filters' )->once();
+		parent::expect( 'do_action' )->once();
+
+		// Method call.
+		$obj->expect( 'apply_filters' )->once();
+		$obj->something()?->expect( 'apply_filters' )->once();
+
+		// Missing param.
+		expect()->once();
+
+		// Param dynamic.
+		Functions\expect( $function )->once();
+
+		// Param partially dynamic.
+		Functions\expect( 'apply_filters' . $extra )->once();
+	}
+
+	public function test_NOT_race_condition_expect_not_called_with_hook_functions() {
+		Functions\expect( 'some_other_function' )->once();
+		expect( 'yet_another_function' )->once();
+
+		Filters\expectApplied('filter_name')
+			->with( true );
+
+		Monkey\Actions\expectDone( 'yoast\action_name' )
+			->with( $param );
+
+		// Do something to satisfy expectations.
+	}
+
+	public function test_NOT_race_condition_expectapplieddone_not_found_as_function_calls() {
+		Functions\expect( 'apply_filters' )->once();
+		expect( 'do_action' )->once();
+
+		// Not a function call.
+		Filters\expectApplied;
+		echo expectDone;
+
+		// Do something to satisfy expectations.
+	}
+
+	public function test_NOT_race_condition_only_expect() {
+		expect( 'apply_filters' )->once();
+		Functions\expect( "apply_filters" )->once();
+		Monkey\Functions\expect( 'do_action' )->once();
+
+		// Do something to satisfy expectations.
+	}
+
+	public function test_NOT_race_condition_only_expectApplied_expectDone() {
+		Monkey\Filters\expectApplied( 'filter_name' )
+			->with( true );
+
+		Actions\expectDone( "yoast\action_name" )
+			->with( $param );
+
+		expectDone( 'yoast\action_name' )
+			->with( $param );
+
+		// Do something to satisfy expectations.
+	}
+
+	public function test_filter_race_condition() {
+		Functions\expect  ("apply_filters")->once();
+
+		Filters\ExpectApplied  ( 'filter_name' )
+			->with( true );
+
+		// Do something to satisfy expectations.
+	}
+
+	public function test_action_race_condition() {
+		Expect( 'do_action' /*comment*/)->once();
+
+		Actions\expectDone( 'yoast\action_name' )
+			->with( $param );
+
+		// Do something to satisfy expectations.
+	}
+
+	public function test_filter_race_condition_order_reversed() {
+		expectApplied( /*comment*/ 'filter_name' )
+			->with( true );
+
+		Monkey\Functions\expect( 'apply_filters' /*comment*/)->once();
+
+		// Do something to satisfy expectations.
+	}
+
+	public function test_action_race_condition_order_reversed() {
+		Monkey\Actions\expectDone( 'action_name' )
+			->with( $param );
+
+		Monkey\Functions\expect( 'do_action' )->once();
+
+		// Do something to satisfy expectations.
+	}
+}

--- a/Yoast/Tests/Tools/BrainMonkeyRaceConditionUnitTest.inc
+++ b/Yoast/Tests/Tools/BrainMonkeyRaceConditionUnitTest.inc
@@ -102,7 +102,7 @@ class BrainMonkeyBasedTest extends TestCase {
 	}
 
 	public function test_filter_race_condition() {
-		Functions\expect  ("apply_filters")->once();
+		Functions\expect  ("apply_filters")->twice();
 
 		Filters\ExpectApplied  ( 'filter_name' )
 			->with( true );
@@ -123,7 +123,7 @@ class BrainMonkeyBasedTest extends TestCase {
 		expectApplied( /*comment*/ 'filter_name' )
 			->with( true );
 
-		Monkey\Functions\expect( 'apply_filters' /*comment*/)->once();
+		Monkey\Functions\expect( 'apply_filters' /*comment*/)->times(10);
 
 		// Do something to satisfy expectations.
 	}
@@ -133,6 +133,23 @@ class BrainMonkeyBasedTest extends TestCase {
 			->with( $param );
 
 		Monkey\Functions\expect( 'do_action' )->once();
+
+		// Do something to satisfy expectations.
+	}
+
+	public function test_NOT_race_condition_filter_vs_action() {
+		Functions\expect  ("apply_filters")->times(5);
+
+		Filters\ExpectDone  ( 'filter_name' );
+
+		// Do something to satisfy expectations.
+	}
+
+	public function test_NOT_race_condition_action_vs_filter() {
+		Expect( 'do_action' /*comment*/)->twice();
+
+		Actions\expectApplied( 'yoast\filter_name' )
+			->with( $param );
 
 		// Do something to satisfy expectations.
 	}

--- a/Yoast/Tests/Tools/BrainMonkeyRaceConditionUnitTest.php
+++ b/Yoast/Tests/Tools/BrainMonkeyRaceConditionUnitTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace YoastCS\Yoast\Tests\Tools;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the BrainMonkeyRaceCondition sniff.
+ *
+ * @package Yoast\YoastCS
+ *
+ * @covers  YoastCS\Yoast\Sniffs\Tools\BrainMonkeyRaceConditionSniff
+ */
+class BrainMonkeyRaceConditionUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return [
+			104 => 1,
+			113 => 1,
+			122 => 1,
+			131 => 1,
+		];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return [];
+	}
+}


### PR DESCRIPTION
This new sniffs detects a particular race condition which can occur when writing tests using the BrainMonkey utilities and which causes tests to fail.

Fixes #264

Includes tests.
Includes docs.