### PR TITLE
YoastCS: add more generic rules

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -215,6 +215,9 @@
 		 consistently at the start of the line. -->
 	<rule ref="Universal.Operators.ConcatPosition"/>
 
+	<!-- CS/QA: Disallow implicit array creation. -->
+	<rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
+
 
 	<!--
 	#############################################################################

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -218,6 +218,9 @@
 	<!-- CS/QA: Disallow implicit array creation. -->
 	<rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
 
+	<!-- CS/QA: Enforce static closures when a closure doesn't access $this. -->
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
+
 
 	<!--
 	#############################################################################

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -196,6 +196,9 @@
 		</properties>
 	</rule>
 
+	<!-- CS/QA: Forbid the use of the and/or logical operators. -->
+	<rule ref="Universal.Operators.DisallowLogicalAndOr"/>
+
 	<!-- CS: enforce that boolean operators between conditions in multi-line control structures are
 		 consistently at the start or end of the line, not a mix of both. -->
 	<rule ref="PSR12.ControlStructures.BooleanOperatorPlacement">

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -176,6 +176,13 @@
 	<!-- Demand that "else(if)" is on a new line after the scope closer of the preceding if. -->
 	<rule ref="Universal.ControlStructures.IfElseDeclaration"/>
 
+	<!-- CS: Forbid the use of alternative control structure syntax, except in combination with inline HTML. -->
+	<rule ref="Universal.ControlStructures.DisallowAlternativeSyntax">
+		<properties>
+			<property name="allowWithInlineHTML" value="true"/>
+		</properties>
+	</rule>
+
 	<!-- Error prevention: Make sure the condition in a inline if declaration is bracketed. -->
 	<rule ref="Squiz.ControlStructures.InlineIfDeclaration"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -169,6 +169,10 @@
 	<!-- PHPCS 3.5.0: This sniff may be added to WPCS in due time and can then be removed from this ruleset. -->
 	<rule ref="PSR12.Files.OpenTag"/>
 
+	<!-- CS: Enforces that a PHP open tag uses lowercase. -->
+	<!-- PHPCSExtra 1.2.0: This sniff may be added to WPCS in due time and can then be removed from this ruleset. -->
+	<rule ref="Universal.PHP.LowercasePHPTag"/>
+
 	<!-- Demand that "else(if)" is on a new line after the scope closer of the preceding if. -->
 	<rule ref="Universal.ControlStructures.IfElseDeclaration"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -199,6 +199,9 @@
 	<!-- CS/QA: Forbid the use of the and/or logical operators. -->
 	<rule ref="Universal.Operators.DisallowLogicalAndOr"/>
 
+	<!-- CS/QA: Forbid the use double `!`. -->
+	<rule ref="Universal.CodeAnalysis.NoDoubleNegative"/>
+
 	<!-- CS: enforce that boolean operators between conditions in multi-line control structures are
 		 consistently at the start or end of the line, not a mix of both. -->
 	<rule ref="PSR12.ControlStructures.BooleanOperatorPlacement">

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -211,6 +211,10 @@
 		</properties>
 	</rule>
 
+	<!-- CS: enforce that concatenation operators in multi-line concatenations are
+		 consistently at the start of the line. -->
+	<rule ref="Universal.Operators.ConcatPosition"/>
+
 
 	<!--
 	#############################################################################


### PR DESCRIPTION
### YoastCS rules: enforce lowercase PHP tags

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | --
| Yst Free          | --

### YoastCS rules: disallow alternative control structure syntax

... except when there is inline HTML nested within the control structure body.

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | --
| Yst Free          | --

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: disallow the use of the logical and/or operators

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | --
| Yst Free          | --

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: forbid double negation

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | --
| Yst Free          | --

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: enforce consistent concatenation operator position

... for multi-line concatenations.

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | --
| Yst Free          | 90

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: disallow implicit array creation

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | 54
| Yst Video         | --
| Yst Premium       | --
| Yst Free          | --

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: enforce closures to be static

... when the `$this` variable is not accessed.

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | --
| Yst Free          | 2

Note: this rule was previously already "silently" enforced via clean-up sweeps.

---

Related to #303
