### PR TITLE
YoastCS: add extra WP related rules

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -49,9 +49,10 @@ jobs:
           squizlabs/php_codesniffer:"dev-master"
           phpcsstandards/phpcsutils:"dev-develop"
           phpcsstandards/phpcsextra:"dev-develop"
-          wp-coding-standards/wpcs:"dev-develop"
+          wp-coding-standards/wpcs:"dev-develop as 3.99" # Alias needed to prevent composer conflict with VIPCS.
           slevomat/coding-standard:"dev-master"
           sirbrillig/phpcs-variable-analysis:"2.x"
+          automattic/vipwpcs:"dev-develop"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -62,7 +62,7 @@ jobs:
           composer require --no-update --no-scripts --no-interaction
           squizlabs/php_codesniffer:"dev-master"
           phpcsstandards/phpcsutils:"dev-develop"
-          wp-coding-standards/wpcs:"dev-develop"
+          wp-coding-standards/wpcs:"dev-develop as 3.99" # Alias needed to prevent composer conflict with VIPCS.
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   PHPCS_HIGHEST: 'dev-master'
   UTILS_HIGHEST: 'dev-develop'
-  WPCS_HIGHEST: 'dev-develop'
+  WPCS_HIGHEST: 'dev-develop as 3.99' # Alias needed to prevent composer conflict with VIPCS.
 
 jobs:
   #### TEST STAGE ####

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The `Yoast` standard for PHP_CodeSniffer is comprised of the following:
 * Select additional sniffs taken from [`PHP_CodeSniffer`](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 * Select additional sniffs taken from [`PHPCSExtra`](https://github.com/PHPCSStandards/PHPCSExtra).
 * Select additional sniffs taken from [`SlevomatCodingStandard`](https://github.com/slevomat/coding-standard).
+* Select additional sniffs taken from [WordPress VIP Coding Standards](https://github.com/Automattic/VIP-Coding-Standards/).
 * A number of custom Yoast specific sniffs.
 
 Files within version management and dependency related directories, such as the Composer `vendor` directory, are excluded from the scans by default.

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -407,6 +407,26 @@
 
 	<!--
 	#############################################################################
+	SNIFFS TO PREVENT SOME WP COMPATIBILITY ISSUES
+	Some of these sniffs are expected to end up in WordPressCS in the future.
+	#############################################################################
+	-->
+	<!-- Verify method signatures for compatibility with a few typical WP parent classes. -->
+	<rule ref="WordPressVIPMinimum.Classes.DeclarationCompatibility"/>
+
+	<!-- Verify that all functions which are hooked into a filter always return a value. -->
+	<rule ref="WordPressVIPMinimum.Hooks.AlwaysReturnInFilter"/>
+
+	<!-- Verify that some typical functions with mixed return types are not nested.
+		 This can prevent some TypeErrors and related deprecation notices. -->
+	<rule ref="WordPressVIPMinimum.Security.EscapingVoidReturnFunctions"/>
+
+	<!-- Verify that the correct escaping function is used based on the context. -->
+	<rule ref="WordPressVIPMinimum.Security.ProperEscapingFunction"/>
+
+
+	<!--
+	#############################################################################
 	SNIFFS TO ENFORCE CODE MODERNIZATION
 	#############################################################################
 	-->

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 	"require": {
 		"php": ">=7.2",
 		"ext-tokenizer": "*",
+		"automattic/vipwpcs": "^3.0.0",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.4",


### PR DESCRIPTION
### Composer: add Automattic VIP sniffs requirement

### YoastCS rules: add a few VIP sniffs to prevent some typical WP compat bugs

There  is one known bug in the `WordPressVIPMinimum.Hooks.AlwaysReturnInFilter` sniff related to a redirect being done from within the filter.
This has been reported upstream Automattic/VIP-Coding-Standards#719.

Related to #303

Fixes #229

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | 2 (proper escaping)
| Yst Video         | --
| Yst Premium       | 1 (false positive/reported bug)
| Yst Free          | 2  (1 false positive/reported bug)

Note: these rules were previously already "silently" enforced via clean-up sweeps.