### PR TITLE
YoastCS: more namespace/import use rules

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -273,6 +273,18 @@
 	</rule>
 
 
+	<!-- NAMESPACED FILES AND IMPORT USE STATEMENTS -->
+
+	<!-- CS/QA: Enforce all classes to be imported. -->
+	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+		<properties>
+			<property name="searchAnnotations" value="true"/>
+			<property name="allowFullyQualifiedGlobalConstants" value="true"/>
+			<property name="allowFullyQualifiedGlobalFunctions" value="true"/>
+		</properties>
+	</rule>
+
+
 	<!--
 	#############################################################################
 	SNIFFS RELATED TO COMMENTS AND DOCBLOCKS

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -300,6 +300,9 @@
 		</properties>
 	</rule>
 
+	<!-- CS/QA: Disallow import use statements for structures in the same namespace. -->
+	<rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
+
 
 	<!--
 	#############################################################################

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -303,6 +303,10 @@
 	<!-- CS/QA: Disallow import use statements for structures in the same namespace. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
 
+	<!-- CS: For namespaced functions/constants: import the namespace, not the function/constant. -->
+	<rule ref="Universal.UseStatements.DisallowUseConst"/>
+	<rule ref="Universal.UseStatements.DisallowUseFunction"/>
+
 
 	<!--
 	#############################################################################

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -284,6 +284,14 @@
 		</properties>
 	</rule>
 
+	<!-- CS: Enforce alphabetically ordered import use statements. -->
+	<rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
+		<properties>
+			<property name="psr12Compatible" value="true"/>
+			<property name="caseSensitive" value="false"/>
+		</properties>
+	</rule>
+
 
 	<!--
 	#############################################################################

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -292,6 +292,14 @@
 		</properties>
 	</rule>
 
+	<!-- CS/QA: Disallow unused import use statements. -->
+	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+		<properties>
+			<!-- Allow import use statements for classes only referenced in documentation. -->
+			<property name="searchAnnotations" value="true"/>
+		</properties>
+	</rule>
+
 
 	<!--
 	#############################################################################

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -307,6 +307,10 @@
 	<rule ref="Universal.UseStatements.DisallowUseConst"/>
 	<rule ref="Universal.UseStatements.DisallowUseFunction"/>
 
+	<!-- CS: For global functions/constants: use fully qualified inline names. -->
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
+
 
 	<!--
 	#############################################################################


### PR DESCRIPTION
### YoastCS rules: enforce import use statements for all used classes

.. in namespaced files and don't allow the use of fully qualified inline names for non-namespaced files.

Note: this sniff does not/cannot flag missing import `use` statements for the use of _unqualified_ classes inline or in docblocks as it cannot know whether that is a class within the same namespace (no `use` statement needed) or from another namespace.
This is a known limitation of sniffs no matter what.

Related to #303

Fixes #201

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | 1
| Yoast Test Helper | 1
| Duplicate Post    | 1
| Yst ACF           | --
| Yst WooCommerce   | 53
| Yst News          | 24
| Yst Local         | 59
| Yst Video         | 37
| Yst Premium       | 128
| Yst Free          | 250

Note: this rule was previously already largely "silently" enforced via clean-up sweeps.

### YoastCS rules: enforce alphabetically ordered import use statements

Related to #303

Fixes #213

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | 1
| Yst Premium       | 3
| Yst Free          | 15

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: disallow unused import use statements

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | 4 (due to backport from the 2.x branch to 1.x)
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | 2
| Yst Free          | 5

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: disallow import use statements for the same namespace

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | 1
| Yst Premium       | --
| Yst Free          | 2

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: disallow use function/const in favour of importing the namespace

Related to #214, #215, #303

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | 1
| Yst Free          | --

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: enforce fully qualified global functions and constants

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | 1
| Yst News          | 2
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | 18
| Yst Free          | 46

Note: this rule was previously already "silently" enforced via clean-up sweeps.