### PR TITLE
Commenting/FileComment: allow for PHPCS disable annotation in file docblock

### DIFF
--- a/Yoast/Tests/Commenting/FileCommentUnitTest.15.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.15.inc
@@ -1,0 +1,13 @@
+<?php
+/**
+ * File Comment for a file WITH a namespace, but containing an ignore comment. This should NOT be flagged as unnecessary.
+ *
+ * @phpcs:disable
+ */
+
+namespace Yoast\Plugin\Sub;
+
+/**
+ * Class docblock.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.16.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.16.inc
@@ -1,0 +1,13 @@
+<?php
+/**
+ * File Comment for a file WITH a namespace, but containing an ignore comment. This should NOT be flagged as unnecessary.
+ *
+ * @phpcs:disable Yoast
+ */
+
+namespace Yoast\Plugin\Sub;
+
+/**
+ * Class docblock.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.17.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.17.inc
@@ -1,0 +1,15 @@
+<?php
+/**
+ * File Comment for a file WITH a namespace, but containing an ignore comment. This should NOT be flagged as unnecessary.
+ *
+ * @phpcs:disable Some.Other.SniffCode
+ * @phpcs:disable Yoast.Commenting
+ * @phpcs:disable Yet.Another.SniffCode
+ */
+
+namespace Yoast\Plugin\Sub;
+
+/**
+ * Class docblock.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.18.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.18.inc
@@ -1,0 +1,13 @@
+<?php
+/**
+ * File Comment for a file WITH a namespace, but containing an ignore comment. This should NOT be flagged as unnecessary.
+ *
+ * @phpcs:disable Yoast.Commenting.FileComment
+ */
+
+namespace Yoast\Plugin\Sub;
+
+/**
+ * Class docblock.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.19.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.19.inc
@@ -1,0 +1,13 @@
+<?php
+/**
+ * File Comment for a file WITH a namespace, but containing an ignore comment. This should NOT be flagged as unnecessary.
+ *
+ * @phpcs:disable Yoast.Commenting.FileComment.Unnecessary
+ */
+
+namespace Yoast\Plugin\Sub;
+
+/**
+ * Class docblock.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.20.inc
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.20.inc
@@ -1,0 +1,14 @@
+<?php
+/**
+ * File Comment for a file WITH a namespace, and containing irrelevant ignore comments. This should be flagged as unnecessary.
+ *
+ * @phpcs:disable Some.Other.SniffCode
+ * @phpcs:disable Yet.Another.SniffCode
+ */
+
+namespace Yoast\Plugin\Sub;
+
+/**
+ * Class docblock.
+ */
+class Testing {}

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.php
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.php
@@ -49,6 +49,7 @@ class FileCommentUnitTest extends AbstractSniffUnitTest {
 			case 'FileCommentUnitTest.4.inc':
 			case 'FileCommentUnitTest.6.inc':
 			case 'FileCommentUnitTest.14.inc':
+			case 'FileCommentUnitTest.20.inc':
 				return [
 					2 => 1,
 				];


### PR DESCRIPTION
Previously, if a namespaced file had a deliberate docblock which shouldn't be removed, there were two options:
1. Add an `<exclude-pattern>` based selective ignore to the ruleset for the file.
2. Add a `// phpcs:ignore ...` comment ABOVE the file docblock to prevent the docblock from being reported.

This modification changes the sniff to allow for a `phpcs:disable ...` comment for this sniff **_within_** the docblock, which makes for tidier code.

It does so by searching the found file docblock for a PHPCS disable annotation disabling this particular sniff and if found, this will prevent the warning from being thrown.

Includes unit tests.