### PR TITLE
Tests: add bootstrap file for PHPUnit

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -100,6 +100,4 @@ jobs:
 
       - name: Run the unit tests - PHP 8.1+
         if: ${{ matrix.php_version >= '8.1' || matrix.php_version == 'latest'}}
-        run: composer test -- --no-configuration --dont-report-useless-tests
-        env:
-          PHPCS_IGNORE_TESTS: 'PHPCompatibility,WordPress'
+        run: composer test -- --no-configuration --bootstrap=./phpunit-bootstrap.php --dont-report-useless-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,9 +155,7 @@ jobs:
 
       - name: Run the unit tests - PHP 8.1+
         if: ${{ matrix.php_version >= '8.1' }}
-        run: composer test -- --no-configuration --dont-report-useless-tests
-        env:
-          PHPCS_IGNORE_TESTS: 'PHPCompatibility,WordPress'
+        run: composer test -- --no-configuration --bootstrap=./phpunit-bootstrap.php --dont-report-useless-tests
 
   #### CODE COVERAGE STAGE ####
   # N.B.: Coverage is only checked on the lowest and highest stable PHP versions

--- a/composer.json
+++ b/composer.json
@@ -55,10 +55,10 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
 		],
 		"test": [
-			"@php ./vendor/phpunit/phpunit/phpunit --filter Yoast --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage"
+			"@php ./vendor/phpunit/phpunit/phpunit --filter Yoast ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage"
 		],
 		"coverage": [
-			"@php ./vendor/phpunit/phpunit/phpunit --filter Yoast --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+			"@php ./vendor/phpunit/phpunit/phpunit --filter Yoast ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 		],
 		"check-complete": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./Yoast"

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * YoastCS: Bootstrap file for running the tests.
+ *
+ * - Load the PHPCS PHPUnit bootstrap file providing cross-version PHPUnit support.
+ *   {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1384}
+ * - Load the Composer autoload file.
+ * - Automatically limit the testing to the YoastCS tests.
+ *
+ * @package Yoast\YoastCS
+ * @since   3.0.0
+ */
+
+use PHP_CodeSniffer\Util\Standards;
+
+if ( \defined( 'PHP_CODESNIFFER_IN_TESTS' ) === false ) {
+	\define( 'PHP_CODESNIFFER_IN_TESTS', true );
+}
+
+/*
+ * Load the necessary PHPCS files.
+ */
+// Get the PHPCS dir from an environment variable.
+$phpcs_dir           = \getenv( 'PHPCS_DIR' );
+$composer_phpcs_path = __DIR__ . '/vendor/squizlabs/php_codesniffer';
+
+if ( $phpcs_dir === false && \is_dir( $composer_phpcs_path ) ) {
+	// PHPCS installed via Composer.
+	$phpcs_dir = $composer_phpcs_path;
+}
+elseif ( $phpcs_dir !== false ) {
+	/*
+	 * PHPCS in a custom directory.
+	 * For this to work, the `PHPCS_DIR` needs to be set in a custom `phpunit.xml` file.
+	 */
+	$phpcs_dir = \realpath( $phpcs_dir );
+}
+
+// Try and load the PHPCS autoloader.
+if ( $phpcs_dir !== false
+	&& \file_exists( $phpcs_dir . '/autoload.php' )
+	&& \file_exists( $phpcs_dir . '/tests/bootstrap.php' )
+) {
+	require_once $phpcs_dir . '/autoload.php';
+	require_once $phpcs_dir . '/tests/bootstrap.php'; // PHPUnit 6.x+ support.
+}
+else {
+	echo 'Uh oh... can\'t find PHPCS.
+
+If you use Composer, please run `composer install`.
+Otherwise, make sure you set a `PHPCS_DIR` environment variable in your phpunit.xml file
+pointing to the PHPCS directory.
+';
+
+	die( 1 );
+}
+
+/*
+ * Set the PHPCS_IGNORE_TEST environment variable to ignore tests from other standards.
+ */
+$yoast_standards = [
+	'Yoast' => true,
+];
+
+$all_standards   = Standards::getInstalledStandards();
+$all_standards[] = 'Generic';
+
+$standards_to_ignore = [];
+foreach ( $all_standards as $standard ) {
+	if ( isset( $yoast_standards[ $standard ] ) === true ) {
+		continue;
+	}
+
+	$standards_to_ignore[] = $standard;
+}
+
+$standards_to_ignore_string = \implode( ',', $standards_to_ignore );
+
+// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv -- This is not production, but test code.
+\putenv( "PHPCS_IGNORE_TESTS={$standards_to_ignore_string}" );
+
+// Clean up.
+unset( $phpcs_dir, $composer_phpcs_path, $all_standards, $standards_to_ignore, $standard, $standards_to_ignore_string );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
 	backupGlobals="true"
+	bootstrap="./phpunit-bootstrap.php"
 	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true"
 	convertErrorsToExceptions="true"
@@ -29,8 +30,4 @@
 		<log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
 		<log type="coverage-clover" target="build/logs/clover.xml"/>
 	</logging>
-
-	<php>
-		<env name="PHPCS_IGNORE_TESTS" value="PHPCompatibility,WordPress"/>
-	</php>
 </phpunit>


### PR DESCRIPTION
As, as of YoastCS 3.0, more external standards will be used, manually maintaining the `PHPCS_IGNORE_TESTS` lists becomes cumbersome.

This commit adds a bootstrap file which will:
* Load the PHPCS autoloader (was previously done from the command-line);
* Will automatically set the `PHPCS_IGNORE_TESTS` environment variable to the correct value to prevent running tests from other standards.