### PR TITLE
YoastCS: upgrade to WordPressCS 3.0.1

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1' # Can be updated to "latest" once PHPCS 3.8.0 has been released.
           coverage: none
           tools: cs2pr
 
@@ -48,14 +48,12 @@ jobs:
 
       # Use the WIP/develop branches of all CS dependencies as an early detection system for bugs upstream.
       - name: 'Composer: adjust dependencies - use dev versions of CS dependencies'
-        # Note: while WPCS 3.0.0 is not yet supported, WPCS will not be updated.
-        # Once YoastCS has been updated for WPCS 3.0.0, WPCS dev-develop should be added (back) to this command.
-        # wp-coding-standards/wpcs:"dev-develop"
         run: >
           composer require --no-update --no-scripts --no-interaction
           squizlabs/php_codesniffer:"dev-master"
           phpcsstandards/phpcsutils:"dev-develop"
           phpcsstandards/phpcsextra:"dev-develop"
+          wp-coding-standards/wpcs:"dev-develop"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -58,12 +58,11 @@ jobs:
 
       - name: "Composer: set PHPCS dependencies for tests (dev)"
         if: ${{ matrix.cs_dependencies == 'dev' }}
-        # Note: while WPCS 3.0.0 is not yet supported, WPCS will not be updated for the `dev` builds.
-        # Once YoastCS has been updated for WPCS 3.0.0, WPCS dev-develop should be added to this command.
         run: >
           composer require --no-update --no-scripts --no-interaction --ignore-platform-req=php+
           squizlabs/php_codesniffer:"dev-master"
           phpcsstandards/phpcsutils:"dev-develop"
+          wp-coding-standards/wpcs:"dev-develop"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Note: while WPCS 3.0.0 is not (yet) supported by YoastCS, the "highest" release for WPCS should use
-# the last stable WPCS release supported by YoastCS, i.e. `2.3.0`.
-# Once support for WPCS 3.0.0 has been added, the matrix should switch (back) using `dev-develop`.
 env:
   PHPCS_HIGHEST: 'dev-master'
   UTILS_HIGHEST: 'dev-develop'
-  WPCS_HIGHEST: '2.3.0'
+  WPCS_HIGHEST: 'dev-develop'
 
 jobs:
   #### TEST STAGE ####
@@ -92,12 +89,11 @@ jobs:
 
       - name: "Composer: set PHPCS dependencies for tests (dev)"
         if: ${{ matrix.cs_dependencies == 'dev' }}
-        # Note: while WPCS 3.0.0 is not yet supported, WPCS will not be updated for the `dev` builds.
-        # Once YoastCS has been updated for WPCS 3.0.0, WPCS dev-develop should be added to this command.
         run: >
           composer require --no-update --no-scripts --no-interaction --ignore-platform-req=php+
           squizlabs/php_codesniffer:"${{ env.PHPCS_HIGHEST }}"
           phpcsstandards/phpcsutils:"${{ env.UTILS_HIGHEST }}"
+          wp-coding-standards/wpcs:"${{ env.WPCS_HIGHEST }}"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
@@ -189,12 +185,11 @@ jobs:
 
       - name: "Composer: set PHPCS dependencies for tests (dev)"
         if: ${{ matrix.cs_dependencies == 'dev' }}
-        # Note: while WPCS 3.0.0 is not yet supported, WPCS will not be updated for the `dev` builds.
-        # Once YoastCS has been updated for WPCS 3.0.0, WPCS dev-develop should be added to this command.
         run: >
           composer require --no-update --no-scripts --no-interaction
           squizlabs/php_codesniffer:"${{ env.PHPCS_HIGHEST }}"
           phpcsstandards/phpcsutils:"${{ env.UTILS_HIGHEST }}"
+          wp-coding-standards/wpcs:"${{ env.WPCS_HIGHEST }}"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -57,6 +57,9 @@
 		<!-- Sniffs are not run in the context of WordPress. -->
 		<exclude name="WordPress.Security"/>
 		<exclude name="WordPress.WP"/>
+
+		<!-- Exclude select "modern PHP" sniffs, which conflict with the minimum supported PHP version of this package. -->
+		<exclude name="Modernize.FunctionCalls.Dirname.Nested"/><!-- PHP 7.0+. -->
 	</rule>
 
 	<!-- While PHPCompatibility is already included in the Yoast ruleset, it uses

--- a/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
+++ b/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
@@ -55,7 +55,6 @@ final class CodeCoverageIgnoreDeprecatedSniff implements Sniff {
 			break;
 		}
 
-
 		if ( $tokens[ $commentEnd ]['code'] !== \T_DOC_COMMENT_CLOSE_TAG ) {
 			// Function without (proper) docblock. Not our concern.
 			return;

--- a/Yoast/Sniffs/Files/TestDoublesSniff.php
+++ b/Yoast/Sniffs/Files/TestDoublesSniff.php
@@ -134,7 +134,6 @@ final class TestDoublesSniff implements Sniff {
 			$name_contains_double_or_mock = true;
 		}
 
-
 		if ( empty( $this->target_paths ) === true ) {
 			if ( $name_contains_double_or_mock === true ) {
 				// No valid target paths found.

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -4,14 +4,20 @@ namespace YoastCS\Yoast\Sniffs\NamingConventions;
 
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\ObjectDeclarations;
+use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
+use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
 use WordPressCS\WordPress\Sniff as WPCS_Sniff;
 
 /**
  * Check the number of words in object names declared within a namespace.
  *
  * @since 2.0.0
+ *
+ * @uses \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
 final class ObjectNameDepthSniff extends WPCS_Sniff {
+
+	use IsUnitTestTrait;
 
 	/**
 	 * Maximum number of words.
@@ -88,7 +94,7 @@ final class ObjectNameDepthSniff extends WPCS_Sniff {
 
 		// Handle names which are potentially in CamelCaps.
 		if ( \strpos( $snakecase_object_name, '_' ) === false ) {
-			$snakecase_object_name = self::get_snake_case_name_suggestion( $snakecase_object_name );
+			$snakecase_object_name = SnakeCaseHelper::get_suggestion( $snakecase_object_name );
 		}
 
 		$parts      = \explode( '_', $snakecase_object_name );
@@ -99,7 +105,7 @@ final class ObjectNameDepthSniff extends WPCS_Sniff {
 		 */
 		$last = \array_pop( $parts );
 		if ( isset( $this->test_suffixes[ $last ] ) ) {
-			if ( $this->test_suffixes[ $last ] === true && $this->is_test_class( $stackPtr ) ) {
+			if ( $this->test_suffixes[ $last ] === true && $this->is_test_class( $this->phpcsFile, $stackPtr ) ) {
 				--$part_count;
 			}
 			else {

--- a/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -167,33 +167,33 @@ final class ValidHookNameSniff extends WPCS_ValidHookNameSniff {
 	 * plugin prefix for hook names and remembers whether a prefix was found to allow
 	 * checking whether it was the correct one.
 	 *
-	 * @param string $string         The target string.
+	 * @param string $text_string    The target string.
 	 * @param string $regex          The punctuation regular expression to use.
 	 * @param string $transform_type Whether to do a partial or complete transform.
 	 *                               Valid values are: 'full', 'case', 'punctuation'.
 	 * @return string
 	 */
-	protected function transform( $string, $regex, $transform_type = 'full' ) {
+	protected function transform( $text_string, $regex, $transform_type = 'full' ) {
 
 		if ( empty( $this->validated_prefixes ) ) {
-			return parent::transform( $string, $regex, $transform_type );
+			return parent::transform( $text_string, $regex, $transform_type );
 		}
 
 		if ( $this->first_string === '' ) {
-			$this->first_string = $string;
+			$this->first_string = $text_string;
 		}
 
 		// Not the first text string.
-		if ( $string !== $this->first_string ) {
-			return parent::transform( $string, $regex, $transform_type );
+		if ( $text_string !== $this->first_string ) {
+			return parent::transform( $text_string, $regex, $transform_type );
 		}
 
 		// Repeated call for the first text string.
 		if ( $this->found_prefix !== '' ) {
-			$string = \substr( $string, \strlen( $this->found_prefix ) );
+			$text_string = \substr( $text_string, \strlen( $this->found_prefix ) );
 		}
 
-		return $this->found_prefix . parent::transform( $string, $regex, $transform_type );
+		return $this->found_prefix . parent::transform( $text_string, $regex, $transform_type );
 	}
 
 	/**

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
@@ -68,4 +68,3 @@ final class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
 		}
 	}
 }
-

--- a/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -82,4 +82,3 @@ final class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 		];
 	}
 }
-

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -41,7 +41,7 @@
 			 Ref: https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
 		-->
 		<properties>
-			<property name="minimum_supported_version" value="6.2"/>
+			<property name="minimum_wp_version" value="6.2"/>
 		</properties>
 
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>
@@ -76,13 +76,13 @@
 		<exclude name="Yoast.Commenting.FileComment.CopyrightTagOrder"/>
 
 		<!-- WPCS demands long arrays. YoastCS demands short arrays. -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
 
 		<!-- Demanding Yoda conditions is stupid. -->
 		<exclude name="WordPress.PHP.YodaConditions"/>
 
 		<!-- A while loop is the only valid control structure where an assignment can be justified. -->
-		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
+		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
 
 		<!-- If a conscious choice has been made for a non-strict comparison, that's ok.
 			 I.e. when `strict` has been explicitely set to `false` in an array comparison,
@@ -152,23 +152,11 @@
 	<!-- Demand that "else(if)" is on a new line after the scope closer of the preceding if. -->
 	<rule ref="Universal.ControlStructures.IfElseDeclaration"/>
 
-	<!-- Disallow namespace declarations without a namespace name. -->
-	<rule ref="Universal.Namespaces.DisallowDeclarationWithoutName"/>
-
-	<!-- Disallow namespace declarations using the curly brace syntax. -->
-	<rule ref="Universal.Namespaces.DisallowCurlyBraceSyntax"/>
-
-	<!-- Disallow declaring multiple namespaces within one file. -->
-	<rule ref="Universal.Namespaces.OneDeclarationPerFile"/>
-
 	<!-- Error prevention: Make sure the condition in a inline if declaration is bracketed. -->
 	<rule ref="Squiz.ControlStructures.InlineIfDeclaration"/>
 
 	<!-- Error prevention: Make sure arithmetics are bracketed. -->
 	<rule ref="Squiz.Formatting.OperatorBracket.MissingBrackets"/>
-
-	<!-- CS: no blank line between the content of a function and a function close brace.-->
-	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
 
 	<!-- CS: ensure exactly one blank line before each property declaration. -->
 	<rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
@@ -192,31 +180,6 @@
 		</properties>
 	</rule>
 
-	<!-- Error prevention: Ensure no git conflicts make it into the code base. -->
-	<!-- PHPCS 3.4.0: This sniff will be added to WPCS in due time and can then be removed from this ruleset.
-		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1500 -->
-	<rule ref="Generic.VersionControl.GitMergeConflict"/>
-
-	<!-- CS: no space between an increment/decrement operator and the variable it applies to. -->
-	<!-- PHPCS 3.4.0: This sniff will be added to WPCS in due time and can then be removed from this ruleset.
-		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1511 -->
-	<rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
-
-	<!-- QA: Function declarations should not contain parameters which will never be used. -->
-	<!-- PHPCS 3.4.0: This sniff will be added to WPCS in due time and can then be removed from this ruleset.
-		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1510 -->
-	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.Found"/>
-	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed"/>
-
-	<!-- CS: Ensure consistent whitespace around spread operators. -->
-	<!-- PHPCS 3.5.0: This sniff will be added to WPCS in due time and can then be removed from this ruleset.
-		 Related: https://github.com/WordPress/WordPress-Coding-Standards/issues/1762 -->
-	<rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter"/>
-
-	<!-- CS: Disallow a leading backslash at the start of an import use statement. -->
-	<!-- PHPCS 3.5.0: This sniff may be added to WPCS in due time and can then be removed from this ruleset. -->
-	<rule ref="PSR12.Files.ImportStatement"/>
-
 	<!-- CS: Enforces that a PHP open tag is on a line by itself when used at the start of a PHP-only file. -->
 	<!-- PHPCS 3.5.0: This sniff may be added to WPCS in due time and can then be removed from this ruleset. -->
 	<rule ref="PSR12.Files.OpenTag"/>
@@ -229,6 +192,18 @@
 	</rule>
 	<rule ref="Squiz.Commenting.InlineComment.NoSpaceBefore">
 		<exclude-pattern>*/index\.php</exclude-pattern>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	SNIFFS TO ENFORCE CODE MODERNIZATION
+	#############################################################################
+	-->
+
+	<!-- Undo the WPCS-Extra silencing of the "no nested dirnames, use $levels" notice (PHP 7.0+). -->
+	<rule ref="Modernize.FunctionCalls.Dirname.Nested">
+		<severity>5</severity>
 	</rule>
 
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"phpcsstandards/phpcsextra": "^1.1.2",
 		"phpcsstandards/phpcsutils": "^1.0.8",
 		"squizlabs/php_codesniffer": "^3.7.2",
-		"wp-coding-standards/wpcs": "^2.3.0"
+		"wp-coding-standards/wpcs": "^3.0.1"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",


### PR DESCRIPTION
### Composer: use WordPressCS 3.0.1+

* Update the dependency.
* Make the associated workflow adjustments.
* Update the YoastCS ruleset for WPCS 3.0:
    - Update a renamed property name.
    - Update sniff references for sniffs which have been swopped over to other sniffs.
    - Remove inclusion of various sniffs which are now included in WPCS (Core/Extra) or have an equivalent included.
    - Undo the silencing of the `Modernize.FunctionCalls.Dirname.Nested` (PHP 7.0+) error code as the majority of the Yoast repos have a PHP 7.2 minimum.
    - Redo the silencing of the `Modernize.FunctionCalls.Dirname.Nested` (PHP 7.0+) error code specifically for the YoastCS codebase as it still has a PHP 5.4 minimum.

Refs:
* https://make.wordpress.org/core/2023/08/21/wordpresscs-3-0-0-is-now-available/
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.0.0
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.0.1
* https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-ruleset-maintainers
* https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-Developers-of-external-standards

### NamingConventions/ObjectNameDepth: account for upstream WPCS changes

Update some function calls using WPCS native utilities, which still exist, but have been moved around or have a changed signature.

Ref:
* https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-Developers-of-external-standards

### NamingConventions/ValidHookName::transform(): sync parameter names

The parameter name of the upstream method was updated in WPCS 3.0.0 to not overlap with a reserved keyword.
And for potential future support of function calls to sniff methods using named parameters, the signature of a method in a child class overloading a method in a parent class should be kept in sync.

This makes it so for the `NamingConventions/ValidHookName::transform()` method.

### CS: minor tweaks to comply with WordPressCS 3.0 