### PR TITLE
Composer: normalize, script descriptions and other tweaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,5 +63,13 @@
 		"check-complete": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./Yoast"
 		]
+	},
+	"scripts-descriptions": {
+		"lint": "Check the PHP files for parse errors.",
+		"check-cs": "Check the PHP files for code style violations and best practices.",
+		"fix-cs": "Auto-fix code style violations in the PHP files.",
+		"test": "Run the unit tests without code coverage.",
+		"coverage": "Run the unit tests with code coverage.",
+		"check-complete": "Check if all the sniffs have tests and XML documentation."
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,8 @@
 {
 	"name": "yoast/yoastcs",
 	"description": "PHP_CodeSniffer rules for Yoast projects",
+	"license": "MIT",
+	"type": "phpcodesniffer-standard",
 	"keywords": [
 		"phpcs",
 		"standards",
@@ -8,8 +10,6 @@
 		"wordpress",
 		"yoast"
 	],
-	"homepage": "https://github.com/Yoast/yoastcs",
-	"license": "MIT",
 	"authors": [
 		{
 			"name": "Team Yoast",
@@ -17,33 +17,33 @@
 			"homepage": "https://yoast.com"
 		}
 	],
-	"type" : "phpcodesniffer-standard",
+	"homepage": "https://github.com/Yoast/yoastcs",
 	"support": {
 		"issues": "https://github.com/Yoast/yoastcs/issues",
 		"source": "https://github.com/Yoast/yoastcs"
 	},
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.7.2",
-		"wp-coding-standards/wpcs": "^2.3.0",
-		"phpcompatibility/phpcompatibility-wp": "^2.1.4",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
-		"php-parallel-lint/php-console-highlighter": "^1.0.0"
+		"phpcompatibility/phpcompatibility-wp": "^2.1.4",
+		"squizlabs/php_codesniffer": "^3.7.2",
+		"wp-coding-standards/wpcs": "^2.3.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",
-		"roave/security-advisories": "dev-master",
+		"phpcsstandards/phpcsdevtools": "^1.2.1",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"phpcsstandards/phpcsdevtools": "^1.2.1"
+		"roave/security-advisories": "dev-master"
 	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	},
-	"minimum-stability": "dev",
-	"prefer-stable": true,
 	"scripts": {
 		"lint": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"

--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,6 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"scripts": {
-		"config-yoastcs" : [
-			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
-		],
 		"lint": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
 		],


### PR DESCRIPTION
### Composer: remove redundant script

This script hasn't been used (in practice) since the Composer PHPCS Installer plugin became a non-dev dependency, so we may as well remove it.

### Composer: normalize the file

Well, mostly (scripts are not alphabetized, but still grouped by task).

Note: this is done as a one-time only action. The normalize script will **_not_** be run in CI to enforce normalization.

Style has been standardized to `--indent-style=tab --indent-size=1`.

Ref: https://github.com/ergebnis/composer-normalize

### Composer: add script descriptions

These descriptions will be used when a list of the available scripts is requested on the command-line using the `composer list` or `composer run -l` commands.

These descriptions also help document the different scripts for the maintainers of the `composer.json` file.

Ref: https://getcomposer.org/doc/articles/scripts.md#custom-descriptions-