### PR TITLE
Composer: update required PHP extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 	},
 	"require": {
 		"php": ">=5.4",
+		"ext-tokenizer": "*",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",


### PR DESCRIPTION
Discovered using the ComposerRequireChecker tool and manually verified (though this was kind of an obvious one).

Ref: https://github.com/maglnet/ComposerRequireChecker