### PR TITLE
YoastCS rules: remove exclusion for empty lines

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -44,8 +44,6 @@
 			<property name="minimum_wp_version" value="6.2"/>
 		</properties>
 
-		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>
-
 		<!-- No need for this sniff as every Yoast travis script includes linting all files. -->
 		<exclude name="Generic.PHP.Syntax"/>
 


### PR DESCRIPTION
The `Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines` error code flags consecutive blank lines within function declarations.

This rule was previously silenced in YoastCS, but will now be enabled.

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | 1
| Duplicate Post    | 1
| Yst ACF           | 2
| Yst WooCommerce   | --
| Yst News          | 1
| Yst Local         | 9
| Yst Video         | 23
| Yst Premium       | 20
| Yst Free          | 11

Related to #303