### PR TITLE
YoastCS rules: flag unused/undefined variables

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -51,6 +51,7 @@ jobs:
           phpcsstandards/phpcsextra:"dev-develop"
           wp-coding-standards/wpcs:"dev-develop"
           slevomat/coding-standard:"dev-master"
+          sirbrillig/phpcs-variable-analysis:"2.x"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Severity levels:
 The `Yoast` standard for PHP_CodeSniffer is comprised of the following:
 * The `WordPress` ruleset from the [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards) implementing the official [WordPress PHP Coding Standards](https://make.wordpress.org/core/handbook/coding-standards/php/), with some [select exclusions](https://github.com/Yoast/yoastcs/blob/develop/Yoast/ruleset.xml#L29-L75).
 * The [`PHPCompatibilityWP`](https://github.com/PHPCompatibility/PHPCompatibilityWP) ruleset which checks code for PHP cross-version compatibility while preventing false positives for functionality polyfilled within WordPress.
+* The [`VariableAnalysis`](https://github.com/sirbrillig/phpcs-variable-analysis/) ruleset.
 * Select additional sniffs taken from [`PHP_CodeSniffer`](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 * Select additional sniffs taken from [`PHPCSExtra`](https://github.com/PHPCSStandards/PHPCSExtra).
 * Select additional sniffs taken from [`SlevomatCodingStandard`](https://github.com/slevomat/coding-standard).

--- a/Yoast/Reports/Threshold.php
+++ b/Yoast/Reports/Threshold.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Reports\Report;
  * available which can be used in calling scripts.
  *
  * @since 2.2.0
+ *
+ * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Flags unused params which are required via the interface. Invalid.
  */
 final class Threshold implements Report {
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -161,6 +161,25 @@
 
 	<!--
 	#############################################################################
+	SNIFF FOR USE OF UNDEFINED/UNUSED VARIABLES
+	#############################################################################
+	-->
+	<rule ref="VariableAnalysis">
+		<properties>
+			<property name="allowUnusedCaughtExceptions" value="true"/>
+			<property name="allowUnusedParametersBeforeUsed" value="true"/>
+			<property name="allowUnusedForeachVariables" value="true"/>
+			<property name="allowWordPressPassByRefFunctions" value="true"/>
+
+			<!-- These two properties (attempt to) prevent false positives for interaction with views. -->
+			<property name="allowUnusedVariablesBeforeRequire" value="true"/>
+			<property name="allowUndefinedVariablesInFileScope" value="true"/>
+		</properties>
+	</rule>
+
+
+	<!--
+	#############################################################################
 	ADD SOME SPECIFIC EXTRA SNIFFS
 	These may make it into WPCS at some point. If so, they can be removed here.
 	#############################################################################

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
 		"phpcompatibility/phpcompatibility-wp": "^2.1.4",
 		"phpcsstandards/phpcsextra": "^1.2.1",
 		"phpcsstandards/phpcsutils": "^1.0.9",
+		"sirbrillig/phpcs-variable-analysis": "^2.11.17",
 		"slevomat/coding-standard": "^8.14.0",
 		"squizlabs/php_codesniffer": "^3.8.0",
 		"wp-coding-standards/wpcs": "^3.0.1"


### PR DESCRIPTION
### Composer: add VariableAnalysis package requirement

### YoastCS rules: flag unused/undefined variables

Related to #303

Impact on Yoast packages (individual results still need review):

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | 5
| WHIP              | 1
| Yoast Test Helper | 5
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | 2
| Yst Local         | 99
| Yst Video         | 38
| Yst Premium       | 33
| Yst Free          | 108