### PR TITLE
README: minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Composer will automatically install dependencies, register standards paths, and 
 To include standards as part of a project require them as development dependencies:
 
 ```bash
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer require --dev yoast/yoastcs:"^2.0"
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Typically, (a variation on) the following snippet would be added to the `compose
 ```json
     "scripts" : {
         "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
         ]
     }
 ```


### PR DESCRIPTION
### README: update for Composer 2.2

The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is a non-dev requirement for YoastCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run.

This commit adds the CLI command to set those permissions to the installation instructions.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution

### README: update suggested linting command

The `--show-deprecated` option was added to PHP Parallel Lint some years ago, but never documented, so I never knew it existed.

Enabling this option allows for deprecations which can be detected at compile time to be shown (in contrast to deprecations which can only be detected at run-time).

Refs:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues/81
* https://github.com/JakubOnderka/PHP-Parallel-Lint/pull/94