### PR TITLE
YoastCS: add some test specific rules and exceptions

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -62,7 +62,10 @@
 	</rule>
 
 	<!-- Enforce PSR1 compatible namespaces. -->
-	<rule ref="PSR1.Classes.ClassDeclaration"/>
+	<rule ref="PSR1.Classes.ClassDeclaration">
+		<!-- YoastCS only applies this rule to test files. Overrule it to apply to all files. -->
+		<include-pattern>*\.php$</include-pattern>
+	</rule>
 
 	<!-- Enforce Final classes to prevent issues with the PHPCS autoloader. -->
 	<rule ref="Universal.Classes.RequireFinalClass"/>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -68,7 +68,10 @@
 	</rule>
 
 	<!-- Enforce Final classes to prevent issues with the PHPCS autoloader. -->
-	<rule ref="Universal.Classes.RequireFinalClass"/>
+	<rule ref="Universal.Classes.RequireFinalClass">
+		<!-- YoastCS only applies this rule to test files. Overrule it to apply to all files. -->
+		<include-pattern>*\.php$</include-pattern>
+	</rule>
 
 
 	<!--

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -464,4 +464,10 @@
 		<exclude-pattern>*/tests/*\.php$</exclude-pattern>
 	</rule>
 
+	<!-- It is fine to use the PHP json_encode() function for mocking the WP/Yoast alternative
+		 or for setting up the "expected" value. -->
+	<rule ref="Yoast.Yoast.JsonEncodeAlternative">
+		<exclude-pattern>*/tests/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -475,4 +475,12 @@
 		<exclude-pattern>*/tests(/*)?/Doubles/*\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Enforce that all test code is namespaced. -->
+	<rule ref="PSR1.Classes.ClassDeclaration">
+		<include-pattern>*/tests/*\.php$</include-pattern>
+
+		<!-- "One object per file" is already enforced by another sniff, so don't report. -->
+		<exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses"/>
+	</rule>
+
 </ruleset>

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -483,4 +483,11 @@
 		<exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses"/>
 	</rule>
 
+	<!-- Enforce that all test classes are either final or abstract. -->
+	<rule ref="Universal.Classes.RequireFinalClass">
+		<include-pattern>*/tests/*\.php$</include-pattern>
+		<!-- But don't enforce this for Mock/Double classes. -->
+		<exclude-pattern>*/tests(/*)?/Doubles/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -470,4 +470,9 @@
 		<exclude-pattern>*/tests/*\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Double classes may overload methods in the parent class to just change visibility. -->
+	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod">
+		<exclude-pattern>*/tests(/*)?/Doubles/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -450,4 +450,18 @@
 	<!-- Modernize: Enforce a nullable type declaration when the param has a null default value (PHP 7.1+). -->
 	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
 
+
+	<!--
+	#############################################################################
+	RULES SPECIFICALLY FOR THE AUTOMATED TESTS
+	A few rules never need to be applied to test files.
+	Other rules should _only_ be applied to test files.
+	#############################################################################
+	-->
+	<!-- Tests are not run within the context of a WP install, so overwriting WP globals is fine
+		 (as long as they're reset after). -->
+	<rule ref="WordPress.WP.GlobalVariablesOverride">
+		<exclude-pattern>*/tests/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
### YoastCS rules: selectively exempt test files [1]

While WordPressCS makes a best effort to try to prevent false positives on test code for the `WordPress.WP.GlobalVariablesOverride`, it is simpler to just plain exclude the test code from being scanned with this sniff.

### YoastCS rules: selectively exempt test files [2]

For mock-based unit tests, it is fine to use the PHP native `json_encode()` function to mock the WP/Yoast native alternative for this function, so let's prevent the test code needing lots of ignore annotations when the issue is not solvable.

### YoastCS rules: selectively exempt test files [3]

Double classes may overload methods from a parent class just to change the visibility of the method from `protected` to `public` to allow for testing the method directly. This is fine.

### YoastCS rules: enforce namespaces for all test files

Related to #303

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | --
| WP Test Utils     | --
| YoastCS           | --
| WHIP              | 9
| Yoast Test Helper | --
| Duplicate Post    | --
| Yst ACF           | --
| Yst WooCommerce   | 5
| Yst News          | 9
| Yst Local         | 1
| Yst Video         | 108
| Yst Premium       | 76
| Yst Free          | 118

### YoastCS rules: enforce final classes for all test files

... while allowing `abstract` TestCases.

Note: the typical/default "Doubles" directories within the "tests" directory are exempt from this rule as "Double" classes are often still combined with mocking and making the class `final` would break those tests.

Related to #303

Impact on Yoast packages:

| Plugin/Tool       | Errors/Warnings |
|-------------------|-----------------|
| PHPUnit Polyfills | 25 (fixtures for the tests, these will be exempt)
| WP Test Utils     | 9 (mostly fixtures for the tests)
| YoastCS           | --
| WHIP              | 9
| Yoast Test Helper | --
| Duplicate Post    | 25
| Yst ACF           | 10
| Yst WooCommerce   | 25
| Yst News          | 13
| Yst Local         | 11
| Yst Video         | 101
| Yst Premium       | 126
| Yst Free          | 647