### PR TITLE
GH Actions: switch to Coveralls action runner to upload reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,26 +220,14 @@ jobs:
       - name: Run the unit tests with code coverage
         run: composer coverage
 
-      # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
-      - name: Switch to PHP 7.4
-        if: ${{ success() && matrix.php_version != '7.4' }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.4
-          coverage: none
-
-      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
-      - name: Install Coveralls
-        if: ${{ success() }}
-        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
-
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-          COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: php-${{ matrix.php_version }}-cs-${{ matrix.cs_dependencies }}
-        run: php-coveralls -v -x build/logs/clover.xml
+        uses: coverallsapp/github-action@v2
+        with:
+          format: clover
+          file: build/logs/clover.xml
+          flag-name: php-${{ matrix.php_version }}-cs-${{ matrix.cs_dependencies }}
+          parallel: true
 
   coveralls-finish:
     needs: coverage
@@ -251,5 +239,4 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.COVERALLS_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
Simplify the code coverage workflow by removing the dependency on the `php-coveralls/php-coveralls` package and switching to the `coverallsapp/github-action` action runner, which, as of the release of the [0.6.5 version of the Coverage Reporter](https://github.com/coverallsapp/coverage-reporter/releases/tag/v0.6.5) now natively supports the Clover format.

The `COVERALLS_TOKEN` can now be removed from Settings -> Secrets.