### PR TITLE
GH Actions: update name of environment variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           tools: cs2pr
         env:
           # Token is needed for the PHPCS 4.x run against source.
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Set Composer up to download only PHPCS from source for PHPCS 4.x.
       # The source is needed to get the base testcase from PHPCS.


### PR DESCRIPTION
`setup-php` has deprecated and replaced an environment variable in a recent release:

> Deprecated `COMPOSER_TOKEN` in favor of `GITHUB_TOKEN`

This updates the workflow for that change.

Refs:
* https://github.com/shivammathur/setup-php/releases/tag/2.21.0
* https://github.com/shivammathur/setup-php#github-composer-authentication