### PR TITLE
WhiteSpace/FunctionSpacing: various minor improvements

### DIFF
--- a/Yoast/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/Yoast/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -51,7 +51,7 @@ final class FunctionSpacingSniff extends Squiz_FunctionSpacingSniff {
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 *
-	 * @return void|int Optionally returns stack pointer to skip to.
+	 * @return void
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
 		// Check that the function is nested in an OO structure (class, trait, interface, enum).
@@ -59,6 +59,6 @@ final class FunctionSpacingSniff extends Squiz_FunctionSpacingSniff {
 			return;
 		}
 
-		return parent::process( $phpcsFile, $stackPtr );
+		parent::process( $phpcsFile, $stackPtr );
 	}
 }

--- a/Yoast/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/Yoast/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -54,7 +54,7 @@ final class FunctionSpacingSniff extends Squiz_FunctionSpacingSniff {
 	 * @return void|int Optionally returns stack pointer to skip to.
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		// Check that the function is nested in an OO structure (class, trait, interface).
+		// Check that the function is nested in an OO structure (class, trait, interface, enum).
 		if ( Conditions::hasCondition( $phpcsFile, $stackPtr, Tokens::$ooScopeTokens ) === false ) {
 			return;
 		}

--- a/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
+++ b/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
@@ -88,3 +88,17 @@ $util->setLogger(new class {
 	private function b(){}
 	protected function c(){}
 });
+
+enum MyTrait: int
+{
+	function func1() {
+
+	}//end func1()
+
+
+
+	function func3() {
+
+	}
+
+}

--- a/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
+++ b/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
@@ -88,3 +88,15 @@ $util->setLogger(new class {
 
 	protected function c(){}
 });
+
+enum MyTrait: int
+{
+
+	function func1() {
+
+	}//end func1()
+
+	function func3() {
+
+	}
+}

--- a/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/Yoast/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -20,16 +20,19 @@ final class FunctionSpacingUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList(): array {
 		return [
-			31 => 1,
-			33 => 1,
-			39 => 1,
-			46 => 1,
-			53 => 2,
-			57 => 1,
-			60 => 1,
-			74 => 1,
-			87 => 2,
-			88 => 1,
+			31  => 1,
+			33  => 1,
+			39  => 1,
+			46  => 1,
+			53  => 2,
+			57  => 1,
+			60  => 1,
+			74  => 1,
+			87  => 2,
+			88  => 1,
+			94  => 1,
+			96  => 1,
+			102 => 1,
 		];
 	}
 


### PR DESCRIPTION
### WhiteSpace/FunctionSpacing: verify support for PHP 8.1 enums

The use of the `Tokens::$ooScopeTokens` token array already takes care of handling of enums in the sniff, but this should still be safeguarded with a test.

### WhiteSpace/FunctionSpacing: minor tweak

The parent `process()` method is a `void` method, so this should be too.