### PR TITLE
CI: start recording code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - develop
     paths-ignore:
       - '**.md'
   pull_request:
@@ -27,6 +28,7 @@ env:
 jobs:
   #### TEST STAGE ####
   test:
+    if: ${{ github.ref != 'refs/heads/develop' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -37,7 +39,9 @@ jobs:
         # You can define jobs here and then augment them with extra variables in `include`,
         # as well as add extra jobs in `include`.
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
-        php_version: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        #
+        # The matrix is set up so as not to duplicate the builds which are run for code coverage.
+        php_version: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2']
         cs_dependencies: ['lowest', 'highest']
         experimental: [false]
 
@@ -154,3 +158,113 @@ jobs:
         run: composer test -- --no-configuration --dont-report-useless-tests
         env:
           PHPCS_IGNORE_TESTS: 'PHPCompatibility,WordPress'
+
+  #### CODE COVERAGE STAGE ####
+  # N.B.: Coverage is only checked on the lowest and highest stable PHP versions
+  # and a low/high of each major for PHPCS.
+  # These builds are left out off the "test" stage so as not to duplicate test runs.
+  coverage:
+    # No use running the coverage builds if there are failing test builds.
+    needs: test
+    # The default condition is success(), but this is false when one of the previous jobs is skipped
+    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # 7.4 should be updated to 8.2 when higher PHPUnit versions can be supported.
+        php_version: ['5.4', '7.4']
+        cs_dependencies: ['lowest', 'highest']
+
+    name: "Coverage${{ matrix.cs_dependencies == 'highest' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - CS Deps ${{ matrix.cs_dependencies }}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # On stable PHPCS versions, allow for PHP deprecation notices.
+      # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+      - name: Setup ini config
+        id: set_ini
+        run: |
+          if [[ "${{ matrix.cs_dependencies }}" != "highest" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
+          else
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php_version }}
+          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+          coverage: xdebug
+          tools: cs2pr
+
+      - name: 'Composer: adjust CS dependencies (high)'
+        if: ${{ matrix.cs_dependencies == 'highest' }}
+        run: |
+          composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ env.PHPCS_HIGHEST }}" --no-interaction
+          composer require --no-update --no-scripts wp-coding-standards/wpcs:"${{ env.WPCS_HIGHEST }}" --no-interaction
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: "Composer: set PHPCS version for tests (low)"
+        if: ${{ matrix.cs_dependencies == 'lowest' }}
+        run: composer update squizlabs/php_codesniffer wp-coding-standards/wpcs --with-dependencies --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
+
+      - name: Verify installed versions
+        run: composer info --no-dev
+
+      - name: Verify installed standards
+        run: vendor/bin/phpcs -i
+
+      # The results of the linting will be shown inline in the PR via the CS2PR tool.
+      # @link https://github.com/staabm/annotate-pull-request-from-checkstyle/
+      - name: Lint against parse errors
+        if: ${{ matrix.cs_dependencies == 'highest' }}
+        run: composer lint -- --checkstyle | cs2pr
+
+      - name: Run the unit tests with code coverage
+        run: composer coverage
+
+      # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
+      - name: Switch to PHP 7.4
+        if: ${{ success() && matrix.php_version != '7.4' }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
+      - name: Install Coveralls
+        if: ${{ success() }}
+        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
+
+      - name: Upload coverage results to Coveralls
+        if: ${{ success() }}
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+          COVERALLS_PARALLEL: true
+          COVERALLS_FLAG_NAME: php-${{ matrix.php_version }}-cs-${{ matrix.cs_dependencies }}
+        run: php-coveralls -v -x build/logs/clover.xml
+
+  coveralls-finish:
+    needs: coverage
+    if: always() && needs.coverage.result == 'success'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.COVERALLS_TOKEN }}
+          parallel-finished: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .cache/phpcs.cache
 phpcs.xml
 phpunit.xml
+build/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Yoast Coding Standards
 
+[![Coverage Status](https://coveralls.io/repos/github/Yoast/yoastcs/badge.svg?branch=develop)](https://coveralls.io/github/Yoast/yoastcs?branch=develop)
+
 Yoast Coding Standards (YoastCS) is a project with rulesets for code style and quality tools to be used in Yoast projects.
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
 		],
 		"test": [
+			"@php ./vendor/phpunit/phpunit/phpunit --filter Yoast --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage"
+		],
+		"coverage": [
 			"@php ./vendor/phpunit/phpunit/phpunit --filter Yoast --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 		],
 		"check-complete": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,8 +21,14 @@
 	<filter>
 		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
 			<directory suffix=".php">Yoast/Sniffs/</directory>
+			<directory suffix=".php">Yoast/Utils/</directory>
 		</whitelist>
 	</filter>
+
+	<logging>
+		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+		<log type="coverage-clover" target="build/logs/clover.xml"/>
+	</logging>
 
 	<php>
 		<env name="PHPCS_IGNORE_TESTS" value="PHPCompatibility,WordPress"/>


### PR DESCRIPTION
### PHPUnit: expand code coverage configuration

* Add missing directory for which coverage should be recorded.
* Add logging configuration.

Includes:
* Ignoring the potentially generated code coverage files in the `build/*` directory to prevent it being committed.
* Adding a script to the `composer.json` file to run code coverage.

### GH Actions: start recording code coverage

This commit updates the GH Actions `test` workflow to record and upload code coverage to Coveralls.

Notes:
* The `test` workflow will now also run for the `develop` branch, but in that case, will _only_ run the coverage jobs.
    This is intentional as otherwise we would not be able to see the code coverage progression over time.
* A new `job` has been added with the steps for the coverage builds.
    These steps largely duplicate the steps in the `test` workflow, but keeping everything in one workflow would make that workflow a lot more complicated with various conditions, so having a separate workflow seemed prudent.
* Coverage will be recorded using `Xdebug` as the code coverage driver.
* Running code coverage is slow, so with a large number of builds, like this repo had, it is prudent to only run code coverage for select builds.
    With that in mind, coverage is only recorded for four builds and only run when the `test` builds have passed - or have been skipped when running against `develop` - to prevent wasting resources.
    The coverage builds are:
    - Low PHP (`5.4`) with high/low PHPCS/WPCS dependencies.
    - High PHP (`7.4`) with high/low PHPCS/WPCS dependencies.
        Note: the high PHP builds _should_ by rights be run against the latest PHP version, but that is a little difficult for this repo as the highest supported PHPUnit version at this time is PHPUnit 7.x and PHPUnit 7.x does not support running code coverage on PHP 8.x.
        Once the PHPUnit version requirements can be widened, the `high` build for code coverage should be adjusted to run on a PHP 8.x version.
* The `php-coveralls/php-coveralls` package is used to convert the coverage information from a format as generated by PHPUnit to a format as can be consumed by Coveralls.
    - The `php-coveralls/php-coveralls` package is not 100% compatible with PHP 8.x (yet). As coverage is not recorded for PHP 8.x for this repo, this is not an issue.
    - As this package is only needed for the upload to Coveralls, the package has **not** been added it to the `composer.json` file, but will be (global) installed in the GH Actions workflow only.
    - For uploading code coverage with PHP < 5.5, `php-coveralls/php-coveralls` `1.x` is needed, but that version of the package doesn't play nice with GH Actions. To get round that, the jobs which run on PHP 5.4, will switch to PHP 7.4 for uploading the code coverage reports.
* Coveralls requires a token to identify the repo and prevent unauthorized uploads.
    This token has been added to the repository secrets.
    People with admin access to the GH repo automatically also have access to the admin settings in Coveralls.
    If ever needed, the Coveralls token can be found (and regenerated) in the Coveralls admin for a repo.
    After regeneration, the token as stored in the GH repo Settings -> Secrets and Variables -> Actions -> Repository secrets should be updated.
* As the workflow send multiple code coverage reports to Coveralls, we need to tell it to process those reports in parallel and give each report a unique name.
    That's what the `COVERALLS_PARALLEL` and `COVERALLS_FLAG_NAME` settings are about.
* The `coveralls-finish` job will signal to Coveralls that all reports have been uploaded.
    This basically gives the "okay" to Coveralls to report on the changes in code coverage via a comment on a GitHub PR as well as via a status check.

The pertinent Coveralls settings used for this repo are:
* "Only send aggregate Coverage updates to SCM": enabled
* "Leave comments": enabled
* "(Comment) Format": compact
* "Use Status API": enabled
* "Coverage threshold for failure": 95%
* "Coverage decrease threshold for failure": 0.5%

### README: show off code coverage 