### PR TITLE
Tests: allow for PHPUnit 8/9

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1' # Can be updated to "latest" once PHPCS 3.8.0 has been released.
+          php-version: 'latest'
           coverage: none
           tools: cs2pr
 
@@ -41,10 +41,6 @@ jobs:
       # @link https://getcomposer.org/doc/03-cli.md#validate
       - name: Validate Composer installation
         run: composer validate --no-check-all --strict
-
-      # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
-      - name: 'Composer: adjust dependencies - remove PHPUnit'
-        run: composer remove --no-update --dev phpunit/phpunit --no-scripts --no-interaction
 
       # Use the WIP/develop branches of all CS dependencies as an early detection system for bugs upstream.
       - name: 'Composer: adjust dependencies - use dev versions of CS dependencies'

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -59,32 +59,23 @@ jobs:
       - name: "Composer: set PHPCS dependencies for tests (dev)"
         if: ${{ matrix.cs_dependencies == 'dev' }}
         run: >
-          composer require --no-update --no-scripts --no-interaction --ignore-platform-req=php+
+          composer require --no-update --no-scripts --no-interaction
           squizlabs/php_codesniffer:"dev-master"
           phpcsstandards/phpcsutils:"dev-develop"
           wp-coding-standards/wpcs:"dev-develop"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-      - name: Install Composer dependencies - normal
-        if: ${{ startsWith( matrix.php_version, '8' ) == false && matrix.php_version != 'latest' }}
+      - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # For PHP 8.0 and higher, we need to install with ignore platform reqs as not all dependencies allow it.
-      - name: Install Composer dependencies - with ignore platform
-        if: ${{ startsWith( matrix.php_version, '8' ) || matrix.php_version == 'latest' }}
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: --ignore-platform-req=php+
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
       - name: "Composer: downgrade PHPCS dependencies for tests (lowest) (with ignore platform)"
         if: ${{ matrix.cs_dependencies == 'lowest' }}
         run: >
-          composer update --prefer-lowest --no-scripts --no-interaction --ignore-platform-req=php+
+          composer update --prefer-lowest --no-scripts --no-interaction
           squizlabs/php_codesniffer
           phpcsstandards/phpcsutils
           wp-coding-standards/wpcs
@@ -96,10 +87,5 @@ jobs:
         if: matrix.cs_dependencies == 'stable'
         run: composer lint
 
-      - name: Run the unit tests - PHP 7.2 - 8.0
-        if: ${{ matrix.php_version < '8.1' && matrix.php_version != 'latest' }}
+      - name: Run the unit tests
         run: composer test
-
-      - name: Run the unit tests - PHP 8.1+
-        if: ${{ matrix.php_version >= '8.1' || matrix.php_version == 'latest'}}
-        run: composer test -- --no-configuration --bootstrap=./phpunit-bootstrap.php --dont-report-useless-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,20 +37,20 @@ jobs:
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php_version: ['7.3', '8.0', '8.1', '8.2', '8.3']
+        php_version: ['7.3', '7.4', '8.0', '8.1', '8.2']
         cs_dependencies: ['lowest', 'stable']
 
         include:
           # Make the matrix complete (when combined with the code coverage builds).
           - php_version: '7.2'
             cs_dependencies: 'stable'
-          - php_version: '7.4'
+          - php_version: '8.3'
             cs_dependencies: 'stable'
 
           # Test against dev versions of all CS dependencies with select PHP versions for early detection of issues.
-          - php_version: '8.0'
+          - php_version: '7.4'
             cs_dependencies: 'dev'
-          - php_version: '8.3'
+          - php_version: '8.1'
             cs_dependencies: 'dev'
 
           # Experimental build(s). These are allowed to fail.
@@ -88,7 +88,7 @@ jobs:
       - name: "Composer: set PHPCS dependencies for tests (dev)"
         if: ${{ matrix.cs_dependencies == 'dev' }}
         run: >
-          composer require --no-update --no-scripts --no-interaction --ignore-platform-req=php+
+          composer require --no-update --no-scripts --no-interaction
           squizlabs/php_codesniffer:"${{ env.PHPCS_HIGHEST }}"
           phpcsstandards/phpcsutils:"${{ env.UTILS_HIGHEST }}"
           wp-coding-standards/wpcs:"${{ env.WPCS_HIGHEST }}"
@@ -96,24 +96,15 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: ${{ startsWith( matrix.php_version, '8' ) == false }}
         uses: ramsey/composer-install@v2
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # For PHP 8/"nightly", we need to install with ignore platform reqs as we're still using PHPUnit 7.
-      - name: Install Composer dependencies - with ignore platform
-        if: ${{ startsWith( matrix.php_version, '8' ) }}
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: --ignore-platform-req=php+
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      - name: "Composer: downgrade PHPCS dependencies for tests (lowest) (with ignore platform)"
+      - name: "Composer: downgrade PHPCS dependencies for tests (lowest)"
         if: ${{ matrix.cs_dependencies == 'lowest' }}
         run: >
-          composer update --prefer-lowest --no-scripts --no-interaction --ignore-platform-req=php+
+          composer update --prefer-lowest --no-scripts --no-interaction
           squizlabs/php_codesniffer
           phpcsstandards/phpcsutils
           wp-coding-standards/wpcs
@@ -130,13 +121,8 @@ jobs:
         if: ${{ matrix.cs_dependencies == 'stable' }}
         run: composer lint -- --checkstyle | cs2pr
 
-      - name: Run the unit tests - PHP 7.2 - 8.0
-        if: ${{ matrix.php_version < '8.1' }}
+      - name: Run the unit tests
         run: composer test
-
-      - name: Run the unit tests - PHP 8.1+
-        if: ${{ matrix.php_version >= '8.1' }}
-        run: composer test -- --no-configuration --bootstrap=./phpunit-bootstrap.php --dont-report-useless-tests
 
   #### CODE COVERAGE STAGE ####
   # N.B.: Coverage is only checked on the lowest and highest stable PHP versions
@@ -152,8 +138,7 @@ jobs:
 
     strategy:
       matrix:
-        # 7.4 should be updated to 8.x when higher PHPUnit versions can be supported.
-        php_version: ['7.2', '7.4']
+        php_version: ['7.2', '8.3']
         cs_dependencies: ['lowest', 'dev']
 
     name: "Coverage${{ matrix.cs_dependencies == 'stable' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - CS Deps ${{ matrix.cs_dependencies }}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ composer.lock
 .phpcs.xml
 phpcs.xml
 phpunit.xml
+.phpunit.result.cache
 build/

--- a/Yoast/Tests/Utils/PSR4PathsTraitTest.php
+++ b/Yoast/Tests/Utils/PSR4PathsTraitTest.php
@@ -34,11 +34,9 @@ final class PSR4PathsTraitTest extends NonSniffTestCase {
 	/**
 	 * Clean up the trait after each test.
 	 *
-	 * @after
-	 *
 	 * @return void
 	 */
-	protected function clean_up() {
+	protected function tearDown(): void {
 		$this->psr4_paths           = [];
 		$this->previous_psr4_paths  = [];
 		$this->validated_psr4_paths = [];

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",
 		"phpcsstandards/phpcsdevtools": "^1.2.1",
-		"phpunit/phpunit": "^7.0",
+		"phpunit/phpunit": "^8.0 || ^9.0",
 		"roave/security-advisories": "dev-master"
 	},
 	"minimum-stability": "dev",


### PR DESCRIPTION
PHP_CodeSniffer 3.8.0 now allows for running the tests, which are based on the PHPCS native test suite, with PHPUnit 8 and 9.

This commit updates the package to take advantage of that.

Includes:
* Update the PHPUnit version requirements.
    As this package no longer supports PHP < 7.2, PHPUnit 8 + 9 is all that's needed.
* Adding the PHPUnit 8+ cache file to `.gitignore`.
* Simplifications to the `quicktest` and `test` workflows. Also, the code coverage "high" run can now be run against PHP 8.3.
* Removing a no longer needed `--ignore-platform*` argument.
* MInor tweaks to the CS run on the code of YoastCS itself.
* Normalize a teardown method. This was set up with an `@after` tag in anticipation of this PR, but before dropping support for PHP < 7.2. As PHP < 7.2 has been dropped, we don't need to support PHPUnit 7 or lower anymore, so don't need this tweak to make the fixture methods cross-version compatible anymore.

Ref:
* PHPCSStandards/PHP_CodeSniffer#59