### PR TITLE
Composer: update dependency version constraints

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -30,13 +30,13 @@ jobs:
             phpcs_version: 'dev-master'
             wpcs_version: 'dev-master'
           - php_version: 'latest'
-            phpcs_version: '3.6.2'
+            phpcs_version: '3.7.1'
             wpcs_version: '2.3.0'
           - php_version: '5.4'
             phpcs_version: 'dev-master'
             wpcs_version: '2.3.0'
           - php_version: '5.4'
-            phpcs_version: '3.6.2'
+            phpcs_version: '3.7.1'
             wpcs_version: 'dev-master'
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - PHPCS ${{ matrix.phpcs_version }} - WPCS ${{ matrix.wpcs_version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         # Once it has been released and YoastCS has been made compatible, the matrix should switch (back)
         # WPCS `dev-master` to `dev-develop`.
         php_version: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
-        phpcs_version: ['3.6.2', 'dev-master']
+        phpcs_version: ['3.7.1', 'dev-master']
         wpcs_version: ['2.3.0', 'dev-master']
         experimental: [false]
 

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
 	},
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.6.2",
+		"squizlabs/php_codesniffer": "^3.7.1",
 		"wp-coding-standards/wpcs": "^2.3.0",
-		"phpcompatibility/phpcompatibility-wp": "^2.1.3",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7",
+		"phpcompatibility/phpcompatibility-wp": "^2.1.4",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0"
 	},


### PR DESCRIPTION
* Ensure latest version of PHPCS is used (which includes PHP 8.1 support).
    Refs:
    * https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.1
    * https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.0
* Ensure latest version of PHPCompatibilityWP is used.
    Ref: https://github.com/PHPCompatibility/PHPCompatibilityWP/releases/tag/2.1.4

Includes updating the workflows for the change in the minimum supported PHPCS version.