### PR TITLE
YoastCS: always flag comma spacing in function calls

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -147,6 +147,19 @@
 		</properties>
 	</rule>
 
+	<!-- Excluded in WPCS, but the exclusion does not work well with a code base using short arrays.
+		 This may lead to some duplicate notices, but rather that, than these issues not being flagged.
+	-->
+	<rule ref="Universal.WhiteSpace.CommaSpacing.SpaceBeforeInFunctionCall">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Universal.WhiteSpace.CommaSpacing.TooMuchSpaceAfterInFunctionCall">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Universal.WhiteSpace.CommaSpacing.NoSpaceAfterInFunctionCall">
+		<severity>5</severity>
+	</rule>
+
 
 	<!--
 	#############################################################################


### PR DESCRIPTION
The `Universal.WhiteSpace.CommaSpacing` has modular error codes to allow for preventing duplicate error messages about the same issue from different sniffs.

WordPressCS excludes the "function call" related error codes from the sniff to prevent an overlap with the `Generic.Functions.FunctionCallArgumentSpacing` sniff, but this doesn't play nice with a code base using short arrays as the spacing after commas in a short array being passed as a parameter in a function call will then also be skipped.

This change prevents this issue and ensures that the spacing around those commas will be checked correctly.