### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -86,7 +86,7 @@ jobs:
       # @link https://github.com/staabm/annotate-pull-request-from-checkstyle/
       - name: Check PHP code style
         id: phpcs
-        run: composer check-cs -- --report-full --report-checkstyle=./phpcs-report.xml
+        run: composer check-cs -- --no-cache --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install xmllint
         run: |

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -76,8 +76,8 @@ jobs:
         if: ${{ startsWith( matrix.php_version, '8' ) == false && matrix.php_version != 'latest' }}
         uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       # For the PHP 8.0 and higher, we need to install with ignore platform reqs as not all dependencies allow it.
       - name: Install Composer dependencies - with ignore platform
@@ -85,7 +85,7 @@ jobs:
         uses: ramsey/composer-install@v2
         with:
           composer-options: --ignore-platform-reqs
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Verify installed standards
         run: vendor/bin/phpcs -i

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -84,7 +84,7 @@ jobs:
         if: ${{ startsWith( matrix.php_version, '8' ) || matrix.php_version == 'latest' }}
         uses: ramsey/composer-install@v2
         with:
-          composer-options: --ignore-platform-reqs
+          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Verify installed standards

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,14 +39,14 @@ jobs:
         wpcs_version: ['2.3.0', 'dev-master']
         experimental: [false]
 
-        #include:
+        include:
           # Experimental builds. These are allowed to fail.
 
           # PHP nightly
-          #- php_version: '8.3'
-          #  phpcs_version: 'dev-master'
-          #  wpcs_version: 'dev-master'
-          #  experimental: true
+          - php_version: '8.3'
+            phpcs_version: 'dev-master'
+            wpcs_version: 'dev-master'
+            experimental: true
           # Test against WPCS unstable. Re-enable when WPCS is not in dev for the next major.
           #- php_version: '8.0'
           #  phpcs_version: 'dev-master'
@@ -122,7 +122,7 @@ jobs:
         if: ${{ startsWith( matrix.php_version, '8' ) }}
         uses: ramsey/composer-install@v2
         with:
-          composer-options: --ignore-platform-reqs
+          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Verify installed standards

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,8 +114,8 @@ jobs:
         if: ${{ startsWith( matrix.php_version, '8' ) == false }}
         uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       # For the PHP 8/"nightly", we need to install with ignore platform reqs as we're still using PHPUnit 7.
       - name: Install Composer dependencies - with ignore platform
@@ -123,7 +123,7 @@ jobs:
         uses: ramsey/composer-install@v2
         with:
           composer-options: --ignore-platform-reqs
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Verify installed standards
         run: vendor/bin/phpcs -i


### PR DESCRIPTION
### GH Actions: minor simplification

... of the bash `date` command in the earlier pulled cache busting.

### GH Actions: improve performance of the CS step

All the repos in the Yoast organisation contain a `<arg name="cache" value="./.cache/phpcs.cache"/>` directive in the PHPCS ruleset.
This directive makes running PHPCS faster by caching the run results in a file and only scanning changed files when running PHPCS again.

However, when there is no cache available, running with the `cache` option enabled will make PHPCS _slower_ as the cache needs to be created and the file read/write actions slow PHPCS down.

In GH Actions, we are not caching the PHPCS `cache` file, which means that there is cache file available and running with `cache` will be slower.

By adding the `--no-cache` option, the `cache` directive in the ruleset is ignored, which should result in a slightly faster runtime for the CS workflow.

Note: the alternative would be to _cache_ the cache file in GH Actions, but aside from the two very frequently changing repos, there's not much point doing that.

### GH Actions: enable linting and testing against PHP 8.3

While early days for PHP 8.3, as this is a CI related package, it needs to be ready early, so better to start running the lint and test workflows against PHP 8.3 already.