### PR TITLE
Composer/GH Actions: start using PHPCSDevTools 1.2.0

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -71,8 +71,8 @@ jobs:
       # Validate the Docs XML files.
       # @link http://xmlsoft.org/xmllint.html
       # For the build to properly error when validating against a scheme, these each have to be in their own condition.
-      - name: Lint the XML sniff docs
-        run: xmllint --noout ./Yoast/Docs/*/*Standard.xml
+      - name: Validate the XML sniff docs against schema
+        run: xmllint --noout --schema vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd ./Yoast/Docs/*/*Standard.xml
 
       # Check the code-style consistency of the XML ruleset files.
       - name: Check XML ruleset code style

--- a/Yoast/Docs/Commenting/CodeCoverageIgnoreDeprecatedStandard.xml
+++ b/Yoast/Docs/Commenting/CodeCoverageIgnoreDeprecatedStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Code Coverage Ignore Deprecated">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Code Coverage Ignore Deprecated"
+    >
     <standard>
     <![CDATA[
     Deprecated functions and methods should be ignored for code coverage calculations.

--- a/Yoast/Docs/Commenting/CoversTagStandard.xml
+++ b/Yoast/Docs/Commenting/CoversTagStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="PHPUnit Covers Tag">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="PHPUnit Covers Tag"
+    >
     <standard>
     <![CDATA[
     The @covers tag used to annotate which code is coverage by a test should follow the specifications of PHPUnit with regards to the supported annotations.

--- a/Yoast/Docs/Commenting/FileCommentStandard.xml
+++ b/Yoast/Docs/Commenting/FileCommentStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="File Comment">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="File Comment"
+    >
     <standard>
     <![CDATA[
     A file containing a (named) namespace declaration does not need a file docblock.

--- a/Yoast/Docs/Commenting/TestsHaveCoversTagStandard.xml
+++ b/Yoast/Docs/Commenting/TestsHaveCoversTagStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Tests Have Covers tag">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Tests Have Covers Tag"
+    >
     <standard>
     <![CDATA[
     Each test function should have at least one @covers tag annotating which class/method/function is being tested.

--- a/Yoast/Docs/ControlStructures/IfElseDeclarationStandard.xml
+++ b/Yoast/Docs/ControlStructures/IfElseDeclarationStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="If-else Declarations">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="If-else Declarations"
+    >
     <standard>
     <![CDATA[
     The `else` and `elseif` keywords should be on a new line.

--- a/Yoast/Docs/Files/FileNameStandard.xml
+++ b/Yoast/Docs/Files/FileNameStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="File Name">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="File Name"
+    >
     <standard>
     <![CDATA[
     Same as in WP, file names should be lowercase and words should be separated by dashes (not underscores).

--- a/Yoast/Docs/Files/TestDoublesStandard.xml
+++ b/Yoast/Docs/Files/TestDoublesStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Test Doubles">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Test Doubles"
+    >
     <standard>
     <![CDATA[
     Double/Mock test helper classes should be in their own file and placed in a dedicated test doubles sub-directory.

--- a/Yoast/Docs/Namespaces/NamespaceDeclarationStandard.xml
+++ b/Yoast/Docs/Namespaces/NamespaceDeclarationStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Namespace Declarations">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Namespace Declarations"
+    >
     <standard>
     <![CDATA[
     Scoped namespace declarations are not allowed.

--- a/Yoast/Docs/NamingConventions/NamespaceNameStandard.xml
+++ b/Yoast/Docs/NamingConventions/NamespaceNameStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Namespace Name Depth">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Namespace Name Depth"
+    >
     <standard>
     <![CDATA[
     A namespace name is not allowed to be more than 3 levels deep (excluding the prefix).

--- a/Yoast/Docs/NamingConventions/ObjectNameDepthStandard.xml
+++ b/Yoast/Docs/NamingConventions/ObjectNameDepthStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Object Name Depth">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Object Name Depth"
+    >
     <standard>
     <![CDATA[
     The name of objects - classes, interfaces, traits - declared within a namespace should consist of a maximum of three words.

--- a/Yoast/Docs/NamingConventions/ValidHookNameStandard.xml
+++ b/Yoast/Docs/NamingConventions/ValidHookNameStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Valid Hook Name">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Valid Hook Name"
+    >
     <standard>
     <![CDATA[
     Use lowercase letters in action and filter names. Separate words using underscores.

--- a/Yoast/Docs/Tools/BrainMonkeyRaceConditionStandard.xml
+++ b/Yoast/Docs/Tools/BrainMonkeyRaceConditionStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="BrainMonkey Race Condition">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="BrainMonkey Race Condition"
+    >
     <standard>
     <![CDATA[
     When writing tests using the BrainMonkey test utilities, either mock and set an expectation for calls to WP hook functions using `Monkey\Functions\expect()` or set the expectation using `Monkey\Filters\expectApplied()` or `Monkey\Actions\expectDone()`.

--- a/Yoast/Docs/WhiteSpace/FunctionSpacingStandard.xml
+++ b/Yoast/Docs/WhiteSpace/FunctionSpacingStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Function Spacing">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Function Spacing"
+    >
     <standard>
     <![CDATA[
     There should be one blank line before the first function in an OO structure.

--- a/Yoast/Docs/Yoast/AlternativeFunctionsStandard.xml
+++ b/Yoast/Docs/Yoast/AlternativeFunctionsStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Alternative Functions">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Alternative Functions"
+    >
     <standard>
     <![CDATA[
     Discourages the use of certain PHP or WP native functions in favour of Yoast native alternatives.

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"phpcompatibility/php-compatibility": "^9.3.5",
 		"roave/security-advisories": "dev-master",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"phpcsstandards/phpcsdevtools": "^1.0"
+		"phpcsstandards/phpcsdevtools": "^1.2.0"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
### Composer/GH Actions: start using PHPCSDevTools 1.2.0

PHPCSDevTools 1.2.0 introduces an XSD for the XML docs which can accompany sniffs.

This commit:
* Updates the PHPCSDevTools to version 1.2.0.
* Adds a new check against the XSD for all sniff XML Docs files.

Ref: https://github.com/PHPCSStandards/PHPCSDevTools/releases/tag/1.2.0

### Sniff XML docs: add schema to docs