### PR TITLE
GH Actions: fix the builds

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -46,8 +46,8 @@ jobs:
           composer remove --no-update --dev phpunit/phpunit --no-scripts --no-interaction
           # Using PHPCS `master` as an early detection system for bugs upstream.
           composer require --no-update --no-scripts squizlabs/php_codesniffer:"dev-master" --no-interaction
-          # Using WPCS `master` (=stable). This can be changed back to `dev-develop` after the WPCS 3.0.0 release.
-          composer require --no-update --no-scripts wp-coding-standards/wpcs:"dev-master" --no-interaction
+          # Using WPCS `main` (=stable). This can be changed back to `dev-develop` after the WPCS 3.0.0 release.
+          # composer require --no-update --no-scripts wp-coding-standards/wpcs:"dev-main" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - php_version: 'latest'
             phpcs_version: 'dev-master'
-            wpcs_version: 'dev-master'
+            wpcs_version: '2.3.0'
           - php_version: 'latest'
             phpcs_version: '3.7.2'
             wpcs_version: '2.3.0'
@@ -37,7 +37,7 @@ jobs:
             wpcs_version: '2.3.0'
           - php_version: '5.4'
             phpcs_version: '3.7.2'
-            wpcs_version: 'dev-master'
+            wpcs_version: '2.3.0'
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - PHPCS ${{ matrix.phpcs_version }} - WPCS ${{ matrix.wpcs_version }}"
 
@@ -79,7 +79,7 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # For the PHP 8.0 and higher, we need to install with ignore platform reqs as not all dependencies allow it.
+      # For PHP 8.0 and higher, we need to install with ignore platform reqs as not all dependencies allow it.
       - name: Install Composer dependencies - with ignore platform
         if: ${{ startsWith( matrix.php_version, '8' ) || matrix.php_version == 'latest' }}
         uses: ramsey/composer-install@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Note: while WPCS 3.0.0 is under development, the "highest" release for WPCS should use `dev-master`.
-# Once WPCS 3.0.0 has been released and YoastCS has been made compatible, the matrix should switch (back)
-# WPCS `dev-master` to `dev-develop`.
+# Note: while WPCS 3.0.0 is not (yet) supported by YoastCS, the "highest" release for WPCS should use
+# the last stable WPCS release supported by YoastCS, i.e. `2.3.0`.
+# Once support for WPCS 3.0.0 has been added, the matrix should switch (back) using `dev-develop`.
 env:
   PHPCS_HIGHEST: 'dev-master'
-  WPCS_HIGHEST: 'dev-master'
+  WPCS_HIGHEST: '2.3.0'
 
 jobs:
   #### TEST STAGE ####
@@ -125,7 +125,7 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # For the PHP 8/"nightly", we need to install with ignore platform reqs as we're still using PHPUnit 7.
+      # For PHP 8/"nightly", we need to install with ignore platform reqs as we're still using PHPUnit 7.
       - name: Install Composer dependencies - with ignore platform
         if: ${{ startsWith( matrix.php_version, '8' ) }}
         uses: ramsey/composer-install@v2


### PR DESCRIPTION
WPCS 3.0.0 has been released and the WordPressCS `master` branch has been renamed to `main` and now contains WPCS 3.0.0.

As YoastCS is not (yet) compatible with WPCS 3.0.0, the CI builds are failing.

This commit makes the minimal changes needed to get the CI builds passing again, by:
1. Not updating WPCS to `master` for the CS check in the `basics` workflow.
2. Running the tests against the highest currently supported WPCS release `2.3.0` instead of against `dev-master`.