### PR TITLE
YoastCS: fix some tests not running

### DIFF
--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -41,7 +41,7 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function getTestFiles( $testFileBase ) {
 		$sep        = \DIRECTORY_SEPARATOR;
-		$test_files = \glob( \dirname( $testFileBase ) . $sep . 'TestDoublesUnitTests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', \GLOB_BRACE );
+		$test_files = \glob( \dirname( $testFileBase ) . $sep . 'TestDoublesUnitTests' . $sep . 'tests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', \GLOB_BRACE );
 
 		if ( ! empty( $test_files ) ) {
 			return $test_files;
@@ -117,7 +117,7 @@ class TestDoublesUnitTest extends AbstractSniffUnitTest {
 			// In tests/mocks.
 			case 'correct-custom-dir-not-mock.inc':
 				return [
-					3 => 1,
+					4 => 1,
 				];
 
 			case 'not-double-or-mock.inc': // In tests.

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
@@ -42,7 +42,15 @@ class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function getTestFiles( $testFileBase ) {
 		$sep        = \DIRECTORY_SEPARATOR;
-		$test_files = \glob( \dirname( $testFileBase ) . $sep . 'NamespaceNameUnitTests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', \GLOB_BRACE );
+		$test_files = \glob(
+			\dirname( $testFileBase ) . $sep . 'NamespaceNameUnitTests{'
+				. $sep . ','                                  // Files in the "NamespaceNameUnitTests" directory.
+				. $sep . '*' . $sep . ','                     // Files in first-level subdirectories.
+				. $sep . '*' . $sep . '*' . $sep . ','        // Files in second-level subdirectories.
+				. $sep . '*' . $sep . '*' . $sep . '*' . $sep // Files in third-level subdirectories.
+			. '}*.inc',
+			\GLOB_BRACE
+		);
 
 		if ( ! empty( $test_files ) ) {
 			return $test_files;


### PR DESCRIPTION
### Files/TestDoubles: bug fix - not all tests were being run

There was a bug in the `glob` expression used to collect all the test case files, which meant that not all test case files were found and checked during the test runs.

Fixed now. Includes one minor, non-consequential fix to the test expectations.

### NamingConventions/NamespaceName: bug fix - not all tests were being run

There was a bug in the `glob` expression used to collect all the test case files, which meant that not all test case files were found and checked during the test runs.

Fixed now.