### PR TITLE
YoastCS: drop support PHP < 7.2 & modernize the codebase

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['5.4', 'latest']
+        php_version: ['7.2', 'latest']
         cs_dependencies: ['lowest', 'stable']
 
         include:
@@ -96,7 +96,7 @@ jobs:
         if: matrix.cs_dependencies == 'stable'
         run: composer lint
 
-      - name: Run the unit tests - PHP 5.4 - 8.0
+      - name: Run the unit tests - PHP 7.2 - 8.0
         if: ${{ matrix.php_version < '8.1' && matrix.php_version != 'latest' }}
         run: composer test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,19 +37,17 @@ jobs:
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php_version: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2']
+        php_version: ['7.3', '8.0', '8.1', '8.2']
         cs_dependencies: ['lowest', 'stable']
 
         include:
           # Make the matrix complete (when combined with the code coverage builds).
-          - php_version: '5.4'
+          - php_version: '7.2'
             cs_dependencies: 'stable'
           - php_version: '7.4'
             cs_dependencies: 'stable'
 
           # Test against dev versions of all CS dependencies with select PHP versions for early detection of issues.
-          - php_version: '7.0'
-            cs_dependencies: 'dev'
           - php_version: '8.0'
             cs_dependencies: 'dev'
           - php_version: '8.2'
@@ -132,7 +130,7 @@ jobs:
         if: ${{ matrix.cs_dependencies == 'stable' }}
         run: composer lint -- --checkstyle | cs2pr
 
-      - name: Run the unit tests - PHP 5.4 - 8.0
+      - name: Run the unit tests - PHP 7.2 - 8.0
         if: ${{ matrix.php_version < '8.1' }}
         run: composer test
 
@@ -155,7 +153,7 @@ jobs:
     strategy:
       matrix:
         # 7.4 should be updated to 8.x when higher PHPUnit versions can be supported.
-        php_version: ['5.4', '7.4']
+        php_version: ['7.2', '7.4']
         cs_dependencies: ['lowest', 'dev']
 
     name: "Coverage${{ matrix.cs_dependencies == 'stable' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - CS Deps ${{ matrix.cs_dependencies }}"

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -37,9 +37,6 @@
 	#############################################################################
 	-->
 
-	<!-- YoastCS supports PHP 5.4 or higher. -->
-	<config name="testVersion" value="5.4-"/>
-
 	<rule ref="Yoast">
 
 		<!-- Conflicts with PHPCS autoloading of sniffs. -->
@@ -57,9 +54,6 @@
 		<!-- Sniffs are not run in the context of WordPress. -->
 		<exclude name="WordPress.Security"/>
 		<exclude name="WordPress.WP"/>
-
-		<!-- Exclude select "modern PHP" sniffs, which conflict with the minimum supported PHP version of this package. -->
-		<exclude name="Modernize.FunctionCalls.Dirname.Nested"/><!-- PHP 7.0+. -->
 	</rule>
 
 	<!-- While PHPCompatibility is already included in the Yoast ruleset, it uses

--- a/Yoast/Reports/Threshold.php
+++ b/Yoast/Reports/Threshold.php
@@ -27,35 +27,35 @@ final class Threshold implements Report {
 	 *
 	 * @var string
 	 */
-	const WHITE = "\033[1m";
+	private const WHITE = "\033[1m";
 
 	/**
 	 * Escape sequence for making text red on the command-line.
 	 *
 	 * @var string
 	 */
-	const RED = "\033[31m";
+	private const RED = "\033[31m";
 
 	/**
 	 * Escape sequence for making text green on the command-line.
 	 *
 	 * @var string
 	 */
-	const GREEN = "\033[32m";
+	private const GREEN = "\033[32m";
 
 	/**
 	 * Escape sequence for making text orange/yellow on the command-line.
 	 *
 	 * @var string
 	 */
-	const YELLOW = "\033[33m";
+	private const YELLOW = "\033[33m";
 
 	/**
 	 * Escape sequence for resetting the text colour.
 	 *
 	 * @var string
 	 */
-	const RESET = "\033[0m";
+	private const RESET = "\033[0m";
 
 	/**
 	 * Generate a partial report for a single processed file.

--- a/Yoast/Sniffs/Commenting/CoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/CoversTagSniff.php
@@ -24,7 +24,7 @@ final class CoversTagSniff implements Sniff {
 	 *
 	 * @var string
 	 */
-	const VALID_CONTENT_REGEX = '(?:\\\\?(?:(?<OOName>[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)\\\\)*(?P>OOName)(?:<extended>|::<[!]?(?:public|protected|private)>|::(?<functionName>(?!public$|protected$|private$)(?P>OOName)))?|::(?P>functionName)|\\\\?(?:(?P>OOName)\\\\)+(?P>functionName))';
+	private const VALID_CONTENT_REGEX = '(?:\\\\?(?:(?<OOName>[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)\\\\)*(?P>OOName)(?:<extended>|::<[!]?(?:public|protected|private)>|::(?<functionName>(?!public$|protected$|private$)(?P>OOName)))?|::(?P>functionName)|\\\\?(?:(?P>OOName)\\\\)+(?P>functionName))';
 
 	/**
 	 * Base error message.
@@ -33,7 +33,7 @@ final class CoversTagSniff implements Sniff {
 	 *
 	 * @var string
 	 */
-	const ERROR_MSG = 'Invalid @covers annotation found.';
+	private const ERROR_MSG = 'Invalid @covers annotation found.';
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -25,6 +25,17 @@ use PHPCSUtils\Utils\ObjectDeclarations;
 final class FileNameSniff implements Sniff {
 
 	/**
+	 * Object tokens to search for in a file.
+	 *
+	 * @var array<int|string>
+	 */
+	private const NAMED_OO_TOKENS = [
+		\T_CLASS,
+		\T_INTERFACE,
+		\T_TRAIT,
+	];
+
+	/**
 	 * List of prefixes for object structures.
 	 *
 	 * These prefixes do not need to be reflected in the file name.
@@ -57,17 +68,6 @@ final class FileNameSniff implements Sniff {
 	 * @var string[]
 	 */
 	public $excluded_files_strict_check = [];
-
-	/**
-	 * Object tokens to search for in a file.
-	 *
-	 * @var (int|string)[]
-	 */
-	private $oo_tokens = [
-		\T_CLASS,
-		\T_INTERFACE,
-		\T_TRAIT,
-	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -118,7 +118,7 @@ final class FileNameSniff implements Sniff {
 		$expected   = \strtolower( \str_replace( '_', '-', $file_name ) );
 
 		if ( $this->is_file_excluded( $phpcsFile, $file ) === false ) {
-			$oo_structure = $phpcsFile->findNext( $this->oo_tokens, $stackPtr );
+			$oo_structure = $phpcsFile->findNext( self::NAMED_OO_TOKENS, $stackPtr );
 			if ( $oo_structure !== false ) {
 
 				$tokens = $phpcsFile->getTokens();

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -20,6 +20,20 @@ final class ObjectNameDepthSniff extends WPCS_Sniff {
 	use IsUnitTestTrait;
 
 	/**
+	 * Suffixes commonly used for classes in the test suites.
+	 *
+	 * The key is the suffix. The value indicates whether this suffix is
+	 * only allowed when the class extends a known test class.
+	 *
+	 * @var array<string, bool>
+	 */
+	private const TEST_SUFFIXES = [
+		'Test'   => true,
+		'Mock'   => false,
+		'Double' => false,
+	];
+
+	/**
 	 * Maximum number of words.
 	 *
 	 * The maximum number of words an object name should consist of, each
@@ -42,20 +56,6 @@ final class ObjectNameDepthSniff extends WPCS_Sniff {
 	 * @var int
 	 */
 	public $recommended_max_words = 3;
-
-	/**
-	 * Suffixes commonly used for classes in the test suites.
-	 *
-	 * The key is the suffix. The value indicates whether this suffix is
-	 * only allowed when the class extends a known test class.
-	 *
-	 * @var bool[]
-	 */
-	private $test_suffixes = [
-		'Test'   => true,
-		'Mock'   => false,
-		'Double' => false,
-	];
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -104,8 +104,8 @@ final class ObjectNameDepthSniff extends WPCS_Sniff {
 		 * Allow the class name to be one part longer for confirmed test/mock/double classes.
 		 */
 		$last = \array_pop( $parts );
-		if ( isset( $this->test_suffixes[ $last ] ) ) {
-			if ( $this->test_suffixes[ $last ] === true && $this->is_test_class( $this->phpcsFile, $stackPtr ) ) {
+		if ( isset( self::TEST_SUFFIXES[ $last ] ) ) {
+			if ( self::TEST_SUFFIXES[ $last ] === true && $this->is_test_class( $this->phpcsFile, $stackPtr ) ) {
 				--$part_count;
 			}
 			else {

--- a/Yoast/Sniffs/Yoast/AlternativeFunctionsSniff.php
+++ b/Yoast/Sniffs/Yoast/AlternativeFunctionsSniff.php
@@ -44,16 +44,12 @@ final class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff 
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$replacement = '';
-		if ( isset( $this->groups[ $group_name ]['replacement'] ) ) {
-			$replacement = $this->groups[ $group_name ]['replacement'];
-		}
-
-		$fixable    = true;
-		$message    = $this->groups[ $group_name ]['message'];
-		$is_error   = ( $this->groups[ $group_name ]['type'] === 'error' );
-		$error_code = MessageHelper::stringToErrorcode( $group_name . '_' . $matched_content );
-		$data       = [
+		$replacement = ( $this->groups[ $group_name ]['replacement'] ?? '' );
+		$fixable     = true;
+		$message     = $this->groups[ $group_name ]['message'];
+		$is_error    = ( $this->groups[ $group_name ]['type'] === 'error' );
+		$error_code  = MessageHelper::stringToErrorcode( $group_name . '_' . $matched_content );
+		$data        = [
 			$matched_content,
 			$replacement,
 		];

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
@@ -18,7 +18,7 @@ final class CodeCoverageIgnoreDeprecatedUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList() {
+	public function getErrorList(): array {
 		return [
 			41 => 1,
 			50 => 1,
@@ -33,7 +33,7 @@ final class CodeCoverageIgnoreDeprecatedUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
+	public function getWarningList(): array {
 		return [];
 	}
 }

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.php
@@ -18,7 +18,7 @@ final class CoversTagUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList() {
+	public function getErrorList(): array {
 		return [
 			36  => 1,
 			37  => 1,
@@ -54,7 +54,7 @@ final class CoversTagUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
+	public function getWarningList(): array {
 		return [];
 	}
 }

--- a/Yoast/Tests/Commenting/FileCommentUnitTest.php
+++ b/Yoast/Tests/Commenting/FileCommentUnitTest.php
@@ -20,7 +20,7 @@ final class FileCommentUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList( $testFile = '' ) {
+	public function getErrorList( string $testFile = '' ): array {
 		switch ( $testFile ) {
 			case 'FileCommentUnitTest.2.inc':
 			case 'FileCommentUnitTest.8.inc':
@@ -42,7 +42,7 @@ final class FileCommentUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList( $testFile = '' ) {
+	public function getWarningList( string $testFile = '' ): array {
 		switch ( $testFile ) {
 			case 'FileCommentUnitTest.4.inc':
 			case 'FileCommentUnitTest.6.inc':

--- a/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/TestsHaveCoversTagUnitTest.php
@@ -18,7 +18,7 @@ final class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList() {
+	public function getErrorList(): array {
 		return [
 			49  => 1,
 			59  => 1,
@@ -34,7 +34,7 @@ final class TestsHaveCoversTagUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
+	public function getWarningList(): array {
 		return [];
 	}
 }

--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -85,7 +85,7 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return void
 	 */
-	public function setCliValues( $testFile, $config ) {
+	public function setCliValues( $testFile, $config ): void {
 		if ( $testFile === 'no-basepath.inc' ) {
 			return;
 		}
@@ -100,7 +100,7 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return string[]
 	 */
-	protected function getTestFiles( $testFileBase ) {
+	protected function getTestFiles( $testFileBase ): array {
 		$sep        = \DIRECTORY_SEPARATOR;
 		$test_files = \glob( \dirname( $testFileBase ) . $sep . 'FileNameUnitTests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', \GLOB_BRACE );
 
@@ -118,7 +118,7 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList( $testFile = '' ) {
+	public function getErrorList( string $testFile = '' ): array {
 
 		if ( isset( $this->expected_results[ $testFile ] ) ) {
 			return [
@@ -136,7 +136,7 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList( $testFile = '' ) {
+	public function getWarningList( string $testFile = '' ): array {
 		if ( $testFile === 'no-basepath.inc' ) {
 			return [
 				1 => 1,

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -22,7 +22,7 @@ final class TestDoublesUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return void
 	 */
-	public function setCliValues( $testFile, $config ) {
+	public function setCliValues( $testFile, $config ): void {
 		if ( $testFile === 'no-basepath.inc' ) {
 			return;
 		}
@@ -37,7 +37,7 @@ final class TestDoublesUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return string[]
 	 */
-	protected function getTestFiles( $testFileBase ) {
+	protected function getTestFiles( $testFileBase ): array {
 		$sep        = \DIRECTORY_SEPARATOR;
 		$test_files = \glob( \dirname( $testFileBase ) . $sep . 'TestDoublesUnitTests' . $sep . 'tests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', \GLOB_BRACE );
 
@@ -55,7 +55,7 @@ final class TestDoublesUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList( $testFile = '' ) {
+	public function getErrorList( string $testFile = '' ): array {
 
 		switch ( $testFile ) {
 			// In tests/.
@@ -134,7 +134,7 @@ final class TestDoublesUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList( $testFile = '' ) {
+	public function getWarningList( string $testFile = '' ): array {
 		switch ( $testFile ) {
 			case 'no-basepath.inc':
 				return [

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
@@ -23,7 +23,7 @@ final class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return void
 	 */
-	public function setCliValues( $testFile, $config ) {
+	public function setCliValues( $testFile, $config ): void {
 		if ( \strpos( $testFile, 'no-basepath' ) === 0 ) {
 			return;
 		}
@@ -38,7 +38,7 @@ final class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return string[]
 	 */
-	protected function getTestFiles( $testFileBase ) {
+	protected function getTestFiles( $testFileBase ): array {
 		$sep        = \DIRECTORY_SEPARATOR;
 		$test_files = \glob(
 			\dirname( $testFileBase ) . $sep . 'NamespaceNameUnitTests{'
@@ -64,7 +64,7 @@ final class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList( $testFile = '' ) {
+	public function getErrorList( string $testFile = '' ): array {
 
 		switch ( $testFile ) {
 			// Level check tests.
@@ -173,7 +173,7 @@ final class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList( $testFile = '' ) {
+	public function getWarningList( string $testFile = '' ): array {
 		switch ( $testFile ) {
 			// Level check tests.
 			case 'no-basepath.inc':

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
@@ -20,7 +20,7 @@ final class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList( $testFile = '' ) {
+	public function getErrorList( string $testFile = '' ): array {
 
 		switch ( $testFile ) {
 			case 'ObjectNameDepthUnitTest.2.inc':
@@ -56,7 +56,7 @@ final class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList( $testFile = '' ) {
+	public function getWarningList( string $testFile = '' ): array {
 		switch ( $testFile ) {
 			case 'ObjectNameDepthUnitTest.2.inc':
 				return [

--- a/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -23,7 +23,7 @@ final class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return void
 	 */
-	public function setCliValues( $filename, $config ) {
+	public function setCliValues( $filename, $config ): void {
 		$config->warningSeverity = 3;
 	}
 
@@ -32,7 +32,7 @@ final class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList() {
+	public function getErrorList(): array {
 
 		return [
 			14  => 1,
@@ -58,7 +58,7 @@ final class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
+	public function getWarningList(): array {
 		return [
 			16  => 1,
 			19  => 1,

--- a/Yoast/Tests/Tools/BrainMonkeyRaceConditionUnitTest.php
+++ b/Yoast/Tests/Tools/BrainMonkeyRaceConditionUnitTest.php
@@ -18,7 +18,7 @@ final class BrainMonkeyRaceConditionUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList() {
+	public function getErrorList(): array {
 		return [
 			104 => 1,
 			113 => 1,
@@ -32,7 +32,7 @@ final class BrainMonkeyRaceConditionUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
+	public function getWarningList(): array {
 		return [];
 	}
 }

--- a/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -18,7 +18,7 @@ final class FunctionSpacingUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList() {
+	public function getErrorList(): array {
 		return [
 			31 => 1,
 			33 => 1,
@@ -38,7 +38,7 @@ final class FunctionSpacingUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
+	public function getWarningList(): array {
 		return [];
 	}
 }

--- a/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.php
+++ b/Yoast/Tests/Yoast/AlternativeFunctionsUnitTest.php
@@ -18,7 +18,7 @@ final class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList() {
+	public function getErrorList(): array {
 		return [
 			12 => 1,
 			13 => 1,
@@ -35,7 +35,7 @@ final class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
+	public function getWarningList(): array {
 		return [];
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"source": "https://github.com/Yoast/yoastcs"
 	},
 	"require": {
-		"php": ">=5.4",
+		"php": ">=7.2",
 		"ext-tokenizer": "*",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
@@ -36,7 +36,7 @@
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",
 		"phpcsstandards/phpcsdevtools": "^1.2.1",
-		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+		"phpunit/phpunit": "^7.0",
 		"roave/security-advisories": "dev-master"
 	},
 	"minimum-stability": "dev",
@@ -51,7 +51,7 @@
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
 		],
 		"check-cs": [
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.4-"
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
 		],
 		"fix-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"


### PR DESCRIPTION
### Drop support for PHP < 7.2

The majority of the Yoast codebases now have a minimum of PHP 7.2.

Additionally, the YoastCS checks should give the same results independently of the PHP version on which the CS check is being run, which means that generally speaking, the CS check is run on a high PHP version, both locally as well as in CI.

With this in mind, there is no reason to keep the YoastCS minimum supported PHP version at PHP 5.4, so let's bring it in line with the other Yoast codebases and let it have a PHP 7.2 minimum.

Note: PHP_CodeSniffer itself still has a PHP 5.4 minimum. PHPCS 4.x is expected to have a PHP 7.2 minimum and this change is in line with that.

### YoastCS/Modernize: add explicit visibility to all OO constants

### YoastCS/Modernize: use constant arrays

Prior to PHP 5.6 class constants couldn't contain arrays. As support for PHP < 7.2 has now been dropped, unchangable properties containing arrays should be changed to constants.

### YoastCS/Modernize: selectively use null coalescing

PHP 7.0 introduced the null coalesce operator. This commit implements the use of the operator in select places.

### YoastCS/Modernize - Tests: add PHP native return type declarations

As support for PHP < 7.2 has now been dropped, PHP native parameter and return type declarations can be used.

There are, however, a couple of caveats:
1. Return type declarations can be freely used as long as the type needed is available in PHP 7.2.
2. Parameter type declarations can **_not_** be freely used as parameter types are contravariant, which means they can only be _wider_ than the original type, which means parameter type declarations can only be added for YoastCS native methods and not for methods which implement a PHPCS native interface method or overload a PHPCS native sniff method, as in that case, the original method will rarely have a type declaration, which means that adding one in YoastCS would violate LSP.

Also note that a `TypeError` thrown by a sniff, would stop the scan of a file dead, so let's be conservative with adding type declarations in the sniffs for now, but add them freely to the tests.