### PR TITLE
Commenting/CoversTag: flag deprecated syntaxes, bug fix and various other improvements

### DIFF
--- a/Yoast/Docs/Commenting/CoversTagStandard.xml
+++ b/Yoast/Docs/Commenting/CoversTagStandard.xml
@@ -5,10 +5,11 @@
     >
     <standard>
     <![CDATA[
-    The @covers tag used to annotate which code is coverage by a test should follow the specifications of PHPUnit with regards to the supported annotations.
-See:
-* https://phpunit.readthedocs.io/en/7.5/code-coverage-analysis.html#specifying-covered-code-parts
-* https://phpunit.readthedocs.io/en/7.5/annotations.html#covers
+    The @covers tag used to annotate which code is covered by a test should follow the specifications of PHPUnit with regards to the supported annotations.
+
+    See:
+    * https://docs.phpunit.de/en/9.6/code-coverage-analysis.html#specifying-covered-code-parts
+    * https://docs.phpunit.de/en/9.6/annotations.html#covers
     ]]>
     </standard>
     <code_comparison>
@@ -24,7 +25,7 @@ class Some_Test extends TestCase {
 }
         ]]>
         </code>
-        <code title="Invalid: Incorrect covers tag annotation.">
+        <code title="Invalid: Incorrect covers tag annotation (superfluous parentheses).">
         <![CDATA[
 class Some_Test extends TestCase {
     /**
@@ -73,7 +74,7 @@ class Some_Test extends TestCase {
     </code_comparison>
     <standard>
     <![CDATA[
-    There should be not be both a @covers tag as well as a @coversNothing tag for the same test.
+    The @covers tag and the @coversNothing tag are mutually exclusive and should never both occur in the same docblock.
     ]]>
     </standard>
     <code_comparison>

--- a/Yoast/Docs/Commenting/CoversTagStandard.xml
+++ b/Yoast/Docs/Commenting/CoversTagStandard.xml
@@ -111,4 +111,39 @@ class Some_Test extends TestCase {
         ]]>
         </code>
     </code_comparison>
+    <standard>
+    <![CDATA[
+    The use of @covers ClassName::<[!](public|protected|private)> tags is deprecated since PHPUnit 9.0 and support has been removed in PHPUnit 10.0.
+    These type of annotations should not be used.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: A @covers tag referencing a function or a method.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     *
+     * @covers <em>::globalFunction</em>
+     * @covers <em>\ClassName::methodName</em>
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+        <code title="Invalid: A @covers tag using one of the deprecated/removed function group formats.">
+        <![CDATA[
+class Some_Test extends TestCase {
+    /**
+     * Testing...
+     *
+     * @covers <em>\ClassName::<public></em>
+     * @covers <em>\ClassName::<!protected></em>
+     * @covers <em>\ClassName<extended></em>
+     */
+    function test_something() {}
+}
+        ]]>
+        </code>
+    </code_comparison>
 </documentation>

--- a/Yoast/Sniffs/Commenting/CoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/CoversTagSniff.php
@@ -24,7 +24,7 @@ final class CoversTagSniff implements Sniff {
 	 *
 	 * @var string
 	 */
-	private const VALID_CONTENT_REGEX = '(?:\\\\?(?:(?<OOName>[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)\\\\)*(?P>OOName)(?:<extended>|::<[!]?(?:public|protected|private)>|::(?<functionName>(?!public$|protected$|private$)(?P>OOName)))?|::(?P>functionName)|\\\\?(?:(?P>OOName)\\\\)+(?P>functionName))';
+	private const VALID_CONTENT_REGEX = '(?:\\\\?(?:(?<OOName>[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)\\\\)*(?P>OOName)(?:<extended>|::<[!]?(?:public|protected|private)>|::(?<functionName>(?!public$|protected$|private$)(?P>OOName)))?|::(?P>functionName)|::<[!]?(?:public|protected|private)>|\\\\?(?:(?P>OOName)\\\\)+(?P>functionName))';
 
 	/**
 	 * Base error message.

--- a/Yoast/Sniffs/Commenting/CoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/CoversTagSniff.php
@@ -281,7 +281,7 @@ final class CoversTagSniff implements Sniff {
 	 *
 	 * @return bool Whether an error has been thrown or not.
 	 */
-	protected function fixSimpleError( File $phpcsFile, $stackPtr, $expected, $errorCode ) {
+	private function fixSimpleError( File $phpcsFile, $stackPtr, $expected, $errorCode ) {
 		$tokens     = $phpcsFile->getTokens();
 		$annotation = $tokens[ $stackPtr ]['content'];
 
@@ -315,7 +315,7 @@ final class CoversTagSniff implements Sniff {
 	 *
 	 * @return bool Whether to skip the rest of the annotation examination or not.
 	 */
-	protected function fixAnnotationToSplit( File $phpcsFile, $stackPtr, $errorCode, $separator ) {
+	private function fixAnnotationToSplit( File $phpcsFile, $stackPtr, $errorCode, $separator ) {
 		$fix = $phpcsFile->addFixableError(
 			'Each @covers annotation should reference only one covered structure',
 			$stackPtr,

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.inc
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.inc
@@ -1,30 +1,14 @@
 <?php
 
 class ClassNameTest {
-
 	/**
-	 * Docblock.
-	 *
 	 * Correct:
 	 * @covers ::global_function
 	 * @covers Name\Space\function_name
 	 * @covers \Name\Space\function_name
 	 * @covers Class_Name
-	 * @covers Class_Name<extended>
-	 * @covers Class_Name::<public>
-	 * @covers Class_Name::<protected>
-	 * @covers Class_Name::<private>
-	 * @covers Class_Name::<!public>
-	 * @covers Class_Name::<!protected>
-	 * @covers Class_Name::<!private>
 	 * @covers Name\Space\Class_Name
 	 * @covers \Name\Space\Class_Name
-	 * @covers Name\Space\Class_Name::<public>
-	 * @covers Name\Space\Class_Name::<protected>
-	 * @covers Name\Space\Class_Name::<private>
-	 * @covers Name\Space\Class_Name::<!public>
-	 * @covers Name\Space\Class_Name::<!protected>
-	 * @covers Name\Space\Class_Name::<!private>
 	 * @covers Class_Name::method_name
 	 * @covers \Class_name::method_name
 	 * @covers Name\Space\Class_Name::method_name
@@ -42,8 +26,24 @@ class ClassNameTest {
 	public function testCoversTag() {}
 
 	/**
-	 * Docblock.
-	 *
+	 * @covers Class_Name<extended>
+	 * @covers Class_Name::<public>
+	 * @covers Class_Name::<protected>
+	 * @covers Class_Name::<private>
+	 * @covers Class_Name::<!public>
+	 * @covers Class_Name::<!protected>
+	 * @covers Class_Name::<!private>
+	 * @covers \Name\Space\Class_Name<extended>
+	 * @covers \Name\Space\Class_Name::<public>
+	 * @covers Name\Space\Class_Name::<protected>
+	 * @covers Name\Space\Class_Name::<private>
+	 * @covers \Name\Space\Class_Name::<!public>
+	 * @covers Name\Space\Class_Name::<!protected>
+	 * @covers \Name\Space\Class_Name::<!private>
+	 */
+	public function testDeprecatedRemovedTagTypes() {}
+
+	/**
 	 * @covers ::global_functionA && ::other_functionA
 	 * @covers ::global_functionB & ::other_functionB
 	 * @covers ::global_functionC|::other_functionC

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.inc
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.inc
@@ -179,3 +179,20 @@ class ClassNameTest {
 	 */
 	public function testCompletelyInvalidAnnotations() {}
 }
+
+/**
+ * The <*> formats can also be used in combination with a `@coversDefaultClass` tag.
+ *
+ * @coversDefaultClass Class_Name
+ */
+class BracketedPartialsTest {
+	/**
+	 * @covers ::<public>
+	 * @covers ::<protected>
+	 * @covers ::<private>
+	 * @covers ::<!public>
+	 * @covers ::<!protected>
+	 * @covers ::<!private>
+	 */
+	public function testPartialTagTypes() {}
+}

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.inc
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.inc
@@ -164,4 +164,18 @@ class ClassNameTest {
 	 * @covers \Name\Space\ClassName::MethodName
 	 */
 	public function testRecognizingNamesNotFollowingWPNamingConventions() {}
+
+	/**
+	 * Docblock.
+	 */
+	public function testDocblockWithoutTags() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers This is not a valid annotation.
+	 * @covers \
+	 * @covers <public>
+	 */
+	public function testCompletelyInvalidAnnotations() {}
 }

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.inc.fixed
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.inc.fixed
@@ -163,4 +163,18 @@ class ClassNameTest {
 	 * @covers \Name\Space\ClassName::MethodName
 	 */
 	public function testRecognizingNamesNotFollowingWPNamingConventions() {}
+
+	/**
+	 * Docblock.
+	 */
+	public function testDocblockWithoutTags() {}
+
+	/**
+	 * Docblock.
+	 *
+	 * @covers This is not a valid annotation.
+	 * @covers \
+	 * @covers <public>
+	 */
+	public function testCompletelyInvalidAnnotations() {}
 }

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.inc.fixed
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.inc.fixed
@@ -1,30 +1,14 @@
 <?php
 
 class ClassNameTest {
-
 	/**
-	 * Docblock.
-	 *
 	 * Correct:
 	 * @covers ::global_function
 	 * @covers Name\Space\function_name
 	 * @covers \Name\Space\function_name
 	 * @covers Class_Name
-	 * @covers Class_Name<extended>
-	 * @covers Class_Name::<public>
-	 * @covers Class_Name::<protected>
-	 * @covers Class_Name::<private>
-	 * @covers Class_Name::<!public>
-	 * @covers Class_Name::<!protected>
-	 * @covers Class_Name::<!private>
 	 * @covers Name\Space\Class_Name
 	 * @covers \Name\Space\Class_Name
-	 * @covers Name\Space\Class_Name::<public>
-	 * @covers Name\Space\Class_Name::<protected>
-	 * @covers Name\Space\Class_Name::<private>
-	 * @covers Name\Space\Class_Name::<!public>
-	 * @covers Name\Space\Class_Name::<!protected>
-	 * @covers Name\Space\Class_Name::<!private>
 	 * @covers Class_Name::method_name
 	 * @covers \Class_name::method_name
 	 * @covers Name\Space\Class_Name::method_name
@@ -42,8 +26,24 @@ class ClassNameTest {
 	public function testCoversTag() {}
 
 	/**
-	 * Docblock.
-	 *
+	 * @covers Class_Name<extended>
+	 * @covers Class_Name::<public>
+	 * @covers Class_Name::<protected>
+	 * @covers Class_Name::<private>
+	 * @covers Class_Name::<!public>
+	 * @covers Class_Name::<!protected>
+	 * @covers Class_Name::<!private>
+	 * @covers \Name\Space\Class_Name<extended>
+	 * @covers \Name\Space\Class_Name::<public>
+	 * @covers Name\Space\Class_Name::<protected>
+	 * @covers Name\Space\Class_Name::<private>
+	 * @covers \Name\Space\Class_Name::<!public>
+	 * @covers Name\Space\Class_Name::<!protected>
+	 * @covers \Name\Space\Class_Name::<!private>
+	 */
+	public function testDeprecatedRemovedTagTypes() {}
+
+	/**
 	 * @covers ::global_functionA
 	 * @covers ::other_functionA
 	 * @covers ::global_functionB

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.inc.fixed
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.inc.fixed
@@ -178,3 +178,20 @@ class ClassNameTest {
 	 */
 	public function testCompletelyInvalidAnnotations() {}
 }
+
+/**
+ * The <*> formats can also be used in combination with a `@coversDefaultClass` tag.
+ *
+ * @coversDefaultClass Class_Name
+ */
+class BracketedPartialsTest {
+	/**
+	 * @covers ::<public>
+	 * @covers ::<protected>
+	 * @covers ::<private>
+	 * @covers ::<!public>
+	 * @covers ::<!protected>
+	 * @covers ::<!private>
+	 */
+	public function testPartialTagTypes() {}
+}

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.php
@@ -20,11 +20,11 @@ final class CoversTagUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList(): array {
 		return [
-			36  => 1,
-			37  => 1,
-			38  => 1,
-			39  => 1,
-			40  => 1,
+			20  => 1,
+			21  => 1,
+			22  => 1,
+			23  => 1,
+			24  => 1,
 			47  => 1,
 			48  => 1,
 			49  => 1,
@@ -58,6 +58,27 @@ final class CoversTagUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList(): array {
-		return [];
+		return [
+			29  => 1,
+			30  => 1,
+			31  => 1,
+			32  => 1,
+			33  => 1,
+			34  => 1,
+			35  => 1,
+			36  => 1,
+			37  => 1,
+			38  => 1,
+			39  => 1,
+			40  => 1,
+			41  => 1,
+			42  => 1,
+			190 => 1,
+			191 => 1,
+			192 => 1,
+			193 => 1,
+			194 => 1,
+			195 => 1,
+		];
 	}
 }

--- a/Yoast/Tests/Commenting/CoversTagUnitTest.php
+++ b/Yoast/Tests/Commenting/CoversTagUnitTest.php
@@ -46,6 +46,9 @@ final class CoversTagUnitTest extends AbstractSniffUnitTest {
 			140 => 1,
 			150 => 1,
 			151 => 1,
+			176 => 1,
+			177 => 1,
+			178 => 1,
 		];
 	}
 


### PR DESCRIPTION
### Commenting/CoversTag: add some extra tests

... for situations previously not (yet) covered by tests.

### Commenting/CoversTag: minor tweaks

* Ensure (make it obvious) that `$data` is always available.
* Use the correct data type for the stack pointers retrieved via the `explode()`.
* Defense in depth tweak.
* Improve the readability of the code a little.

### Commenting/CoversTag: make non-interface methods private

As the sniff class is now `final` (since PR #319), there is no need for any `protected` methods, so let's make these `private`.

### Commenting/CoversTag: improve XML documentation

Update external reference links and minor textual improvements.

### Commenting/CoversTag: bug fix - allow for `<[!]visibility>` format without class name

This is perfectly valid when used in combination with a `@coversDefaultClass` class level tag, but would be flagged by the sniff (false positives).

Fixed now. Includes tests.

### Commenting/CoversTag: flag deprecated `@covers` tag formats

PHPUnit 9.0 (soft) deprecated the use of `ClassName<*>` type `@covers` annotations. Support for these type of annotation has been removed completely in PHPUnit 10.0.0.

This commit adds a new _warning_ to the sniff, which will detect the use of these deprecated formats and flag them.

The choice for _warning_ vs _error_ is deliberate. The Yoast repos, for now, do not use PHPUnit 10.x yet, so for now, a warning is sufficient.
Once the repos would be upgraded to start using PHPUnit 10.x, this sniff should be updated and the `warning` changed to an `error`.

Includes tests.
Includes a new section in the XML docs about this new warning.

Refs:
* sebastianbergmann/phpunit#3630 (PHPUnit 9.0 deprecation).
* sebastianbergmann/phpunit#3631 (PHPUnit 10.0 removal).