### PR TITLE
NamingConventions/ObjectNameDepth: bug fix, support modern PHP and other improvements

### DIFF
--- a/Yoast/Docs/NamingConventions/ObjectNameDepthStandard.xml
+++ b/Yoast/Docs/NamingConventions/ObjectNameDepthStandard.xml
@@ -7,7 +7,7 @@
     <![CDATA[
     The name of objects - classes, interfaces, traits - declared within a namespace should consist of a maximum of three words.
 
-    A partial exception is made for test, mock and double classes. These can have a `_Test`, `_Mock` or `_Double` class name suffix, which won't be counted.
+    A partial exception is made for test, mock and double classes. These can have a `_Test`, `_TestCase`, `_Mock` or `_Double` class name suffix, which won't be counted.
 
     Note: the maximum (error) and the recommended (warning) maximum length are configurable.
     ]]>

--- a/Yoast/Docs/NamingConventions/ObjectNameDepthStandard.xml
+++ b/Yoast/Docs/NamingConventions/ObjectNameDepthStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-    The name of objects - classes, interfaces, traits - declared within a namespace should consist of a maximum of three words.
+    The name of OO structures - classes, interfaces, traits, enums - declared within a namespace should consist of a maximum of three words.
 
     A partial exception is made for test, mock and double classes. These can have a `_Test`, `_TestCase`, `_Mock` or `_Double` class name suffix, which won't be counted.
 

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -5,6 +5,7 @@ namespace YoastCS\Yoast\Sniffs\NamingConventions;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
@@ -129,11 +130,8 @@ final class ObjectNameDepthSniff implements Sniff {
 		}
 
 		// Check if the OO structure is deprecated.
-		$ignore = [
-			\T_ABSTRACT   => \T_ABSTRACT,
-			\T_FINAL      => \T_FINAL,
-			\T_WHITESPACE => \T_WHITESPACE,
-		];
+		$ignore                  = Collections::classModifierKeywords();
+		$ignore[ \T_WHITESPACE ] = \T_WHITESPACE;
 
 		$comment_end = $stackPtr;
 		for ( $comment_end = ( $stackPtr - 1 ); $comment_end >= 0; $comment_end-- ) {

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -6,7 +6,6 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\ObjectDeclarations;
-use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
 use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
 
 /**
@@ -14,18 +13,15 @@ use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
  *
  * @since 2.0.0
  * @since 3.0.0 This sniff no longer extends the WPCS abstract Sniff class.
- *
- * @uses \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
 final class ObjectNameDepthSniff implements Sniff {
-
-	use IsUnitTestTrait;
 
 	/**
 	 * Suffixes commonly used for classes in the test suites.
 	 *
 	 * The key is the suffix in lowercase. The value indicates whether this suffix is
 	 * only allowed when the class extends a known test class.
+	 * The value is currently unused.
 	 *
 	 * @var array<string, bool>
 	 */
@@ -113,14 +109,9 @@ final class ObjectNameDepthSniff implements Sniff {
 		 */
 		$last = \strtolower( \array_pop( $parts ) );
 		if ( isset( self::TEST_SUFFIXES[ $last ] ) ) {
-			if ( self::TEST_SUFFIXES[ $last ] === true && $this->is_test_class( $phpcsFile, $stackPtr ) ) {
+			$extends = ObjectDeclarations::findExtendedClassName( $phpcsFile, $stackPtr );
+			if ( \is_string( $extends ) ) {
 				--$part_count;
-			}
-			else {
-				$extends = ObjectDeclarations::findExtendedClassName( $phpcsFile, $stackPtr );
-				if ( \is_string( $extends ) ) {
-					--$part_count;
-				}
 			}
 		}
 

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -78,7 +78,7 @@ final class ObjectNameDepthSniff implements Sniff {
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
-	 * @return void|int Optionally returns stack pointer to skip to.
+	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
 
@@ -103,7 +103,7 @@ final class ObjectNameDepthSniff implements Sniff {
 		$part_count = \count( $parts );
 
 		/*
-		 * Allow the class name to be one part longer for confirmed test/mock/double classes.
+		 * Allow the OO name to be one part longer for confirmed test/mock/double OO structures.
 		 */
 		$last = \array_pop( $parts );
 		if ( isset( self::TEST_SUFFIXES[ $last ] ) ) {
@@ -123,7 +123,7 @@ final class ObjectNameDepthSniff implements Sniff {
 			return;
 		}
 
-		// Check if the class is deprecated.
+		// Check if the OO structure is deprecated.
 		$ignore = [
 			\T_ABSTRACT   => \T_ABSTRACT,
 			\T_FINAL      => \T_FINAL,
@@ -149,11 +149,11 @@ final class ObjectNameDepthSniff implements Sniff {
 		}
 
 		if ( $tokens[ $comment_end ]['code'] === \T_DOC_COMMENT_CLOSE_TAG ) {
-			// Only check if the class has a docblock.
+			// Only check if the OO structure has a docblock.
 			$comment_start = $tokens[ $comment_end ]['comment_opener'];
 			foreach ( $tokens[ $comment_start ]['comment_tags'] as $tag ) {
 				if ( $tokens[ $tag ]['content'] === '@deprecated' ) {
-					// Deprecated class, ignore.
+					// Deprecated OO structure, ignore.
 					return;
 				}
 			}
@@ -161,7 +161,7 @@ final class ObjectNameDepthSniff implements Sniff {
 
 		$phpcsFile->recordMetric( $stackPtr, 'Nr of words in object name', $part_count );
 
-		// Active class.
+		// Not a deprecated OO structure, this OO structure should comply with the rules.
 		$object_type = 'a ' . $tokens[ $stackPtr ]['content'];
 		if ( $tokens[ $stackPtr ]['code'] === \T_INTERFACE ) {
 			$object_type = 'an ' . $tokens[ $stackPtr ]['content'];

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -24,15 +24,15 @@ final class ObjectNameDepthSniff implements Sniff {
 	/**
 	 * Suffixes commonly used for classes in the test suites.
 	 *
-	 * The key is the suffix. The value indicates whether this suffix is
+	 * The key is the suffix in lowercase. The value indicates whether this suffix is
 	 * only allowed when the class extends a known test class.
 	 *
 	 * @var array<string, bool>
 	 */
 	private const TEST_SUFFIXES = [
-		'Test'   => true,
-		'Mock'   => false,
-		'Double' => false,
+		'test'   => true,
+		'mock'   => false,
+		'double' => false,
 	];
 
 	/**
@@ -105,7 +105,7 @@ final class ObjectNameDepthSniff implements Sniff {
 		/*
 		 * Allow the OO name to be one part longer for confirmed test/mock/double OO structures.
 		 */
-		$last = \array_pop( $parts );
+		$last = \strtolower( \array_pop( $parts ) );
 		if ( isset( self::TEST_SUFFIXES[ $last ] ) ) {
 			if ( self::TEST_SUFFIXES[ $last ] === true && $this->is_test_class( $phpcsFile, $stackPtr ) ) {
 				--$part_count;

--- a/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ObjectNameDepthSniff.php
@@ -30,9 +30,10 @@ final class ObjectNameDepthSniff implements Sniff {
 	 * @var array<string, bool>
 	 */
 	private const TEST_SUFFIXES = [
-		'test'   => true,
-		'mock'   => false,
-		'double' => false,
+		'test'     => true,
+		'testcase' => true,
+		'mock'     => false,
+		'double'   => false,
 	];
 
 	/**
@@ -97,6 +98,11 @@ final class ObjectNameDepthSniff implements Sniff {
 		// Handle names which are potentially in CamelCaps.
 		if ( \strpos( $snakecase_object_name, '_' ) === false ) {
 			$snakecase_object_name = SnakeCaseHelper::get_suggestion( $snakecase_object_name );
+
+			// Always treat "TestCase" as one word.
+			if ( \substr( $snakecase_object_name, -9 ) === 'test_case' ) {
+				$snakecase_object_name = \substr( $snakecase_object_name, 0, -9 ) . 'testcase';
+			}
 		}
 
 		$parts      = \explode( '_', $snakecase_object_name );

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
@@ -114,3 +114,9 @@ trait SomeACRONYMName {} // Error - false positive, this will be fixed in a late
 class TooLongClassName {} // Error.
 interface ThisInterfaceNameIsTooLong {} // Error.
 trait TraitNameIsTooLong {} // Error.
+
+// Now, let's also make sure the test/double handling works for CamelCaps class names + class names with the suffix in an unconventional case.
+class ThreeWordNameTest extends TestCase {} // OK.
+class ThreeWordNameDouble extends ThreeWordName {} // OK.
+class Three_Word_Name_test extends TestCase {} // OK.
+class Three_Word_Name_MOCK extends Some_Class {} // OK.

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
@@ -126,3 +126,12 @@ class Three_Word_Name_MOCK extends Some_Class {} // OK.
  */
 class ThreeWordNameTestCase extends TestCase {} // OK.
 class Three_Word_Name_TestCase extends TestCase {} // OK.
+
+/*
+ * Allow for PHP 8.1+ enums.
+ */
+enum My_Enum_Name {} // OK.
+enum MyEnumName {} // OK.
+enum Too_Long_Enum_Name: int {} // Error.
+enum TooLongEnumName: int {} // Error.
+enum Three_Word_Name_Mock: string implements Word_Interface {} // OK.

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
@@ -120,3 +120,9 @@ class ThreeWordNameTest extends TestCase {} // OK.
 class ThreeWordNameDouble extends ThreeWordName {} // OK.
 class Three_Word_Name_test extends TestCase {} // OK.
 class Three_Word_Name_MOCK extends Some_Class {} // OK.
+
+/*
+ * TestCase classes should also be allowed extra word length.
+ */
+class ThreeWordNameTestCase extends TestCase {} // OK.
+class Three_Word_Name_TestCase extends TestCase {} // OK.

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
@@ -135,3 +135,18 @@ enum MyEnumName {} // OK.
 enum Too_Long_Enum_Name: int {} // Error.
 enum TooLongEnumName: int {} // Error.
 enum Three_Word_Name_Mock: string implements Word_Interface {} // OK.
+
+/**
+ * Class description, no @deprecated tag.
+ *
+ * @since x.x.x
+ */
+#[Some_Attribute]
+readonly class Active_Class_With_Attribute_With_Too_Long_Class_Name {} // Error.
+
+/**
+ * Class description.
+ *
+ * @deprecated x.x.x
+ */
+final readonly class Deprecated_Readonly_Class_With_Too_Long_Class_Name {} // OK.

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.2.inc
@@ -70,7 +70,7 @@ class Deprecated_Class_With_Too_Long_Class_Name {} // OK.
  * @since x.x.x
  */
 #[Some_Attribute]
-class Active_Class_With_Attribute_With_Too_Long_Class_Name {} // Error.
+final class Active_Class_With_Attribute_With_Too_Long_Class_Name {} // Error.
 
 /**
  * Class description.
@@ -79,7 +79,7 @@ class Active_Class_With_Attribute_With_Too_Long_Class_Name {} // Error.
  */
 #[Attribute_One]
 #[Attribute_Two]
-class Deprecated_Class_With_Attribute_With_Too_Long_Class_Name {} // OK.
+abstract class Deprecated_Class_With_Attribute_With_Too_Long_Class_Name {} // OK.
 
 /*
  * Allow for a `_Test` suffix in classes within the unit test suite.
@@ -87,7 +87,7 @@ class Deprecated_Class_With_Attribute_With_Too_Long_Class_Name {} // OK.
 class Three_Word_Name_Test {} // Error.
 
 class Three_Word_Name_Test extends TestCase {} // OK.
-class Three_Word_Name_Test extends WP_UnitTestCase {} // OK.
+class Three_Word_Name_Test extends \WP_UnitTestCase {} // OK.
 
 class Four_Word_Long_Name_Test extends TestCase {} // Error.
 

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.3.inc
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.3.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Foo;
+
+// Live coding/parse error test.
+// This must be the only/last test in the file.
+class

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
@@ -42,6 +42,8 @@ final class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
 					114 => 1,
 					115 => 1,
 					116 => 1,
+					135 => 1,
+					136 => 1,
 				];
 
 			default:

--- a/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
+++ b/Yoast/Tests/NamingConventions/ObjectNameDepthUnitTest.php
@@ -44,6 +44,7 @@ final class ObjectNameDepthUnitTest extends AbstractSniffUnitTest {
 					116 => 1,
 					135 => 1,
 					136 => 1,
+					145 => 1,
 				];
 
 			default:


### PR DESCRIPTION
### NamingConventions/ObjectNameDepth: decouple from WPCS sniff

.... as extending the WPCS sniff is no longer needed, as the utility functions we used from that sniff before, have all been replaced with utilities from PHPCSUtils and utilities from the new WPCS 3.0.0 Helper classes/traits.

Follow up on PRs #322 and #323.

### NamingConventions/ObjectNameDepth: add extra tests

... for a few edge cases previously not covered by tests.

Includes updating a couple of pre-existing tests to expand the scope of what these are testing.

### NamingConventions/ObjectNameDepth: minor documentation improvements

### NamingConventions/ObjectNameDepth: bug fix for test classes using CamelCaps

Test classes and Double/Mock classes are allowed one extra word in the name to account for the `Test`/`Mock`/`Double`.

However, this was not handled correctly for test classes in CamelCaps as those are first converted to `snake_case`, which means that the suffix used in the comparison is now lowercase, while the name comparison was done in a case-sensitive manner.

Along the same lines, underscore separated class names where the suffix would not be "proper case" would also not be recognized correctly as, again, the name comparison was done in a case-sensitive manner.

As the casing of the class name is not the concern of this sniff, the name comparison should be done in a case-INsensitive manner.

Fixed now.

Includes tests.

### NamingConventions/ObjectNameDepth: allow for TestCase classes

Aside from a generic `TestCase`, typically called `TestCase`, a test suite may contain more specialized `TestCase` classes with longer names.

Those classes should also get the "one extra word" treatment (with `TestCase` counted as one word).

Fixed now.

Includes tests.
Includes update to the XML docs.

### NamingConventions/ObjectNameDepth: remove some redundant code

The WPCS `IsUnitTestTrait::is_test_class()` method does not (and never has so far) handle import `use` statements, which means that in the context of namespaced files, the results of the function are unreliable.

As documented with the `TEST_SUFFIXES` constant, the `Test` and `TestCase` suffixes should only be given the "one extra word" treatment when these classes extend a "known" test class.

As things were, this wasn't respected properly by the sniff anyhow (the `$this->is_test_class()` should have been _nested_ within the `self::TEST_SUFFIXES[ $last ] === true` condition).

And as it cannot reliably be enforced at this time, we're better off removing the useless condition and just checking if a class with one of the "extra word" suffixes extends.

### NamingConventions/ObjectNameDepth: examine PHP 8.1+ enums

The names of `enum` structures should comply with the same rules as classes.

This commit:
* Adds the `T_ENUM` token to the tokens being sniffed for.
* Makes an exception in the "one extra word for test/mocks/double" logic as `enum`s cannot extend, though the may still need to be mocked.
* Ensures the error message for enums is grammatically correct.

Includes tests.
Includes update to the XML docs.

### NamingConventions/ObjectNameDepth: support PHP 8.2+ readonly classes

To check whether a class is deprecated, the sniff needs to skip over the potential class modifier keywords, like `final` and `abstract`.

As of PHP 8.2, it will also need to skip over the new `readonly` keyword.

Includes unit tests.