### PR TITLE
Switch to PHPCSStandards/PHP_CodeSniffer

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Clean up: make sure to reset all the file changes made during testing!
 #### Public properties
 
 Some sniffs will behave differently based on the value of the sniff's `public` properties.
-These properties can be set [from a custom ruleset](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset) or in a test situation, in-line using `// phpcs:set Yoast.Category.SniffName propertyName propertyValue`.
+These properties can be set [from a custom ruleset](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset) or in a test situation, in-line using `// phpcs:set Yoast.Category.SniffName propertyName propertyValue`.
 
 If the results you are getting when testing are different from what you expected, first thing to do is to check whether the sniff has `public` properties, what those properties are set to (in your custom ruleset or in a test file in-line) and whether that setting is interferring with the results.
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,7 +8,7 @@
 	<!--
 	#############################################################################
 	COMMAND LINE ARGUMENTS
-	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
 	#############################################################################
 	-->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -468,7 +468,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 Initial public release as a stand-alone package.
 
 
-[PHP_CodeSniffer]:         https://github.com/squizlabs/PHP_CodeSniffer/releases
+[PHP_CodeSniffer]:         https://github.com/PHPCSStandards/PHP_CodeSniffer/releases
 [WordPressCS]:             https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/CHANGELOG.md
 [PHPCompatibilityWP]:      https://github.com/PHPCompatibility/PHPCompatibilityWP#changelog
 [PHPCompatibility]:        https://github.com/PHPCompatibility/PHPCompatibility/blob/master/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Typically, (a variation on) the following snippet would be added to the `compose
 
 ## PHP Code Sniffer
 
-Set of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) rules.
+Set of [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) rules.
 
 Severity levels:
 
@@ -65,7 +65,7 @@ Severity levels:
 The `Yoast` standard for PHP_CodeSniffer is comprised of the following:
 * The `WordPress` ruleset from the [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards) implementing the official [WordPress PHP Coding Standards](https://make.wordpress.org/core/handbook/coding-standards/php/), with some [select exclusions](https://github.com/Yoast/yoastcs/blob/develop/Yoast/ruleset.xml#L29-L75).
 * The [`PHPCompatibilityWP`](https://github.com/PHPCompatibility/PHPCompatibilityWP) ruleset which checks code for PHP cross-version compatibility while preventing false positives for functionality polyfilled within WordPress.
-* Select additional sniffs taken from [`PHP_CodeSniffer`](https://github.com/squizlabs/PHP_CodeSniffer).
+* Select additional sniffs taken from [`PHP_CodeSniffer`](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 * Select additional sniffs taken from [`PHPCSExtra`](https://github.com/PHPCSStandards/PHPCSExtra).
 * A number of custom Yoast specific sniffs.
 
@@ -93,7 +93,7 @@ Not all sniffs have documentation available about what they sniff for, but for t
 "vendor/bin/phpcs" --extensions=php /path/to/folder/
 ```
 
-For more command-line options, please have a read through the [PHP_CodeSniffer documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage).
+For more command-line options, please have a read through the [PHP_CodeSniffer documentation](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage).
 
 #### Yoast plugin repositories
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -6,7 +6,7 @@
 	<!--
 	#############################################################################
 	COMMAND LINE ARGUMENTS
-	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
 	#############################################################################
 	-->
 

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,9 @@
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.4",
-		"phpcsstandards/phpcsextra": "^1.1.2",
-		"phpcsstandards/phpcsutils": "^1.0.8",
-		"squizlabs/php_codesniffer": "^3.7.2",
+		"phpcsstandards/phpcsextra": "^1.2.1",
+		"phpcsstandards/phpcsutils": "^1.0.9",
+		"squizlabs/php_codesniffer": "^3.8.0",
 		"wp-coding-standards/wpcs": "^3.0.1"
 	},
 	"require-dev": {


### PR DESCRIPTION
### Switch to PHPCSStandards/PHP_CodeSniffer

The Squizlabs repo has been abandoned. The project continues in a fork in the PHPCSStandards organisation.

Ref:
* squizlabs/PHP_CodeSniffer#3932

### Composer: raise minimum PHPCS version and update various version constraints

... after the tooling has also updated to the PHPCSStandards version of PHPCS.

Refs:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.8.0
* https://github.com/PHPCSStandards/PHPCSUtils/releases
* https://github.com/PHPCSStandards/PHPCSExtra/releases