### PR TITLE
Composer: update minimum requirements for various dependencies

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -188,10 +188,6 @@
 	<!-- PHPCS 3.5.0: This sniff may be added to WPCS in due time and can then be removed from this ruleset. -->
 	<rule ref="PSR12.Files.OpenTag"/>
 
-	<!-- CS: Enforces that a PHP open tag uses lowercase. -->
-	<!-- PHPCSExtra 1.2.0: This sniff may be added to WPCS in due time and can then be removed from this ruleset. -->
-	<rule ref="Universal.PHP.LowercasePHPTag"/>
-
 	<!-- Demand that "else(if)" is on a new line after the scope closer of the preceding if. -->
 	<rule ref="Universal.ControlStructures.IfElseDeclaration"/>
 
@@ -217,9 +213,6 @@
 
 	<!-- CS/QA: Forbid the use of the and/or logical operators. -->
 	<rule ref="Universal.Operators.DisallowLogicalAndOr"/>
-
-	<!-- CS/QA: Forbid the use double `!`. -->
-	<rule ref="Universal.CodeAnalysis.NoDoubleNegative"/>
 
 	<!-- CS: enforce that boolean operators between conditions in multi-line control structures are
 		 consistently at the start or end of the line, not a mix of both. -->

--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,14 @@
 		"ext-tokenizer": "*",
 		"automattic/vipwpcs": "^3.0.0",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
-		"php-parallel-lint/php-parallel-lint": "^1.3.2",
+		"php-parallel-lint/php-parallel-lint": "^1.4.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.4",
 		"phpcsstandards/phpcsextra": "^1.2.1",
-		"phpcsstandards/phpcsutils": "^1.0.9",
+		"phpcsstandards/phpcsutils": "^1.0.10",
 		"sirbrillig/phpcs-variable-analysis": "^2.11.17",
-		"slevomat/coding-standard": "^8.14.0",
-		"squizlabs/php_codesniffer": "^3.8.0",
-		"wp-coding-standards/wpcs": "^3.0.1"
+		"slevomat/coding-standard": "^8.15.0",
+		"squizlabs/php_codesniffer": "^3.9.1",
+		"wp-coding-standards/wpcs": "^3.1.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",


### PR DESCRIPTION
### Composer: update minimum requirements for various dependencies

**PHP Parallel Lint** has released a version which fixes a PHP 8.4 incompatibility (and fixes some bugs).

**PHP_CodeSnifer** has released three new versions in the mean time. The most important changes are:
* Support for PHP 8.3 typed class constants.
* Support for PHP 8.3 readonly anonymous classes.
* A new sniff: `Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence` - this sniff is included in WPCS 3.1.0.
* New feature adding the ability to deprecate sniffs in a user friendly manner.
* Lots of new sniff documentation.
* Various performance improvements.
* Range of bugfixes.

**PHPCSUtils** has released a version with compatibility fixes for PHP 8.4.

**WPCS** has released a version with updates related to the WP 6.5 release and three new sniffs (from PHPCS itself + PHPCSExtra).

**Slevomat** has released a version with mostly bugfixes.

Refs:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.4.0
* https://github.com/phpcsstandards/php_codesniffer/releases
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.10
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.1.0
* https://github.com/slevomat/coding-standard/releases/tag/8.15.0

### YoastCS ruleset: remove two sniffs which are now in WPCS

WPCS 3.1.0 includes the `Universal.PHP.LowercasePHPTag` (Core) and the `Universal.CodeAnalysis.NoDoubleNegative` (Extra) sniffs, so no need to explicitly require those anymore for YoastCS.