### PR TITLE
Composer: update version constraints for dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.6.2",
 		"wp-coding-standards/wpcs": "^2.3.0",
-		"phpcompatibility/phpcompatibility-wp": "^2.1.0",
+		"phpcompatibility/phpcompatibility-wp": "^2.1.3",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7",
-		"php-parallel-lint/php-parallel-lint": "^1.3.1",
-		"php-parallel-lint/php-console-highlighter": "^0.5.0"
+		"php-parallel-lint/php-parallel-lint": "^1.3.2",
+		"php-parallel-lint/php-console-highlighter": "^1.0.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",


### PR DESCRIPTION
Various dependencies have had new releases:
* PHPCompatibilityWP 2.1.3 which brings compatibility with WP 5.9.
    Ref: https://github.com/PHPCompatibility/PHPCompatibilityWP/releases
* PHP Parallel Lint 1.3.2 which contains a fix for the checkstyle reports now used in the GH Actions workflows.
    Ref: https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases
* PHP Console Highlighter 1.0.0 which bring PHP 8 compatibility to the syntax highlighting used in Parallel Lint.
    Ref: https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases

Additionally, the following new release has come out, which does not need a change in the version restraints:
* DealerDirect plugin 0.7.2
    Ref: https://github.com/PHPCSStandards/composer-installer/releases