### PR TITLE
YoastCS rules: exclude files from other plugins

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -18,6 +18,9 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor(_prefixed)?/*</exclude-pattern>
 
+	<!-- Always exclude files from other plugins which may be installed for test purposes. -->
+	<exclude-pattern>*/wp-content/plugins*</exclude-pattern>
+
 
 	<!--
 	#############################################################################


### PR DESCRIPTION
Other plugins may be installed in a `wp-content/plugins` subdirectory to be available for test situations.

Those files should not be included in a PHPCS scan.