### PR TITLE
CS/QA: make all classes final

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -70,6 +70,9 @@
 	<!-- Enforce PSR1 compatible namespaces. -->
 	<rule ref="PSR1.Classes.ClassDeclaration"/>
 
+	<!-- Enforce Final classes to prevent issues with the PHPCS autoloader. -->
+	<rule ref="Universal.Classes.RequireFinalClass"/>
+
 
 	<!--
 	#############################################################################

--- a/Yoast/Reports/Threshold.php
+++ b/Yoast/Reports/Threshold.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Reports\Report;
  *
  * @since 2.2.0
  */
-class Threshold implements Report {
+final class Threshold implements Report {
 
 	/**
 	 * Escape sequence for making text white on the command-line.

--- a/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
+++ b/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since   1.1.0
  */
-class CodeCoverageIgnoreDeprecatedSniff implements Sniff {
+final class CodeCoverageIgnoreDeprecatedSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/Yoast/Sniffs/Commenting/CoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/CoversTagSniff.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  *
  * @since   1.3.0
  */
-class CoversTagSniff implements Sniff {
+final class CoversTagSniff implements Sniff {
 
 	/**
 	 * Regex to check for valid content of a @covers tags.

--- a/Yoast/Sniffs/Commenting/FileCommentSniff.php
+++ b/Yoast/Sniffs/Commenting/FileCommentSniff.php
@@ -27,7 +27,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since   1.2.0
  */
-class FileCommentSniff extends Squiz_FileCommentSniff {
+final class FileCommentSniff extends Squiz_FileCommentSniff {
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.

--- a/Yoast/Sniffs/Commenting/TestsHaveCoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/TestsHaveCoversTagSniff.php
@@ -14,7 +14,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since   1.3.0
  */
-class TestsHaveCoversTagSniff implements Sniff {
+final class TestsHaveCoversTagSniff implements Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -23,7 +23,7 @@ use PHP_CodeSniffer\Util\Common;
  *
  * @since   0.5
  */
-class FileNameSniff implements Sniff {
+final class FileNameSniff implements Sniff {
 
 	/**
 	 * List of prefixes for object structures.

--- a/Yoast/Sniffs/Files/TestDoublesSniff.php
+++ b/Yoast/Sniffs/Files/TestDoublesSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  *
  * @since   1.0.0
  */
-class TestDoublesSniff implements Sniff {
+final class TestDoublesSniff implements Sniff {
 
 	/**
 	 * Relative paths to the directories where the test doubles/mocks are allowed to be placed.

--- a/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
@@ -24,7 +24,7 @@ use YoastCS\Yoast\Utils\CustomPrefixesTrait;
  *
  * @since   2.0.0
  */
-class NamespaceNameSniff implements Sniff {
+final class NamespaceNameSniff implements Sniff {
 
 	use CustomPrefixesTrait;
 

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -12,7 +12,7 @@ use WordPressCS\WordPress\Sniff as WPCS_Sniff;
  *
  * @since   2.0.0
  */
-class ObjectNameDepthSniff extends WPCS_Sniff {
+final class ObjectNameDepthSniff extends WPCS_Sniff {
 
 	/**
 	 * Maximum number of words.

--- a/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -32,7 +32,7 @@ use YoastCS\Yoast\Utils\CustomPrefixesTrait;
  *
  * @since   2.0.0
  */
-class ValidHookNameSniff extends WPCS_ValidHookNameSniff {
+final class ValidHookNameSniff extends WPCS_ValidHookNameSniff {
 
 	use CustomPrefixesTrait;
 

--- a/Yoast/Sniffs/Tools/BrainMonkeyRaceConditionSniff.php
+++ b/Yoast/Sniffs/Tools/BrainMonkeyRaceConditionSniff.php
@@ -15,7 +15,7 @@ use WordPressCS\WordPress\Sniff;
  * @package Yoast\YoastCS
  * @author  Juliette Reinders Folmer
  */
-class BrainMonkeyRaceConditionSniff extends Sniff {
+final class BrainMonkeyRaceConditionSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/Yoast/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/Yoast/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since   1.0.0
  */
-class FunctionSpacingSniff extends Squiz_FunctionSpacingSniff {
+final class FunctionSpacingSniff extends Squiz_FunctionSpacingSniff {
 
 	/**
 	 * The number of blank lines between functions.

--- a/Yoast/Sniffs/Yoast/AlternativeFunctionsSniff.php
+++ b/Yoast/Sniffs/Yoast/AlternativeFunctionsSniff.php
@@ -12,7 +12,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *
  * @since   1.3.0
  */
-class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+final class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
@@ -13,7 +13,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers  YoastCS\Yoast\Sniffs\Commenting\CodeCoverageIgnoreDeprecatedSniff
  */
-class CodeCoverageIgnoreDeprecatedUnitTest extends AbstractSniffUnitTest {
+final class CodeCoverageIgnoreDeprecatedUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.php
@@ -13,7 +13,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers  YoastCS\Yoast\Sniffs\Commenting\CoversTagSniff
  */
-class CoversTagUnitTest extends AbstractSniffUnitTest {
+final class CoversTagUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.php
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.php
@@ -13,7 +13,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers  YoastCS\Yoast\Sniffs\Commenting\FileCommentSniff
  */
-class FileCommentUnitTest extends AbstractSniffUnitTest {
+final class FileCommentUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
@@ -13,7 +13,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers  YoastCS\Yoast\Sniffs\Commenting\TestsHaveCoversTagSniff
  */
-class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
+final class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -14,7 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers  YoastCS\Yoast\Sniffs\Files\FileNameSniff
  */
-class FileNameUnitTest extends AbstractSniffUnitTest {
+final class FileNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Error files with the expected nr of errors.

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -14,7 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers  YoastCS\Yoast\Sniffs\Files\TestDoublesSniff
  */
-class TestDoublesUnitTest extends AbstractSniffUnitTest {
+final class TestDoublesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Set CLI values before the file is tested.

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @covers  YoastCS\Yoast\Sniffs\NamingConventions\NamespaceNameSniff
  * @covers  YoastCS\Yoast\Utils\CustomPrefixesTrait
  */
-class NamespaceNameUnitTest extends AbstractSniffUnitTest {
+final class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Set CLI values before the file is tested.

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
@@ -13,7 +13,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers  YoastCS\Yoast\Sniffs\NamingConventions\ObjectNameDepthSniff
  */
-class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
+final class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @covers  YoastCS\Yoast\Sniffs\NamingConventions\ValidHookNameSniff
  * @covers  YoastCS\Yoast\Utils\CustomPrefixesTrait
  */
-class ValidHookNameUnitTest extends AbstractSniffUnitTest {
+final class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Set warnings level to 3 to trigger suggestions as warnings.

--- a/Yoast/Tests/Tools/BrainMonkeyRaceConditionUnitTest.php
+++ b/Yoast/Tests/Tools/BrainMonkeyRaceConditionUnitTest.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers  YoastCS\Yoast\Sniffs\Tools\BrainMonkeyRaceConditionSniff
  */
-class BrainMonkeyRaceConditionUnitTest extends AbstractSniffUnitTest {
+final class BrainMonkeyRaceConditionUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -13,7 +13,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers  YoastCS\Yoast\Sniffs\WhiteSpace\FunctionSpacingSniff
  */
-class FunctionSpacingUnitTest extends AbstractSniffUnitTest {
+final class FunctionSpacingUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.php
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.php
@@ -13,7 +13,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers  YoastCS\Yoast\Sniffs\Yoast\AlternativeFunctionsSniff
  */
-class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
+final class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.


### PR DESCRIPTION
The PHPCS native autoloader which YoastCS uses, doesn't always play nice with sniffs extending other sniffs, which can lead to fatal "Class already declared" errors.

With this in mind, all YoastCS classes will now be made `final`.

This will now also be enforced via a sniff available from PHPCSExtra.

Note: this is a breaking change!