### PR TITLE
YoastCS: more modernization rules

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -430,6 +430,15 @@
 	SNIFFS TO ENFORCE CODE MODERNIZATION
 	#############################################################################
 	-->
+	<!-- Modernize: Enforce the use of ClassName::class (PHP 5.5+). -->
+	<!-- A better version of this sniff is expected in PHPCSExtra at some point in the future. -->
+	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference">
+		<properties>
+			<!-- Prevent unsolvable issues as use with variables is PHP 8.0+. -->
+			<property name="enableOnObjects" value="false"/>
+		</properties>
+	</rule>
+
 	<!-- Undo the WPCS-Extra silencing of the "no nested dirnames, use $levels" notice (PHP 7.0+). -->
 	<rule ref="Modernize.FunctionCalls.Dirname.Nested">
 		<severity>5</severity>

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -447,4 +447,7 @@
 	<!-- Modernize: Enforce visibility declarations for class constants (PHP 7.1+). -->
 	<rule ref="PSR12.Properties.ConstantVisibility"/>
 
+	<!-- Modernize: Enforce a nullable type declaration when the param has a null default value (PHP 7.1+). -->
+	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+
 </ruleset>

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -444,4 +444,7 @@
 		<severity>5</severity>
 	</rule>
 
+	<!-- Modernize: Enforce visibility declarations for class constants (PHP 7.1+). -->
+	<rule ref="PSR12.Properties.ConstantVisibility"/>
+
 </ruleset>


### PR DESCRIPTION
### YoastCS rules: enforce the use of *::class

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | --
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | 6
| Yst Premium       | --
| Yst Free          | 30

Note: this rule was previously already "silently" enforced via clean-up sweeps.

### YoastCS rules: enforce visibility on class constants

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | _N/A_ (minimum PHP version too low)
| WP Test Utils     | _N/A_ (minimum PHP version too low)
| YoastCS           | --
| WHIP              | _N/A_ (minimum PHP version too low)
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | 2
| Yst WooCommerce   | 11
| Yst News          | 1
| Yst Local         | 11
| Yst Video         | 1
| Yst Premium       | 107
| Yst Free          | 325

### YoastCS rules: enforce nullable type for param with null default

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | _N/A_ (minimum PHP version too low)
| WP Test Utils     | _N/A_ (minimum PHP version too low)
| YoastCS           | --
| WHIP              | _N/A_ (minimum PHP version too low)
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | --
| Yst News          | --
| Yst Local         | --
| Yst Video         | --
| Yst Premium       | 20
| Yst Free          | 9


---

Related to #303
