### PR TITLE
Changes for version 2.3.1, including changelog

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -30,13 +30,13 @@ jobs:
             phpcs_version: 'dev-master'
             wpcs_version: 'dev-master'
           - php_version: 'latest'
-            phpcs_version: '3.7.1'
+            phpcs_version: '3.7.2'
             wpcs_version: '2.3.0'
           - php_version: '5.4'
             phpcs_version: 'dev-master'
             wpcs_version: '2.3.0'
           - php_version: '5.4'
-            phpcs_version: '3.7.1'
+            phpcs_version: '3.7.2'
             wpcs_version: 'dev-master'
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - PHPCS ${{ matrix.phpcs_version }} - WPCS ${{ matrix.wpcs_version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         # Once it has been released and YoastCS has been made compatible, the matrix should switch (back)
         # WPCS `dev-master` to `dev-develop`.
         php_version: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
-        phpcs_version: ['3.7.1', 'dev-master']
+        phpcs_version: ['3.7.2', 'dev-master']
         wpcs_version: ['2.3.0', 'dev-master']
         experimental: [false]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+### [2.3.1] - 2023-03-09
+
+#### Changed
+* PHPCS: The default setting for the minimum supported PHP version for repos using YoastCS is now PHP 7.2 (was 5.6).
+* Composer: Supported version of [PHP_CodeSniffer] has been changed from `^3.7.1` to `^3.7.2`.
+
 ### [2.3.0] - 2023-01-09
 
 #### Added

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -126,7 +126,7 @@
 	SNIFF FOR PHP CROSS-VERSION COMPATIBILITY
 	#############################################################################
 	-->
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.2-"/>
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php$</include-pattern>
 	</rule>

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	},
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.7.1",
+		"squizlabs/php_codesniffer": "^3.7.2",
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",


### PR DESCRIPTION
### YoastCS: update minimum support PHP version to 7.2

### Composer: update PHPCS

PHPCS 3.7.2 has been released 🎉 and contains numerous bugfixes we should take advantage of.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.2

### Changelog for the YoastCS 2.3.1 release

Includes all changes in the [2.3.1 milestone](https://github.com/Yoast/yoastcs/milestone/19).