### PR TITLE
Tests: add abstract `NonSniffTestCase` class

### DIFF
--- a/Yoast/Tests/NonSniffTestCase.php
+++ b/Yoast/Tests/NonSniffTestCase.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace YoastCS\Yoast\Tests;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\File;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base TestCase for non-sniff, non-code related tests, which still need a PHPCS File object.
+ *
+ * Note: this class will likely be moved to PHPCSUtils at some point in the future (once PHPCSUtils drops PHP < 7.0).
+ *
+ * @since 3.0.0
+ */
+abstract class NonSniffTestCase extends TestCase {
+
+	/**
+	 * Create a mocked PHPCS File object.
+	 *
+	 * @return File
+	 */
+	protected function get_mock_file() {
+		$config = new class() extends Config {
+
+			/**
+			 * Disable the original class constructor.
+			 */
+			public function __construct() {}
+		};
+
+		$phpcsFile = new class() extends File {
+
+			/**
+			 * Disable the original class constructor.
+			 */
+			public function __construct() {}
+		};
+
+		$phpcsFile->config = $config;
+
+		return $phpcsFile;
+	}
+}


### PR DESCRIPTION
... for tests which are directly not related to sniffs, nor need a code sample, but which do need a functioning PHPCS File object, for instance to mock retrieve the file name from the File object or mock retrieve a base path from the Config object within the File object.

Note: this test case will likely be moved to PHPCSUtils at some point in the future, though it may be a while as in its current set up, the class needs a PHP 7.0 minimum.

_Note: this base class is needed for some tests which will be added in subsequent PRs._