### PR TITLE
YoastCS: sync parameter names with PHPCS

### DIFF
--- a/Yoast/Tests/Files/FileNameUnitTest.php
+++ b/Yoast/Tests/Files/FileNameUnitTest.php
@@ -80,13 +80,13 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Set CLI values before the file is tested.
 	 *
-	 * @param string $testFile The name of the file being tested.
+	 * @param string $filename The name of the file being tested.
 	 * @param Config $config   The config data for the test run.
 	 *
 	 * @return void
 	 */
-	public function setCliValues( $testFile, $config ): void {
-		if ( $testFile === 'no-basepath.inc' ) {
+	public function setCliValues( $filename, $config ): void {
+		if ( $filename === 'no-basepath.inc' ) {
 			return;
 		}
 

--- a/Yoast/Tests/Files/TestDoublesUnitTest.php
+++ b/Yoast/Tests/Files/TestDoublesUnitTest.php
@@ -17,13 +17,13 @@ final class TestDoublesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Set CLI values before the file is tested.
 	 *
-	 * @param string $testFile The name of the file being tested.
+	 * @param string $filename The name of the file being tested.
 	 * @param Config $config   The config data for the test run.
 	 *
 	 * @return void
 	 */
-	public function setCliValues( $testFile, $config ): void {
-		if ( $testFile === 'no-basepath.inc' ) {
+	public function setCliValues( $filename, $config ): void {
+		if ( $filename === 'no-basepath.inc' ) {
 			return;
 		}
 

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
@@ -18,13 +18,13 @@ final class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Set CLI values before the file is tested.
 	 *
-	 * @param string $testFile The name of the file being tested.
+	 * @param string $filename The name of the file being tested.
 	 * @param Config $config   The config data for the test run.
 	 *
 	 * @return void
 	 */
-	public function setCliValues( $testFile, $config ): void {
-		if ( \strpos( $testFile, 'no-basepath' ) === 0 ) {
+	public function setCliValues( $filename, $config ): void {
+		if ( \strpos( $filename, 'no-basepath' ) === 0 ) {
 			return;
 		}
 


### PR DESCRIPTION
... to allow for eventually potentially supporting function calls using PHP 8.0 named pararameters.