### PR TITLE
Docs: add `@uses` tags for inherited public properties

### DIFF
--- a/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
@@ -20,6 +20,8 @@ use YoastCS\Yoast\Utils\CustomPrefixesTrait;
  * placed in.
  *
  * @since 2.0.0
+ *
+ * @uses \YoastCS\Yoast\Utils\CustomPrefixesTrait::$prefixes
  */
 final class NamespaceNameSniff implements Sniff {
 

--- a/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -28,6 +28,8 @@ use YoastCS\Yoast\Utils\CustomPrefixesTrait;
  *            changed to an error and only namespace-like prefixes should be allowed.}
  *
  * @since 2.0.0
+ *
+ * @uses \YoastCS\Yoast\Utils\CustomPrefixesTrait::$prefixes
  */
 final class ValidHookNameSniff extends WPCS_ValidHookNameSniff {
 


### PR DESCRIPTION
Some sniffs use traits and inherit `public` properties, which can be set from a ruleset, from a trait.

To make this more obvious, annotate inherited `public` properties for a sniff via a `@uses` tag.