### PR TITLE
YoastCS: more code structure rules

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -227,6 +227,19 @@
 	SNIFFS RELATED TO CODE STRUCTURING
 	#############################################################################
 	-->
+	<!-- CS/QA: Enforce consistent order of OO structures. -->
+	<rule ref="SlevomatCodingStandard.Classes.ClassStructure">
+		<properties>
+			<property name="groups" type="array">
+				<element value="uses"/>
+				<element value="enum cases"/>
+				<element value="constants"/>
+				<element value="properties"/>
+				<element value="methods"/>
+			</property>
+		</properties>
+	</rule>
+
 	<!-- CS: ensure exactly one blank line before each property declaration. -->
 	<rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -243,6 +243,16 @@
 	<!-- CS: ensure exactly one blank line before each property declaration. -->
 	<rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
 
+	<!-- CS/QA: Forbid the use long closures. Use named functions instead. -->
+	<rule ref="Universal.FunctionDeclarations.NoLongClosures">
+		<properties>
+			<property name="maxLines" value="10"/>
+		</properties>
+
+		<!-- Disable the warning, only have an error. -->
+		<exclude name="Universal.FunctionDeclarations.NoLongClosures.ExceedsRecommended"/>
+	</rule>
+
 
 	<!--
 	#############################################################################


### PR DESCRIPTION
### YoastCS rules: enforce a consistent OO structure order

Related to #303

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | 1
| Yst Free          | --

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: disallow long closures

This sniff will throw an error when a closure is more than 10 lines long.

Note: blank lines and comment-only lines are not includes in the closure line count.

Related to #303

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | 1 error (11 lines)
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | 1 error (17 lines)
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | 1 error (16 lines)
| Yst Video         | --
| Yst Premium       | 1 error (15 lines)
| Yst Free          | 3 errors (21/25/37 lines)