### PR TITLE
Commenting/CodeCoverageIgnoreDeprecated: apply rule to OO docblocks too + small other improvements

### DIFF
--- a/Yoast/Docs/Commenting/CodeCoverageIgnoreDeprecatedStandard.xml
+++ b/Yoast/Docs/Commenting/CodeCoverageIgnoreDeprecatedStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-    Deprecated functions and methods should be ignored for code coverage calculations.
+    Deprecated OO structures, functions and methods should be ignored for code coverage calculations.
     ]]>
     </standard>
     <code_comparison>

--- a/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
+++ b/Yoast/Sniffs/Commenting/CodeCoverageIgnoreDeprecatedSniff.php
@@ -45,9 +45,7 @@ final class CodeCoverageIgnoreDeprecatedSniff implements Sniff {
 				continue;
 			}
 
-			if ( $tokens[ $commentEnd ]['code'] === \T_ATTRIBUTE_END
-				&& isset( $tokens[ $commentEnd ]['attribute_opener'] ) === true
-			) {
+			if ( isset( $tokens[ $commentEnd ]['attribute_opener'] ) === true ) {
 				$commentEnd = $tokens[ $commentEnd ]['attribute_opener'];
 				continue;
 			}
@@ -91,7 +89,7 @@ final class CodeCoverageIgnoreDeprecatedSniff implements Sniff {
 		$hasTagAsString = $phpcsFile->findNext( \T_DOC_COMMENT_STRING, ( $commentStart + 1 ), $commentEnd, false, 'codeCoverageIgnore' );
 		if ( $hasTagAsString !== false ) {
 			$prev = $phpcsFile->findPrevious( \T_DOC_COMMENT_WHITESPACE, ( $hasTagAsString - 1 ), $commentStart, true );
-			if ( $prev !== false && $tokens[ $prev ]['code'] === \T_DOC_COMMENT_STAR ) {
+			if ( $tokens[ $prev ]['code'] === \T_DOC_COMMENT_STAR ) {
 				$fix = $phpcsFile->addFixableError(
 					'The `codeCoverageIgnore` annotation in the function docblock needs to be prefixed with an `@`.',
 					$hasTagAsString,

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc
@@ -89,3 +89,96 @@ abstract class SomeThing {
 	#[fietsbel /*comment*/]
 	public function inlineCommentWithinAttribute() {}
 }
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+class C_IsDeprecatedNotIgnored {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+abstract class C_IsDeprecatedNotIgnoredAbstract {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+#[AllowDynamicProperties]
+final class C_IsDeprecatedNotIgnoredFinal {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+readonly class C_IsDeprecatedNotIgnoredReadonly {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+final readonly class C_IsDeprecatedNotIgnoredFinalReadonly {}
+
+/**
+ * Description.
+ *
+ * @codeCoverageIgnore
+ * @deprecated
+ */
+readonly final class C_IsDeprecatedAndIgnored {}
+
+/**
+ * @deprecated
+ */
+#[MyAttribute, AnotherAttribute]
+interface I_IsDeprecatedNotIgnored {}
+
+/**
+ * @codeCoverageIgnore
+ * @deprecated
+ */
+interface I_IsDeprecatedAndIgnored {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+trait T_IsDeprecatedNotIgnored {}
+
+/**
+ * @deprecated
+ * codeCoverageIgnore
+ */
+trait T_IsDeprecatedAndIgnored {}
+
+/**
+ * @deprecated
+ */
+enum E_IsDeprecatedNotIgnored {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ * @codeCoverageIgnore
+ */
+enum E_IsDeprecatedAndIgnored {}
+
+/**
+ * Not necessarily correct, but as this is an anomymous class, this won't be flagged
+ * same as closures/arrow functions won't be flagged.
+ *
+ * @deprecated
+ */
+$anon = new
+	#[AllowDynamicProperties]
+	#[AnotherAttribute([1, 2, 3])]
+	class {};

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc
@@ -1,6 +1,6 @@
 <?php
 
-class SomeThing {
+abstract class SomeThing {
 
 	/**
 	 * Active (non-deprecated) function.
@@ -47,12 +47,12 @@ class SomeThing {
 	 *
 	 * This is a sentence containing the phrase codeCoverageIgnore, but should not be regarded as the tag.
 	 */
-	static protected function missingStaticCodeCoverageIgnore() {}
+	final static protected function missingStaticCodeCoverageIgnore() {}
 
 	/**
 	 * @deprecated x.x
 	 */
-	public function missingCodeCoverageIgnore() {}
+	public abstract function missingCodeCoverageIgnore();
 
 	/**
 	 * @deprecated x.x

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc.fixed
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc.fixed
@@ -89,3 +89,96 @@ abstract class SomeThing {
 	#[fietsbel /*comment*/]
 	public function inlineCommentWithinAttribute() {}
 }
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+class C_IsDeprecatedNotIgnored {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+abstract class C_IsDeprecatedNotIgnoredAbstract {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+#[AllowDynamicProperties]
+final class C_IsDeprecatedNotIgnoredFinal {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+readonly class C_IsDeprecatedNotIgnoredReadonly {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+final readonly class C_IsDeprecatedNotIgnoredFinalReadonly {}
+
+/**
+ * Description.
+ *
+ * @codeCoverageIgnore
+ * @deprecated
+ */
+readonly final class C_IsDeprecatedAndIgnored {}
+
+/**
+ * @deprecated
+ */
+#[MyAttribute, AnotherAttribute]
+interface I_IsDeprecatedNotIgnored {}
+
+/**
+ * @codeCoverageIgnore
+ * @deprecated
+ */
+interface I_IsDeprecatedAndIgnored {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ */
+trait T_IsDeprecatedNotIgnored {}
+
+/**
+ * @deprecated
+ * @codeCoverageIgnore
+ */
+trait T_IsDeprecatedAndIgnored {}
+
+/**
+ * @deprecated
+ */
+enum E_IsDeprecatedNotIgnored {}
+
+/**
+ * Description.
+ *
+ * @deprecated
+ * @codeCoverageIgnore
+ */
+enum E_IsDeprecatedAndIgnored {}
+
+/**
+ * Not necessarily correct, but as this is an anomymous class, this won't be flagged
+ * same as closures/arrow functions won't be flagged.
+ *
+ * @deprecated
+ */
+$anon = new
+	#[AllowDynamicProperties]
+	#[AnotherAttribute([1, 2, 3])]
+	class {};

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc.fixed
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 
-class SomeThing {
+abstract class SomeThing {
 
 	/**
 	 * Active (non-deprecated) function.
@@ -47,12 +47,12 @@ class SomeThing {
 	 *
 	 * This is a sentence containing the phrase codeCoverageIgnore, but should not be regarded as the tag.
 	 */
-	static protected function missingStaticCodeCoverageIgnore() {}
+	final static protected function missingStaticCodeCoverageIgnore() {}
 
 	/**
 	 * @deprecated x.x
 	 */
-	public function missingCodeCoverageIgnore() {}
+	public abstract function missingCodeCoverageIgnore();
 
 	/**
 	 * @deprecated x.x

--- a/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
+++ b/Yoast/Tests/Commenting/CodeCoverageIgnoreDeprecatedUnitTest.php
@@ -20,11 +20,19 @@ final class CodeCoverageIgnoreDeprecatedUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList(): array {
 		return [
-			41 => 1,
-			50 => 1,
-			55 => 1,
-			69 => 1,
-			90 => 1,
+			41  => 1,
+			50  => 1,
+			55  => 1,
+			69  => 1,
+			90  => 1,
+			98  => 1,
+			105 => 1,
+			113 => 1,
+			120 => 1,
+			127 => 1,
+			154 => 1,
+			158 => 1,
+			165 => 1,
 		];
 	}
 


### PR DESCRIPTION
### Commenting/CodeCoverageIgnoreDeprecated: minor test improvements

Add some more variation of method prefixes to the tests to safeguard the handling of those better.

### Commenting/CodeCoverageIgnoreDeprecated: minor code simplifications

Remove two redundant conditions.

The first is not needed as it's not actually important what token type we encounter, the only thing important is that there is a known attribute opener to skip to.

The second is not needed as the `findPrevious()` call will always find something, if nothing else, it will find the docblock opener, so checking for `false` is unnecessary.

### Commenting/CodeCoverageIgnoreDeprecated: check OO docblocks too

As things were, the `Yoast.Commenting.CodeCoverageIgnoreDeprecated` sniff only checked function docblocks to find a `@deprecated` tag and verify this was accompanied by a `@codeCoverageIgnore` tag.

However, if a complete class (or other OO structure) is deprecated, we can also safely ignore it for code coverage checking.

This updates the sniff to also check the docblocks of OO structures for `@deprecated` tags and verifies that, if those are found, they are accompanied by a `@codeCoverageIgnore` tag.

Two exceptions are made:
* The rule does not apply to interfaces as those can't contain code, so code coverage is not relevant.
* The rule does not apply to anonymous classes. Those are treated the same as closures/arrow functions: those are normally nested within another construct and code coverage should be based on the wrapping construct.

Includes tests.