### PR TITLE
GH Actions: automate some label management

### DIFF
--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -1,0 +1,68 @@
+name: Remove outdated labels
+
+on:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    types:
+      - closed
+  issues:
+    types:
+      - closed
+
+jobs:
+  on-pr-merge:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Yoast' && github.event.pull_request.merged == true
+
+    name: Clean up labels on PR merge
+
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            Status: awaiting feedback
+            Status: blocked
+            Status: needs investigation
+            Status: wait for upstream/PHPCSExtra
+            Status: wait for upstream/Slevomat
+            Status: wait for upstream/VIPCS
+            Status: wait for upstream/WordPressCS
+
+  on-pr-close:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Yoast' && github.event_name == 'pull_request_target' && github.event.pull_request.merged == false
+
+    name: Clean up labels on PR close
+
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            Status: awaiting feedback
+            Status: blocked
+            Status: needs investigation
+            Status: wait for upstream/PHPCSExtra
+            Status: wait for upstream/Slevomat
+            Status: wait for upstream/VIPCS
+            Status: wait for upstream/WordPressCS
+
+  on-issue-close:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Yoast' && github.event.issue.state == 'closed'
+
+    name: Clean up labels on issue close
+
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            Status: awaiting feedback
+            Status: blocked
+            Status: needs investigation
+            Status: wait for upstream/PHPCSExtra
+            Status: wait for upstream/Slevomat
+            Status: wait for upstream/VIPCS
+            Status: wait for upstream/WordPressCS


### PR DESCRIPTION
This is a quite straight-forward workflow to just remove some labels which should only be on open issues/open PRs and which should be removed once an issue or PR has been closed/merged.

Just attempting to reduce some manual labour.