### PR TITLE
Change the minimum_supported_version to WP 5.8

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -31,7 +31,7 @@
 			 Ref: https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
 		-->
 		<properties>
-			<property name="minimum_supported_version" value="5.7"/>
+			<property name="minimum_supported_version" value="5.8"/>
 		</properties>
 
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>


### PR DESCRIPTION
On January 25, 2022, WordPress 5.9 was released. We'll support only the latest 2 WP versions. This PR updates the minimum_supported_version to WP 5.8.
