### PR TITLE
GH Actions/test: update for the release of PHP 8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php_version: ['7.3', '8.0', '8.1', '8.2']
+        php_version: ['7.3', '8.0', '8.1', '8.2', '8.3']
         cs_dependencies: ['lowest', 'stable']
 
         include:
@@ -50,17 +50,17 @@ jobs:
           # Test against dev versions of all CS dependencies with select PHP versions for early detection of issues.
           - php_version: '8.0'
             cs_dependencies: 'dev'
-          - php_version: '8.2'
+          - php_version: '8.3'
             cs_dependencies: 'dev'
 
           # Experimental build(s). These are allowed to fail.
           # PHP nightly
-          - php_version: '8.3'
+          - php_version: '8.4'
             cs_dependencies: 'dev'
 
     name: "Test${{ matrix.cs_dependencies == 'stable' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - CS Deps ${{ matrix.cs_dependencies }}"
 
-    continue-on-error: ${{ matrix.php == '8.3' }}
+    continue-on-error: ${{ matrix.php == '8.4' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
... which is expected later today.

* Builds against PHP 8.3 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.4.