### PR TITLE
NamingConventions/NamespaceName: add support for strict PSR-4 compliance checking

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -79,11 +79,8 @@
 
 	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
-			<property name="prefixes" type="array">
-				<element value="YoastCS\Yoast"/>
-			</property>
-			<property name="src_directory" type="array">
-				<element value="Yoast"/>
+			<property name="psr4_paths" type="array">
+				<element key="YoastCS\Yoast\\" value="Yoast"/>
 			</property>
 		</properties>
 	</rule>

--- a/Yoast/Docs/NamingConventions/NamespaceNameStandard.xml
+++ b/Yoast/Docs/NamingConventions/NamespaceNameStandard.xml
@@ -50,10 +50,18 @@ namespace Yoast\WP\Plugin\Tests\<em>Foo\Bar\Flo\Sub</em>;
     <standard>
     <![CDATA[
     The levels in a namespace name should reflect the path to the file.
+    Optional, strict PSR-4 compliance for the path to namespace name translation can be enforced by setting the `psr4_paths` property.
+
+    The differences between the "basic" path to namespace translation and strict PSR-4 path to namespace translation, are as follows:
+    * The "basic" translation is case-insensitive, while the PSR-4 translation is case-sensitive.
+    * The "basic" translation will convert dashes and other punctuation characters in the path to underscores, while the PSR-4 translation enforces that the names match exactly.
+    * The "basic" translation will accept any of the provided prefixes, while the strict PSR-4 translation will require the exact prefix assigned to the matched PSR-4 path.
+    * The "basic" translation is suitable for use in combination with a Composer classmap for autoloading.
+      The PSR-4 compliant translation is suitable for use in combination with the Composer `psr4` autoload directive.
+
+    If the `psr4_paths` property is provided, the PSR-4 based path translation will always take precedence for a file matching any of the PSR-4 paths.
 
     If a path to name translation would result in an invalid namespace name based on the naming rules for PHP, an error will be thrown to rename the problem directory.
-
-    The plugin specific prefix is disregarded for this check.
     ]]>
     </standard>
     <code_comparison>
@@ -69,6 +77,22 @@ namespace Yoast\WP\Plugin\<em>Admin\Forms</em>;
 <!-- Path to file: <em>admin/forms/</em>file.php -->
 <?php
 namespace Yoast\WP\Plugin\<em>Unrelated</em>;
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: PSR-4 compliant namespace name reflects the path to the file exactly.">
+        <![CDATA[
+<!-- Path to file: <em>User_Forms/</em>file.php -->
+<?php
+namespace Yoast\WP\Plugin\<em>User_Forms</em>;
+        ]]>
+        </code>
+        <code title="Invalid: non-PSR-4 compliant namespace name does not reflect the path to the file exactly.">
+        <![CDATA[
+<!-- Path to file: <em>User_forms/</em>file.php -->
+<?php
+namespace Yoast\WP\Plugin\<em>user_Forms</em>;
         ]]>
         </code>
     </code_comparison>

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTest.php
@@ -171,6 +171,75 @@ final class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 					14 => 1,
 				];
 
+			// Path translation with $psr4_paths set tests.
+			case 'path-translation-psr4.inc':
+				return [
+					11 => 2,
+					12 => 2,
+					21 => 2,
+					22 => 1,
+					23 => 1,
+					33 => 2,
+					34 => 2,
+					35 => 1,
+					36 => 1,
+					37 => 1,
+					53 => 2,
+					54 => 2,
+					70 => 2,
+					71 => 2,
+					72 => 2,
+					73 => 2,
+				];
+
+			case 'path-translation-psr4-case-sensitive-lower.inc':
+				return [
+					11 => 1,
+				];
+
+			case 'path-translation-psr4-case-sensitive-proper.inc':
+				return [
+					12 => 3,
+					13 => 2,
+					14 => 1,
+					15 => 1,
+					16 => 1,
+					26 => 2,
+					27 => 2,
+					28 => 1,
+					29 => 1,
+					39 => 3,
+					40 => 2,
+					41 => 1,
+					42 => 1,
+					52 => 2,
+					53 => 2,
+					54 => 3,
+					55 => 1,
+					56 => 1,
+					66 => 2,
+					67 => 3,
+					68 => 1,
+					69 => 1,
+				];
+
+			case 'path-translation-src-deeper-than-psr4-sub.inc':
+				return [
+					13 => 1,
+					14 => 1,
+					15 => 1,
+					16 => 3,
+					17 => 3,
+				];
+
+			// PSR4 path translation with unconventional chars in directory name.
+			case 'path-translation-psr4-dash.inc':
+			case 'path-translation-psr4-dot.inc':
+			case 'path-translation-psr4-space.inc':
+				return [
+					1 => 1, // Invalid dir error.
+				];
+
 			// Path translation with no matching $src_directory.
 			case 'path-translation-mismatch.inc':
 				return [
@@ -214,6 +283,22 @@ final class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 					127 => 1,
 					128 => 1,
 					129 => 1,
+					147 => 1,
+					148 => 1,
+					149 => 1,
+					150 => 1,
+					151 => 1,
+					152 => 1,
+					153 => 1,
+					154 => 1,
+					172 => 1,
+					173 => 1,
+					174 => 1,
+					175 => 1,
+					176 => 1,
+					177 => 1,
+					178 => 1,
+					179 => 1,
 				];
 
 			case 'no-basepath-scoped.inc':
@@ -224,6 +309,15 @@ final class NamespaceNameUnitTest extends AbstractSniffUnitTest {
 			case 'path-translation-ignore-src-sub-path.inc':
 				return [
 					14 => 1,
+				];
+
+			case 'path-translation-psr4-case-sensitive-proper.inc':
+				return [
+					13 => 1,
+					27 => 1,
+					40 => 1,
+					53 => 1,
+					66 => 1,
 				];
 
 			default:

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/ProperCase/SubPath/path-translation-src-deeper-than-psr4-sub.inc
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/ProperCase/SubPath/path-translation-src-deeper-than-psr4-sub.inc
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Testing that PSR-4 path translation takes precedence over src_directory [5].
+ *
+ * phpcs:set Yoast.NamingConventions.NamespaceName prefixes[] Yoast\WP\Plugin
+ * phpcs:set Yoast.NamingConventions.NamespaceName src_directory[] PSR4_Path/ProperCase
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Prefix\\=>PSR4_Path
+ */
+
+namespace Prefix\ProperCase\SubPath; // Error.
+
+namespace Prefix\SubPath; // Error.
+namespace Prefix\ProperCase\Subpath; // Error.
+namespace Prefix\ProperCase\subpath; // Error.
+namespace Yoast\WP\Plugin\SubPath; // Error.
+namespace Yoast\WP\Plugin\PSR4_Path\ProperCase\SubPath; // Error.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.NamespaceName prefixes[]
+// phpcs:set Yoast.NamingConventions.NamespaceName src_directory[]
+// phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[]

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/ProperCase/path-translation-psr4-case-sensitive-proper.inc
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/ProperCase/path-translation-psr4-case-sensitive-proper.inc
@@ -1,0 +1,74 @@
+<?php
+
+// phpcs:set Yoast.NamingConventions.NamespaceName prefixes[] Yoast\Plugin
+
+/*
+ * Testing PSR-4 path translation, no src_directory.
+ *
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Yoast\WP\Plugin\\=>PSR4_Path
+ */
+namespace Yoast\WP\Plugin\ProperCase; // OK.
+
+namespace Yoast\Plugin\PSR4_Path\ProperCase; // Error x 3.
+namespace Yoast\Plugin\ProperCase; // Error x 2 + warning.
+namespace Yoast\WP\Plugin\propercase; // Error.
+namespace Yoast\WP\Plugin\Propercase; // Error.
+namespace Yoast\WP\Plugin\PROPERCASE; // Error.
+
+/*
+ * Testing that PSR-4 path translation takes precedence over src_directory [1].
+ *
+ * @phpcs:set Yoast.NamingConventions.NamespaceName src_directory[] PSR4_Path/ProperCase
+ * @phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Yoast\WP\Plugin=>PSR4_Path
+ */
+namespace Yoast\WP\Plugin\ProperCase; // OK.
+
+namespace Yoast\Plugin; // Error x 2.
+namespace Yoast\Plugin\ProperCase; // Error x 2 + warning.
+namespace Yoast\WP\Plugin; // Error.
+namespace Yoast\WP\Plugin\PSR4_Path\ProperCase; // Error.
+
+/*
+ * Testing that PSR-4 path translation takes precedence over src_directory [2].
+ *
+ * @phpcs:set Yoast.NamingConventions.NamespaceName src_directory[] PSR4_Path
+ * @phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Yoast\WP\Plugin\\=>.
+ */
+namespace Yoast\WP\Plugin\PSR4_Path\ProperCase; // OK.
+
+namespace Yoast\Plugin\PSR4_Path\ProperCase; // Error x 3.
+namespace Yoast\Plugin\ProperCase; // Error x 2 + warning.
+namespace Yoast\WP\Plugin; // Error.
+namespace Yoast\WP\Plugin\ProperCase; // Error.
+
+/*
+ * Testing that PSR-4 path translation takes precedence over src_directory [3].
+ *
+ * phpcs:set Yoast.NamingConventions.NamespaceName src_directory[] PSR4_Path
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Yoast\WP\Plugin=>PSR4_Path/ProperCase
+ */
+namespace Yoast\WP\Plugin; // OK.
+
+namespace Yoast\Plugin; // Error x 2.
+namespace Yoast\Plugin\ProperCase; // Error x 2 + warning.
+namespace Yoast\Plugin\PSR4_Path\ProperCase; // Error x 3.
+namespace Yoast\WP\Plugin\ProperCase; // Error.
+namespace Yoast\WP\Plugin\PSR4_Path\ProperCase; // Error.
+
+/*
+ * Testing that PSR-4 path translation takes precedence over src_directory [4].
+ *
+ * phpcs:set Yoast.NamingConventions.NamespaceName src_directory[] .
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Yoast\WP\Plugin\\=>PSR4_Path/
+ */
+namespace Yoast\WP\Plugin\ProperCase; // OK.
+
+namespace Yoast\Plugin\ProperCase; // Error x 2 + warning.
+namespace Yoast\Plugin\PSR4_Path\ProperCase; // Error x 3.
+namespace Yoast\WP\Plugin; // Error.
+namespace Yoast\WP\Plugin\PSR4_Path\ProperCase; // Error.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.NamespaceName prefixes[]
+// phpcs:set Yoast.NamingConventions.NamespaceName src_directory[]
+// phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[]

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/lowercase/path-translation-psr4-case-sensitive-lower.inc
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/lowercase/path-translation-psr4-case-sensitive-lower.inc
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Testing path translation in combination with src_directory.
+ *
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Yoast\WP\Plugin\\=>PSR4_Path
+ */
+
+namespace Yoast\WP\Plugin\lowercase; // OK.
+
+namespace Yoast\WP\Plugin\Lowercase; // Error.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[]

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/path-translation-psr4.inc
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/path-translation-psr4.inc
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Testing path translation in combination with psr4_paths, no src directory, no prefixes.
+ *
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] PSR4_Path\\=>PSR4_Path
+ */
+namespace PSR4_Path; // OK.
+
+// PSR-4 names are case-sensitive.
+namespace psr4_Path; // Error x 2.
+namespace Psr4_PATH; // Error x 2.
+
+/*
+ * Testing path translation in combination with psr4_paths, no src directory, no prefixes.
+ *
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] PrefixA\\=>PSR4_Path,PrefixB\\=>OtherPath
+ */
+namespace PrefixA; // OK.
+
+namespace PrefixB; // Error x 2.
+namespace PrefixA\PSR4_PATH; // Error.
+namespace PrefixA\Psr4_path; // Error.
+
+/*
+ * Testing path translation in combination with multiple psr4_paths + src_directory, no prefixes.
+ *
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] PrefixA=>Some_Other,PrefixB=>PSR4_Path,PrefixC=>MyMy
+ * phpcs:set Yoast.NamingConventions.NamespaceName src_directory[] PSR4_Path
+ */
+namespace PrefixB; // OK.
+
+namespace PrefixA; // Error x 2.
+namespace PrefixC; // Error x 2.
+namespace PrefixB\PSR4_Path; // Error.
+namespace PrefixB\psr4_path; // Error.
+namespace PrefixB\PSR4_PATH; // Error.
+
+/*
+ * Testing path translation in combination with psr4_paths + src_directory, with prefix,
+ * when there is no matching PSR4 path due to a case-mismatch.
+ *
+ * In that case, the "normal" rules apply.
+ *
+ * @phpcs:set Yoast.NamingConventions.NamespaceName prefixes[] Yoast\WP\Plugin
+ * phpcs:set Yoast.NamingConventions.NamespaceName src_directory[] .
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Prefix\\=>pSr4_path
+ */
+namespace Yoast\WP\Plugin\PSR4_Path; // OK.
+namespace Yoast\WP\Plugin\Psr4_PATH; // OK.
+namespace Yoast\WP\Plugin\psr4_path; // OK.
+
+namespace Prefix; // Error x 2.
+namespace Prefix\PSR4_Path; // Error x 2.
+
+/*
+ * Testing path translation in combination with psr4_paths + src_directory, with prefix,
+ * when there is no matching PSR4 path.
+ *
+ * In that case, the "normal" rules apply.
+ *
+ * @phpcs:set Yoast.NamingConventions.NamespaceName prefixes[] Yoast\WP\Plugin
+ * phpcs:set Yoast.NamingConventions.NamespaceName src_directory[] .
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] PrefixA\\=>not-this-path,PrefixB\\=>Invalid
+ */
+namespace Yoast\WP\Plugin\PSR4_Path; // OK.
+namespace Yoast\WP\Plugin\Psr4_PATH; // OK.
+namespace Yoast\WP\Plugin\psr4_path; // OK.
+
+namespace PrefixA; // Error x 2.
+namespace PrefixA\PSR4_Path; // Error x 2.
+namespace PrefixB; // Error x 2.
+namespace PrefixB\PSR4_Path; // Error x 2.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.NamespaceName prefixes[]
+// phpcs:set Yoast.NamingConventions.NamespaceName src_directory[]
+// phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[]

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/sub path/path-translation-psr4-space.inc
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/sub path/path-translation-psr4-space.inc
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * Testing path translation when the path contains characters not allowed in a namespace.
+ *
+ * @phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Yoast\WP\Plugin=>PSR4_Path
+ */
+
+namespace Yoast\WP\Plugin\PSR4_Path\Sub Path; // Error: invalid path. Would cause parse error, illegal space in namespace.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[]

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/sub#path/path-translation-psr4-hash.inc
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/sub#path/path-translation-psr4-hash.inc
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * Testing path translation.
+ *
+ * @phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Yoast\WP\Plugin\\=>PSR4_Path
+ */
+
+namespace Yoast\WP\Plugin\PSR4_Path\Sub#Path; // Error: invalid path. Would cause parse error, unexpected end of file, sniff won't be able to reliably retrieve the namespace.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[]

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/sub-path/path-translation-psr4-dash.inc
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/sub-path/path-translation-psr4-dash.inc
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * Testing path translation.
+ *
+ * @phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Yoast\WP\Plugin\\=>PSR4_Path
+ */
+
+namespace Yoast\WP\Plugin\PSR4_Path\Sub-Path; // Error: invalid path. Would cause parse error, illegal dash in namespace.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[]

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/sub.path/path-translation-psr4-dot.inc
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/PSR4_Path/sub.path/path-translation-psr4-dot.inc
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * Testing path translation.
+ *
+ * @phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Yoast\WP\Plugin=>PSR4_Path
+ */
+
+namespace Yoast\WP\Plugin\PSR4_Path\Sub.Path; // Error: invalid path. Would cause parse error, illegal concatenation in namespace.
+
+// Reset to default settings.
+// phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[]

--- a/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/no-basepath.inc
+++ b/Yoast/Tests/NamingConventions/NamespaceNameUnitTests/no-basepath.inc
@@ -128,8 +128,59 @@ namespace Yoast\WP\Plugin\Tests\Unit\Mocks\Foo\Bar\Baz; // Warning.
 namespace Yoast\WP\Plugin\Tests\WP\Fixtures\Foo\Bar\Baz; // Warning.
 namespace Yoast\WP\Plugin\Tests\Unit\Fixtures\Foo\Bar\Baz; // Warning.
 
+/*
+ * Test allowing for more variations of test directories and deeper double directories based on PSR4 paths.
+ *
+ * phpcs:set Yoast.NamingConventions.NamespaceName prefixes[]
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] Prefix\Foo=>PSR4_Path,Prefix\Bar=>OtherPath
+ */
+
+namespace Prefix\Foo\Tests\WP\Foo\Bar; // OK.
+namespace Prefix\Bar\Tests\Unit\Foo\Bar; // OK.
+namespace Prefix\Foo\Tests\WP\Doubles\Foo\Bar; // OK.
+namespace Prefix\Bar\Tests\Unit\Doubles\Foo\Bar; // OK.
+namespace Prefix\Foo\Tests\WP\Mocks\Foo\Bar; // OK.
+namespace Prefix\Bar\Tests\Unit\Mocks\Foo\Bar; // OK.
+namespace Prefix\Foo\Tests\WP\Fixtures\Foo\Bar; // OK.
+namespace Prefix\Bar\Tests\Unit\Fixtures\Foo\Bar; // OK.
+
+namespace Prefix\Foo\Tests\WP\Foo\Bar\Baz; // Warning.
+namespace Prefix\Bar\Tests\Unit\Foo\Bar\Baz; // Warning.
+namespace Prefix\Foo\Tests\WP\Doubles\Foo\Bar\Baz; // Warning.
+namespace Prefix\Bar\Tests\Unit\Doubles\Foo\Bar\Baz; // Warning.
+namespace Prefix\Foo\Tests\WP\Mocks\Foo\Bar\Baz; // Warning.
+namespace Prefix\Bar\Tests\Unit\Mocks\Foo\Bar\Baz; // Warning.
+namespace Prefix\Foo\Tests\WP\Fixtures\Foo\Bar\Baz; // Warning.
+namespace Prefix\Bar\Tests\Unit\Fixtures\Foo\Bar\Baz; // Warning.
+
+/*
+ * Test with PSR4 paths where the prefix already includes `Tests`.
+ *
+ * phpcs:set Yoast.NamingConventions.NamespaceName prefixes[]
+ * phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[] PrefixA\Tests\\=>PSR4_Path
+ */
+
+namespace PrefixA\Tests\WP\Foo\Bar; // OK.
+namespace PrefixA\Tests\Unit\Foo\Bar; // OK.
+namespace PrefixA\Tests\WP\Doubles\Foo\Bar; // OK.
+namespace PrefixA\Tests\Unit\Doubles\Foo\Bar; // OK.
+namespace PrefixA\Tests\WP\Mocks\Foo\Bar; // OK.
+namespace PrefixA\Tests\Unit\Mocks\Foo\Bar; // OK.
+namespace PrefixA\Tests\WP\Fixtures\Foo\Bar; // OK.
+namespace PrefixA\Tests\Unit\Fixtures\Foo\Bar; // OK.
+
+namespace PrefixA\Tests\WP\Foo\Bar\Baz; // Warning.
+namespace PrefixA\Tests\Unit\Foo\Bar\Baz; // Warning.
+namespace PrefixA\Tests\WP\Doubles\Foo\Bar\Baz; // Warning.
+namespace PrefixA\Tests\Unit\Doubles\Foo\Bar\Baz; // Warning.
+namespace PrefixA\Tests\WP\Mocks\Foo\Bar\Baz; // Warning.
+namespace PrefixA\Tests\Unit\Mocks\Foo\Bar\Baz; // Warning.
+namespace PrefixA\Tests\WP\Fixtures\Foo\Bar\Baz; // Warning.
+namespace PrefixA\Tests\Unit\Fixtures\Foo\Bar\Baz; // Warning.
+
 // Reset to default settings.
 // phpcs:set Yoast.NamingConventions.NamespaceName prefixes[]
+// phpcs:set Yoast.NamingConventions.NamespaceName psr4_paths[]
 
 /*
  * Test against false positives for namespace operator and incorrect namespace declarations.


### PR DESCRIPTION
As the Yoast plugin test directories will start to follow PSR-4. the `NamespaceName` sniff will need to be able to enforce this.

This commit adds this ability to the sniff.

Notes:
* It adds a new `public` `psr4_paths` ruleset property via the `PSR4PathsTrait` utility.
* If the file being examined is in a path indicated as a PSR-4 path, PSR-4 based namespace names will be enforced. The differences between the "old-style" enforcement and PSR-4 are in case-sensitivity and in how characters which are allowed in paths, but not allowed in namespace names are handled.
* Includes updated error message/code for the "missing prefix" check when the file is in a PSR-4 path.
* Includes updated/adjusted logic for the "not counting of `Tests`/`Doubles`" directories as the `Tests` may be part of the PSR-4 namespace.

Also note that when both a `psr4_paths` as well as the `src_directory` and `prefixes` properties are set, the `psr4_paths` property will take precedence and the sniff will only fall back to the previous logic if the file is not in a path matching one of the PSR-4 directories.

Includes ample tests for this new functionality.
Includes updated XML documentation.

Includes updating the YoastCS native PHPCS ruleset to indicate that the YoastCS repo follows PSR-4 (as per the PHPCS file name rules).

Note: if the name in use in the file is causing a problematic parse error (like in the test with the `#` in the namespace name), the sniff will stay silent. This is the normal behaviour for a PHPCS check when encountering parse errors.

:point_right: The sniff changes are probably easiest to review while ignoring whitespace.