### PR TITLE
YoastCS: more docblock/comment rules

### DIFF
--- a/Yoast/Reports/Threshold.php
+++ b/Yoast/Reports/Threshold.php
@@ -21,6 +21,7 @@ use PHP_CodeSniffer\Reports\Report;
  * @since 2.2.0
  *
  * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Flags unused params which are required via the interface. Invalid.
+ * @phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- Type is too complex to document properly.
  */
 final class Threshold implements Report {
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -317,6 +317,11 @@
 	SNIFFS RELATED TO COMMENTS AND DOCBLOCKS
 	#############################################################################
 	-->
+	<!-- Undo the WPCS-Docs silencing of the @param tag formatting/alignment rule. -->
+	<rule ref="Squiz.Commenting.FunctionComment.SpacingAfterParamName">
+		<severity>5</severity>
+	</rule>
+
 	<!-- CS: don't allow "// end class" comments and the likes. -->
 	<rule ref="PSR12.Classes.ClosingBrace"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -325,6 +325,14 @@
 		<severity>5</severity>
 	</rule>
 
+	<!-- Undo the WPCS-Docs silencing of some @return tag related rules. -->
+	<rule ref="Squiz.Commenting.FunctionComment.MissingReturn">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.InvalidReturnNotVoid">
+		<severity>5</severity>
+	</rule>
+
 	<!-- CS: don't allow "// end class" comments and the likes. -->
 	<rule ref="PSR12.Classes.ClosingBrace"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -387,6 +387,12 @@
 		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
 	</rule>
 
+	<!-- Disallows usage of "mixed" type hint. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint">
+		<!-- Make an exception for the tests as "mixed" is a valid type for testing type validation in code. -->
+		<exclude-pattern>*/tests/*\.php$</exclude-pattern>
+	</rule>
+
 	<!-- CS: don't allow "// end class" comments and the likes. -->
 	<rule ref="PSR12.Classes.ClosingBrace"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -339,6 +339,21 @@
 	<!-- Enforces null type hint on last position. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
 
+	<!-- Check property type information, but don't enforce native type declarations. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+		<properties>
+			<!-- PHP 7.4+. -->
+			<property name="enableNativeTypeHint" value="false"/>
+			<!-- PHP 8.0+. -->
+			<property name="enableMixedTypeHint" value="false"/>
+			<property name="enableUnionTypeHint" value="false"/>
+			<!-- PHP 8.1+. -->
+			<property name="enableIntersectionTypeHint" value="false"/>
+			<!-- PHP 8.2+. -->
+			<property name="enableStandaloneNullTrueFalseTypeHints" value="false"/>
+		</properties>
+	</rule>
+
 	<!-- CS: don't allow "// end class" comments and the likes. -->
 	<rule ref="PSR12.Classes.ClosingBrace"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -317,8 +317,11 @@
 	SNIFFS RELATED TO COMMENTS AND DOCBLOCKS
 	#############################################################################
 	-->
-	<!-- Undo the WPCS-Docs silencing of the @param tag formatting/alignment rule. -->
+	<!-- Undo the WPCS-Docs silencing of the @param tag formatting/alignment and grammar/punctuation rules. -->
 	<rule ref="Squiz.Commenting.FunctionComment.SpacingAfterParamName">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.ParamCommentNotCapital">
 		<severity>5</severity>
 	</rule>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -354,6 +354,21 @@
 		</properties>
 	</rule>
 
+	<!-- Check parameter type information, but don't enforce native type declarations. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+		<properties>
+			<!-- PHP 8.0+. -->
+			<property name="enableMixedTypeHint" value="false"/>
+			<property name="enableUnionTypeHint" value="false"/>
+			<!-- PHP 8.1+. -->
+			<property name="enableIntersectionTypeHint" value="false"/>
+			<!-- PHP 8.2+. -->
+			<property name="enableStandaloneNullTrueFalseTypeHints" value="false"/>
+		</properties>
+
+		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
+	</rule>
+
 	<!-- CS: don't allow "// end class" comments and the likes. -->
 	<rule ref="PSR12.Classes.ClosingBrace"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -369,6 +369,24 @@
 		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
 	</rule>
 
+	<!-- Check return type information, but don't enforce native type declarations. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+		<properties>
+			<!-- PHP 8.0+. -->
+			<property name="enableStaticTypeHint" value="false"/>
+			<property name="enableMixedTypeHint" value="false"/>
+			<property name="enableUnionTypeHint" value="false"/>
+			<!-- PHP 8.1+. -->
+			<property name="enableIntersectionTypeHint" value="false"/>
+			<property name="enableNeverTypeHint" value="false"/>
+			<!-- PHP 8.2+. -->
+			<property name="enableStandaloneNullTrueFalseTypeHints" value="false"/>
+		</properties>
+
+		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
+		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
+	</rule>
+
 	<!-- CS: don't allow "// end class" comments and the likes. -->
 	<rule ref="PSR12.Classes.ClosingBrace"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -336,6 +336,9 @@
 	<!-- Enforces using shorthand scalar typehint variants. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 
+	<!-- Enforces null type hint on last position. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
+
 	<!-- CS: don't allow "// end class" comments and the likes. -->
 	<rule ref="PSR12.Classes.ClosingBrace"/>
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -333,6 +333,9 @@
 		<severity>5</severity>
 	</rule>
 
+	<!-- Enforces using shorthand scalar typehint variants. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
+
 	<!-- CS: don't allow "// end class" comments and the likes. -->
 	<rule ref="PSR12.Classes.ClosingBrace"/>
 


### PR DESCRIPTION
### YoastCS rules: enforce alignment of the description parts for a `@param` tag

This rule is disabled in WordPressCS as it doesn't play nice with the convoluted WP native array annotation.

For YoastCS it has been decided to apply the rule anyway. We'll need to evaluate on a case-by-case basis how to convert from the WP array annotation to another form of documenting the array format.

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | 6
| Yst News          | --
| Yst Local         | 6
| Yst Video         | 1
| Yst Premium       | 11
| Yst Free          | 77

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: enforce proper grammar/punctuation in param description

This rule is disabled in WordPressCS as it doesn't play nice with the convoluted WP native array annotation.

For YoastCS it has been decided to apply the rule anyway. We'll need to evaluate on a case-by-case basis how to convert from the WP array annotation to another form of documenting the array format.

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | 1
| Yst News          | --
| Yst Local         | 1
| Yst Video         | --
| Yst Premium       | --
| Yst Free          | 11

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: enforce that docblocks should have a valid @return tag

This rule is disabled in WordPressCS as WP Core does not want `@return void`, but consistency and explicitness of _intend_ is important, so we're going to turn it back on.

Note: `@return` tags will still not be enforced for constructors which should always be "never" methods anyway.

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | 57 // = Test fixtures.
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | 1
| Yoast Test Helper | 18
| Duplicate Post    | 280
| Yst ACF           | 14
| Yst WooCommerce   | 172
| Yst News          | 92
| Yst Local         | 204 (but there are also still 54 functions without a docblock altogether)
| Yst Video         | 381
| Yst Premium       | 804 + 2 invalid void
| Yst Free          | 4162 + 3 invalid void (and 4 function without a docblock altogether)

### YoastCS rules: enforce short form type annotations

I.e. `bool` not `boolean`, `int` not `integer`.

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | --
| Yst Free          | 1

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: enforce type annotations to have null as last type

(whenever relevant)

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | --
| Yst Free          | --

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: verify property type annotations

This sniff:
* Disallows plain `array` type annotations. These should always be made specific.
* Flags missing type annotations.

Optionally the sniff can enforce PHP native type declarations instead of annotations in a docblock.

This functionality has been **disabled** for the following reasons:
* Adding type declarations without using `strict_types` leads to bugs as the original (scalar) data will be juggled by PHP, even if the original data was never correct to start with. The loss of the type information of the original data passed, means that the function can no longer discern whether the input is invalid/incorrect.
    Think: a function expecting an integer, but being passed `false`. This will be juggled to `0`, while it should have been flagged as unusable input.
* Adding `strict_types` in the context of WP is a no-no to begin with as it can cause fatal errors (= white screen of death) when the exceptions are not caught and they generally are not caught and WP doesn't have a native exception handler in place either.
* Adding `strict_types` is useless anyway as it is only enforced for files containing such a declaration, which means that parameters passed to a function call from an external source which doesn't have the `strict_types` declaration (callback called from WP) will still be juggled, which again leads to bugs.
* Adding type declarations in functions hooked into WP filters is especially dangerous due to the loss of type info.

All in all, with the type system offered by PHP as-is, adding PHP native type declarations is next to useless unless you have full control of all code + the environment the code is being run on, which for the Yoast code is just not the case (with the exception of Platform).

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | 2
| Yoast Test Helper | 2
| Duplicate Post    | 1
| Yst ACF           | 4
| Yst WooCommerce   | 7
| Yst News          | 3
| Yst Local         | 40
| Yst Video         | 44
| Yst Premium       | 85
| Yst Free          | 366

### YoastCS rules: verify parameter type annotations

This sniff:
* Disallows plain `array` type annotations. These should always be made specific.
* Flags missing type annotations.

Optionally the sniff can enforce PHP native type declarations instead of annotations in a docblock.

This functionality has been **disabled** for the following reasons:
* Adding type declarations without using `strict_types` leads to bugs as the original (scalar) data will be juggled by PHP, even if the original data was never correct to start with. The loss of the type information of the original data passed, means that the function can no longer discern whether the input is invalid/incorrect.
    Think: a function expecting an integer, but being passed `false`. This will be juggled to `0`, while it should have been flagged as unusable input.
* Adding `strict_types` in the context of WP is a no-no to begin with as it can cause fatal errors (= white screen of death) when the exceptions are not caught and they generally are not caught and WP doesn't have a native exception handler in place either.
* Adding `strict_types` is useless anyway as it is only enforced for files containing such a declaration, which means that parameters passed to a function call from an external source which doesn't have the `strict_types` declaration (callback called from WP) will still be juggled, which again leads to bugs.
* Adding type declarations in functions hooked into WP filters is especially dangerous due to the loss of type info.

All in all, with the type system offered by PHP as-is, adding PHP native type declarations is next to useless unless you have full control of all code + the environment the code is being run on, which for the Yoast code is just not the case (with the exception of Platform).

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | 4
| WP Test Utils     | 3
| YoastCS           | --
| WHIP              | 4
| Yoast Test Helper | 10
| Duplicate Post    | 37
| Yst ACF           | 1
| Yst WooCommerce   | 37
| Yst News          | 17
| Yst Local         | 176
| Yst Video         | 147
| Yst Premium       | 263
| Yst Free          | 913

### YoastCS rules: verify return type annotations

This sniff:
* Disallows plain `array` type annotations. These should always be made specific.
* Flags missing type annotations.

Optionally the sniff can enforce PHP native type declarations instead of annotations in a docblock.

This functionality has been **disabled** for the following reasons:
* Adding type declarations without using `strict_types` leads to bugs as the original (scalar) data will be juggled by PHP, even if the original data was never correct to start with. The loss of the type information of the original data passed, means that the function can no longer discern whether the input is invalid/incorrect.
    Think: a function expecting an integer, but being passed `false`. This will be juggled to `0`, while it should have been flagged as unusable input.
* Adding `strict_types` in the context of WP is a no-no to begin with as it can cause fatal errors (= white screen of death) when the exceptions are not caught and they generally are not caught and WP doesn't have a native exception handler in place either.
* Adding `strict_types` is useless anyway as it is only enforced for files containing such a declaration, which means that parameters passed to a function call from an external source which doesn't have the `strict_types` declaration (callback called from WP) will still be juggled, which again leads to bugs.
* Adding type declarations in functions hooked into WP filters is especially dangerous due to the loss of type info.

All in all, with the type system offered by PHP as-is, adding PHP native type declarations is next to useless unless you have full control of all code + the environment the code is being run on, which for the Yoast code is just not the case (with the exception of Platform).

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | 22
| WP Test Utils     | 9
| YoastCS           | --
| WHIP              | 5
| Yoast Test Helper | 21
| Duplicate Post    | 44
| Yst ACF           | 5
| Yst WooCommerce   | 48
| Yst News          | 22
| Yst Local         | 132
| Yst Video         | 237
| Yst Premium       | 269
| Yst Free          | 1066

### YoastCS rules: disallow the "mixed" type in annotations

An exception is made for the tests, as a data provider for input validation within a function could well be passing every single different type, in which case, `mixed` is perfectly valid.

Fixes #196

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | 49 (this is valid though as these are assertion declarations)
| WP Test Utils     | --
| YoastCS           | 2
| WHIP              | --
| Yoast Test Helper | 4
| Duplicate Post    | 12
| Yst ACF           | 1
| Yst WooCommerce   | 2
| Yst News          | 1
| Yst Local         | 42
| Yst Video         | 12
| Yst Premium       | 17
| Yst Free          | 151

---

Related to #303
