### PR TITLE
:sparkles: New `PSR4PathsTrait`

### DIFF
--- a/Yoast/Tests/Utils/PSR4PathsTraitTest.php
+++ b/Yoast/Tests/Utils/PSR4PathsTraitTest.php
@@ -1,0 +1,545 @@
+<?php
+
+namespace YoastCS\Yoast\Tests\Utils;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use YoastCS\Yoast\Tests\NonSniffTestCase;
+use YoastCS\Yoast\Utils\PSR4PathsTrait;
+
+/**
+ * Tests for the YoastCS\Yoast\Utils\PSR4PathsTrait trait.
+ *
+ * @coversDefaultClass \YoastCS\Yoast\Utils\PSR4PathsTrait
+ *
+ * @since 3.0.0
+ */
+final class PSR4PathsTraitTest extends NonSniffTestCase {
+
+	use PSR4PathsTrait;
+
+	/**
+	 * Default basepath.
+	 *
+	 * @var string
+	 */
+	private const DIRTY_BASEPATH = '/base/path';
+
+	/**
+	 * Cleaned up version of the default basepath.
+	 *
+	 * @var string
+	 */
+	private const CLEAN_BASEPATH = '/base/path/';
+
+	/**
+	 * Clean up the trait after each test.
+	 *
+	 * @after
+	 */
+	protected function clean_up() {
+		$this->psr4_paths           = [];
+		$this->previous_psr4_paths  = [];
+		$this->validated_psr4_paths = [];
+	}
+
+	/**
+	 * Test validating the $psr4_paths property
+	 *
+	 * @dataProvider data_is_get_psr4_info
+	 * @covers       ::is_in_psr4_path
+	 *
+	 * @param array<string, string>      $psr4_paths The initial input for the $psr4_paths property.
+	 * @param string                     $file_path  The file path to evaluate.
+	 * @param array<string, string|bool> $expected   The expected function output.
+	 *
+	 * @return void
+	 */
+	public function test_is_in_psr4_path( $psr4_paths, $file_path, $expected ) {
+		$phpcsFile                   = $this->get_mock_file();
+		$phpcsFile->config->basepath = self::CLEAN_BASEPATH;
+		$phpcsFile->path             = $file_path;
+
+		$this->psr4_paths = $psr4_paths;
+
+		$this->assertSame( $expected['is'], $this->is_in_psr4_path( $phpcsFile ) );
+	}
+
+	/**
+	 * Test validating the $psr4_paths property
+	 *
+	 * @dataProvider data_is_get_psr4_info
+	 * @covers       ::get_psr4_info
+	 *
+	 * @param array<string, string>      $psr4_paths The initial input for the $psr4_paths property.
+	 * @param string                     $file_path  The file path to evaluate.
+	 * @param array<string, string|bool> $expected   The expected function output.
+	 *
+	 * @return void
+	 */
+	public function test_get_psr4_info( $psr4_paths, $file_path, $expected ) {
+		$phpcsFile                   = $this->get_mock_file();
+		$phpcsFile->config->basepath = self::DIRTY_BASEPATH;
+		$phpcsFile->path             = $file_path;
+
+		$this->psr4_paths = $psr4_paths;
+
+		$this->assertSame( $expected['get'], $this->get_psr4_info( $phpcsFile ) );
+	}
+
+	/**
+	 * Test validating the $psr4_paths property
+	 *
+	 * @dataProvider data_is_get_psr4_info
+	 * @covers       ::get_psr4_info
+	 *
+	 * @param array<string, string>      $psr4_paths The initial input for the $psr4_paths property.
+	 * @param string                     $file_path  The file path to evaluate.
+	 * @param array<string, string|bool> $expected   The expected function output.
+	 *
+	 * @return void
+	 */
+	public function test_get_psr4_info_explicit( $psr4_paths, $file_path, $expected ) {
+		$phpcsFile                   = $this->get_mock_file();
+		$phpcsFile->config->basepath = self::DIRTY_BASEPATH;
+
+		$this->psr4_paths = $psr4_paths;
+
+		$this->assertSame( $expected['get'], $this->get_psr4_info( $phpcsFile, $file_path ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see test_is_in_psr4_path()        For the array format.
+	 * @see test_get_psr4_info()          For the array format.
+	 * @see test_get_psr4_info_explicit() For the array format.
+	 *
+	 * @return array<string, array<string, string|array<string, string|bool>>>
+	 */
+	public static function data_is_get_psr4_info() {
+		$default_psr4_paths = self::data_validate_psr4_paths()['multiple prefixes, variation of paths']['psr4_paths'];
+
+		return [
+			'path is unknown' => [
+				'psr4_paths' => [],
+				'file_path'  => '',
+				'expected'   => [
+					'is'  => false,
+					'get' => false,
+				],
+			],
+			'path is STDIN' => [
+				'psr4_paths' => [],
+				'file_path'  => 'STDIN',
+				'expected'   => [
+					'is'  => false,
+					'get' => false,
+				],
+			],
+			'path is single-quoted STDIN' => [
+				'psr4_paths' => [],
+				'file_path'  => "'STDIN'",
+				'expected'   => [
+					'is'  => false,
+					'get' => false,
+				],
+			],
+			'path is double-quoted STDIN' => [
+				'psr4_paths' => [],
+				'file_path'  => '"STDIN"',
+				'expected'   => [
+					'is'  => false,
+					'get' => false,
+				],
+			],
+			'PSR-4 paths is empty/not set' => [
+				'psr4_paths' => [],
+				'file_path'  => 'path/is/not/relevant',
+				'expected'   => [
+					'is'  => false,
+					'get' => false,
+				],
+			],
+			'Linux style file path, not matching' => [
+				'psr4_paths' => $default_psr4_paths,
+				'file_path'  => 'path/will/not/match/filename.ext',
+				'expected'   => [
+					'is'  => false,
+					'get' => false,
+				],
+			],
+			'Linux style file path, matching' => [
+				'psr4_paths' => $default_psr4_paths,
+				'file_path'  => self::DIRTY_BASEPATH . '/config/subdir/filename.ext',
+				'expected'   => [
+					'is'  => true,
+					'get' => [
+						'prefix'   => 'Plugin\PrefixB',
+						'basepath' => self::CLEAN_BASEPATH . 'config/',
+						'relative' => 'subdir',
+					],
+				],
+			],
+			'Windows style file path, not matching' => [
+				'psr4_paths' => $default_psr4_paths,
+				'file_path'  => 'path\will\not\match\filename.ext',
+				'expected'   => [
+					'is'  => false,
+					'get' => false,
+				],
+			],
+			'Windows style file path, matching' => [
+				'psr4_paths' => $default_psr4_paths,
+				'file_path'  => '\base\path\config\subdir\filename.ext',
+				'expected'   => [
+					'is'  => true,
+					'get' => [
+						'prefix'   => 'Plugin\PrefixB',
+						'basepath' => self::CLEAN_BASEPATH . 'config/',
+						'relative' => 'subdir',
+					],
+				],
+			],
+			'Mixed slashes in file path, not matching' => [
+				'psr4_paths' => $default_psr4_paths,
+				'file_path'  => self::DIRTY_BASEPATH . '\subdir\filename.ext',
+				'expected'   => [
+					'is'  => false,
+					'get' => false,
+				],
+			],
+			'Mixed slashes in file path, matching' => [
+				'psr4_paths' => $default_psr4_paths,
+				'file_path'  => self::CLEAN_BASEPATH . 'subA\sub/deeper/filename.ext',
+				'expected'   => [
+					'is'  => true,
+					'get' => [
+						'prefix'   => 'Plugin\PrefixC',
+						'basepath' => self::CLEAN_BASEPATH . 'subA/sub/',
+						'relative' => 'deeper',
+					],
+				],
+			],
+			'Exact match, no file name' => [
+				'psr4_paths' => $default_psr4_paths,
+				'file_path'  => self::CLEAN_BASEPATH . 'tests/',
+				'expected'   => [
+					'is'  => true,
+					'get' => [
+						'prefix'   => 'Plugin\PrefixB',
+						'basepath' => self::CLEAN_BASEPATH . 'tests/',
+						'relative' => '.',
+					],
+				],
+			],
+			'Exact match, no file name, no trailing slash' => [
+				'psr4_paths' => $default_psr4_paths,
+				'file_path'  => self::CLEAN_BASEPATH . 'subC',
+				'expected'   => [
+					'is'  => true,
+					'get' => [
+						'prefix'   => 'Plugin\PrefixC',
+						'basepath' => self::CLEAN_BASEPATH . 'subC/',
+						'relative' => '.',
+					],
+				],
+			],
+			'Exact match, with file name' => [
+				'psr4_paths' => $default_psr4_paths,
+				'file_path'  => self::CLEAN_BASEPATH . 'subC/file.ext',
+				'expected'   => [
+					'is'  => true,
+					'get' => [
+						'prefix'   => 'Plugin\PrefixC',
+						'basepath' => self::CLEAN_BASEPATH . 'subC/',
+						'relative' => '.',
+					],
+				],
+			],
+			'Long subdir, matching' => [
+				'psr4_paths' => $default_psr4_paths,
+				'file_path'  => self::CLEAN_BASEPATH . 'src/something/else/and/more/file.ext',
+				'expected'   => [
+					'is'  => true,
+					'get' => [
+						'prefix'   => 'Plugin\PrefixA',
+						'basepath' => self::CLEAN_BASEPATH . 'src/',
+						'relative' => 'something/else/and/more',
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test validating the $psr4_paths property when no basepath is present.
+	 *
+	 * @covers ::validate_psr4_paths
+	 *
+	 * @return void
+	 */
+	public function test_validate_psr4_paths_without_basepath_doesnt_set_validated() {
+		$phpcsFile = $this->get_mock_file();
+
+		$this->psr4_paths = self::data_validate_psr4_paths()['multiple prefixes, variation of paths']['psr4_paths'];
+
+		$this->validate_psr4_paths( $phpcsFile );
+
+		$this->assertSame( [], $this->previous_psr4_paths, 'Previous paths has been set' );
+		$this->assertSame( [], $this->validated_psr4_paths, 'Validated paths has been set' );
+	}
+
+	/**
+	 * Test validating the $psr4_paths property when no basepath is present while a previous run did have a basepath.
+	 *
+	 * @covers ::validate_psr4_paths
+	 *
+	 * @return void
+	 */
+	public function test_validate_psr4_paths_without_basepath_resets_validated() {
+		$phpcsFile = $this->get_mock_file();
+
+		// Initial test with basepath.
+		$phpcsFile->config->basepath = self::DIRTY_BASEPATH;
+
+		$input            = self::data_validate_psr4_paths()['multiple prefixes, variation of paths'];
+		$this->psr4_paths = $input['psr4_paths'];
+
+		$this->validate_psr4_paths( $phpcsFile );
+
+		$this->assertSame( $input['psr4_paths'], $this->previous_psr4_paths, 'Previous paths has not been set correctly' );
+		$this->assertSame( $input['expected'], $this->validated_psr4_paths, 'Validated paths has not been set correctly' );
+
+		// Now make sure that the missing basepath resets the validated paths.
+		$phpcsFile->config->basepath = null;
+
+		$this->validate_psr4_paths( $phpcsFile );
+
+		$this->assertSame( $input['psr4_paths'], $this->previous_psr4_paths, 'Previous paths is not still the same' );
+		$this->assertSame( [], $this->validated_psr4_paths, 'Validated paths has not been reset' );
+	}
+
+	/**
+	 * Test validating the $psr4_paths property results in an exception when no prefixes are passed.
+	 *
+	 * @covers ::validate_psr4_paths
+	 *
+	 * @return void
+	 */
+	public function test_validate_psr4_paths_throws_exception_on_missing_prefixes() {
+		$phpcsFile                   = $this->get_mock_file();
+		$phpcsFile->config->basepath = self::CLEAN_BASEPATH;
+
+		// PSR-4 paths contains the same path for two different prefixes.
+		$this->psr4_paths = [
+			'src',
+			'tests',
+		];
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage(
+			'Invalid value passed for `psr4_paths`. Path "src" is not associated with a namespace prefix'
+		);
+
+		$this->validate_psr4_paths( $phpcsFile );
+	}
+
+	/**
+	 * Test validating the $psr4_paths property results in an exception when the same path is passed for multiple prefixes.
+	 *
+	 * @covers ::validate_psr4_paths
+	 *
+	 * @return void
+	 */
+	public function test_validate_psr4_paths_throws_exception_on_duplicate_paths_for_different_prefixes() {
+		$phpcsFile                   = $this->get_mock_file();
+		$phpcsFile->config->basepath = self::DIRTY_BASEPATH;
+
+		// PSR-4 paths contains the same path for two different prefixes.
+		$this->psr4_paths = [
+			'Plugin\Prefix\\'       => 'src/',
+			'Plugin\Prefix\Tests\\' => 'src/,tests/',
+		];
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage(
+			'Invalid value passed for `psr4_paths`. Multiple prefixes include the same path. Problem path: ' . self::CLEAN_BASEPATH . 'src/'
+		);
+
+		$this->validate_psr4_paths( $phpcsFile );
+	}
+
+	/**
+	 * Test validating the $psr4_paths property
+	 *
+	 * @dataProvider data_validate_psr4_paths
+	 * @covers       ::validate_psr4_paths
+	 *
+	 * @param array<string, string> $psr4_paths The initial input for the $psr4_paths property.
+	 * @param array<string, string> $expected   The expected value for the validated property.
+	 *
+	 * @return void
+	 */
+	public function test_validate_psr4_paths( $psr4_paths, $expected ) {
+		$phpcsFile                   = $this->get_mock_file();
+		$phpcsFile->config->basepath = self::CLEAN_BASEPATH;
+
+		$this->psr4_paths = $psr4_paths;
+
+		$this->validate_psr4_paths( $phpcsFile );
+
+		$this->assertSame( $psr4_paths, $this->previous_psr4_paths );
+		$this->assertSame( $expected, $this->validated_psr4_paths );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see test_validate_psr4_paths() For the array format.
+	 *
+	 * @return array<string, array<string, array<string, string>>>
+	 */
+	public static function data_validate_psr4_paths() {
+		return [
+			'empty array' => [
+				'psr4_paths' => [],
+				'expected'   => [],
+			],
+			'array with only empty values' => [
+				'psr4_paths' => [
+					'Plugin\PrefixA' => '',
+					'Plugin\PrefixB' => ' ',
+					'Plugin\PrefixC' => '   ',
+					'Plugin\PrefixD' => '   ,, "   ", \' \' ',
+				],
+				'expected'   => [],
+			],
+
+			'single prefix, single path; no trailing slash at end of prefix' => [
+				'psr4_paths' => [
+					'Plugin\Prefix' => 'src',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/' => 'Plugin\Prefix',
+				],
+			],
+			'single prefix, single path; trailing slash at end of prefix' => [
+				'psr4_paths' => [
+					'Plugin\Prefix\\' => 'src',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/' => 'Plugin\Prefix',
+				],
+			],
+			'single prefix, single path; double slashes within prefix' => [
+				'psr4_paths' => [
+					'Plugin\\Prefix\\Sub\\' => 'src',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/' => 'Plugin\Prefix\Sub',
+				],
+			],
+
+			'single prefix, single path; path has leading slash' => [
+				'psr4_paths' => [
+					'Plugin\Prefix' => '/src',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/' => 'Plugin\Prefix',
+				],
+			],
+			'single prefix, single path; path has trailing slash' => [
+				'psr4_paths' => [
+					'Plugin\Prefix\\' => 'src/',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/' => 'Plugin\Prefix',
+				],
+			],
+			'single prefix, single path; path has leading dot-slash and trailing slash' => [
+				'psr4_paths' => [
+					'Plugin\Prefix\\' => './src/',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/' => 'Plugin\Prefix',
+				],
+			],
+
+			'single prefix, multiple paths; simple comma-separated value' => [
+				'psr4_paths' => [
+					'Plugin\Prefix' => 'src,tests,config',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/'    => 'Plugin\Prefix',
+					self::CLEAN_BASEPATH . 'tests/'  => 'Plugin\Prefix',
+					self::CLEAN_BASEPATH . 'config/' => 'Plugin\Prefix',
+				],
+			],
+			'single prefix, multiple paths; leading/trailing slash variations in comma-separated value' => [
+				'psr4_paths' => [
+					'Plugin\Prefix\\' => 'src/,./tests/,/config',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/'    => 'Plugin\Prefix',
+					self::CLEAN_BASEPATH . 'tests/'  => 'Plugin\Prefix',
+					self::CLEAN_BASEPATH . 'config/' => 'Plugin\Prefix',
+				],
+			],
+			'single prefix, multiple paths; brackets around comma-separated value and spaces within' => [
+				'psr4_paths' => [
+					'Plugin\Prefix' => '[src, tests, config]',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/'    => 'Plugin\Prefix',
+					self::CLEAN_BASEPATH . 'tests/'  => 'Plugin\Prefix',
+					self::CLEAN_BASEPATH . 'config/' => 'Plugin\Prefix',
+				],
+			],
+			'single prefix, multiple paths; brackets around comma-separated value and spaces and single quotes within' => [
+				'psr4_paths' => [
+					'Plugin\Prefix\\' => "[ 'src',   'tests'  , '  config  ']",
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/'    => 'Plugin\Prefix',
+					self::CLEAN_BASEPATH . 'tests/'  => 'Plugin\Prefix',
+					self::CLEAN_BASEPATH . 'config/' => 'Plugin\Prefix',
+				],
+			],
+			'single prefix, multiple paths; brackets around comma-separated value and spaces and double quotes within' => [
+				'psr4_paths' => [
+					'Plugin\Prefix' => '[ "src/", " ./tests", "/config/ " ]',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/'    => 'Plugin\Prefix',
+					self::CLEAN_BASEPATH . 'tests/'  => 'Plugin\Prefix',
+					self::CLEAN_BASEPATH . 'config/' => 'Plugin\Prefix',
+				],
+			],
+			'single prefix, multiple paths; duplicate values' => [
+				'psr4_paths' => [
+					'Plugin\Prefix\\' => 'src, "./src" , /src/',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/'    => 'Plugin\Prefix',
+				],
+			],
+
+			'multiple prefixes, variation of paths' => [
+				'psr4_paths' => [
+					'Plugin\PrefixA'   => 'src',
+					'Plugin\PrefixB\\' => 'tests/,config/',
+					'Plugin\PrefixC'   => '[ \'subA\sub\\\',   "subB"  ,  subC]',
+					'Plugin\PrefixD\\' => '   ,, "   ", \' \' ',
+				],
+				'expected' => [
+					self::CLEAN_BASEPATH . 'src/'      => 'Plugin\PrefixA',
+					self::CLEAN_BASEPATH . 'tests/'    => 'Plugin\PrefixB',
+					self::CLEAN_BASEPATH . 'config/'   => 'Plugin\PrefixB',
+					self::CLEAN_BASEPATH . 'subA/sub/' => 'Plugin\PrefixC',
+					self::CLEAN_BASEPATH . 'subB/'     => 'Plugin\PrefixC',
+					self::CLEAN_BASEPATH . 'subC/'     => 'Plugin\PrefixC',
+				],
+			],
+		];
+	}
+}

--- a/Yoast/Utils/PSR4PathsTrait.php
+++ b/Yoast/Utils/PSR4PathsTrait.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace YoastCS\Yoast\Utils;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\TextStrings;
+
+/**
+ * Trait to add a custom `$psr4_paths` property to sniffs. Including associated utility functions.
+ *
+ * @since 3.0.0
+ */
+trait PSR4PathsTrait {
+
+	/**
+	 * PSR-4 prefix-path definitions as supported by Composer.
+	 *
+	 * Example of how to set this:
+	 * ```xml
+	 * <rule ref="Yoast.Cat.SniffName">
+	 *   <properties>
+	 *     <property name="psr4_paths" type="array">
+	 *       <!-- Prefix mapped to single directory. -->
+	 *       <element key="Monolog\\" value="src/"/>
+	 *       <!-- Prefix mapped to multiple directories. -->
+	 *       <element key="Vendor\\Namespace\\" value="src/,lib/"/>
+	 *     </property>
+	 *   </properties>
+	 * </rule>
+	 * ```
+	 *
+	 * Note: paths are handled case-sensitively!
+	 *
+	 * @var array<string, string> Key should be the prefix, value a comma-separated list of relative paths.
+	 */
+	public $psr4_paths = [];
+
+	/**
+	 * Cache of previously set list of psr4 paths.
+	 *
+	 * Prevents having to do the same path validation over and over again.
+	 *
+	 * @var array<string, string>
+	 */
+	private $previous_psr4_paths = [];
+
+	/**
+	 * Validated & cleaned up list of absolute paths to the directories expecting PSR-4 file names
+	 * with their associated prefixes.
+	 *
+	 * @var array<string, string> Key is the absolute path, value the applicable prefix without trailing slash.
+	 */
+	private $validated_psr4_paths = [];
+
+	/**
+	 * Check if the file is in one of the PSR4 directories.
+	 *
+	 * @param File   $phpcsFile    The file being scanned.
+	 * @param string $path_to_file Optional The absolute path to the file currently being examined.
+	 *                             If not provided, the file name will be retrieved from the File object.
+	 *
+	 * @return bool
+	 */
+	final protected function is_in_psr4_path( File $phpcsFile, $path_to_file = '' ) {
+		return \is_array( $this->get_psr4_info( $phpcsFile, $path_to_file ) );
+	}
+
+	/**
+	 * Retrieve all applicable information for a PSR-4 path.
+	 *
+	 * @param File   $phpcsFile    The file being scanned.
+	 * @param string $path_to_file Optional The absolute path to the file currently being examined.
+	 *                             If not provided, the file name will be retrieved from the File object.
+	 *
+	 * @return array<string, string>|false Array with information about the PSR-4 path. Otherwise FALSE.
+	 */
+	final protected function get_psr4_info( File $phpcsFile, $path_to_file = '' ) {
+		if ( $path_to_file === '' ) {
+			$path_to_file = TextStrings::stripQuotes( $phpcsFile->getFileName() );
+			if ( $path_to_file === 'STDIN' ) {
+				return false;
+			}
+		}
+
+		$this->validate_psr4_paths( $phpcsFile );
+		if ( empty( $this->validated_psr4_paths ) ) {
+			return false;
+		}
+
+		$path_to_file = PathHelper::normalize_absolute_path( $path_to_file );
+
+		foreach ( $this->validated_psr4_paths as $psr4_path => $prefix ) {
+			$remainder = PathHelper::strip_basepath( $path_to_file, $psr4_path );
+			if ( $remainder === $path_to_file ) {
+				// Nothing was stripped, so this wasn't a match.
+				continue;
+			}
+
+			return [
+				'prefix'   => $prefix,
+				'basepath' => $psr4_path,
+				'relative' => \dirname( $remainder ),
+			];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Validate the list of PSR-4 paths passed from a custom ruleset.
+	 *
+	 * This will only need to be done once in a normal PHPCS run, though for
+	 * tests the function may be called multiple times.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException When the `psr4_paths` array is missing keys.
+	 * @throws RuntimeException When the `psr4_paths` array contains duplicate paths in multiple entries.
+	 */
+	private function validate_psr4_paths( File $phpcsFile ) {
+		// The basepath check needs to be done first as otherwise the previous/current comparison would be broken.
+		if ( ! isset( $phpcsFile->config->basepath ) ) {
+			// Only relevant for the tests: make sure previously set validated paths are cleared out.
+			$this->validated_psr4_paths = [];
+
+			// No use continuing as we can't turn relative paths into absolute paths.
+			return;
+		}
+
+		if ( $this->previous_psr4_paths === $this->psr4_paths ) {
+			return;
+		}
+
+		// Set the cache *before* validation so as to not break the above compare.
+		$this->previous_psr4_paths = $this->psr4_paths;
+
+		$validated_paths = [];
+
+		foreach ( $this->psr4_paths as $prefix => $paths ) {
+			if ( \is_string( $prefix ) === false || $prefix === '' ) {
+				throw new RuntimeException(
+					'Invalid value passed for `psr4_paths`. Path "' . $paths . '" is not associated with a namespace prefix'
+				);
+			}
+
+			$prefix = \rtrim( $prefix, '\\' );
+
+			$paths = \rtrim( \ltrim( $paths, '[' ), ']' ); // Trim off potential [] copied over from Composer.json.
+			$paths = \explode( ',', $paths );
+			$paths = \array_map( 'trim', $paths );
+			$paths = \array_map( [ TextStrings::class, 'stripQuotes' ], $paths ); // Trim off potential quotes around the paths copied over.
+			$paths = \array_map( 'trim', $paths );
+			$paths = PathValidationHelper::relative_to_absolute( $phpcsFile, $paths );
+			$paths = \array_unique( $paths ); // Filter out multiple of the same paths for the same prefix.
+
+			foreach ( $paths as $path ) {
+				if ( isset( $validated_paths[ $path ] ) ) {
+					throw new RuntimeException(
+						'Invalid value passed for `psr4_paths`. Multiple prefixes include the same path. Problem path: ' . $path
+					);
+				}
+
+				$validated_paths[ $path ] = $prefix;
+			}
+		}
+
+		// Set the validated value.
+		$this->validated_psr4_paths = $validated_paths;
+	}
+}


### PR DESCRIPTION
This commit introduces a new `PSR4PathsTrait` to add a custom `$psr4_paths` property to sniffs.

The value expected by the `$psr4_paths` property mirrors the `autoload` directive for Composer, with the prefix as the array key and a comma separated list of relative paths as the array value. Multiple PSR-4 paths can be passed (array elements).

Includes utility functions to validate the property value, to verify if an arbitrary file is in one of the PSR4 paths and to retrieve the matched PSR-4 path information.

Includes dedicated unit tests for this trait.