### PR TITLE
YoastCS ruleset: set the minimum supported WP version to 6.5

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -56,7 +56,7 @@
 			 Ref: https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
 		-->
 		<properties>
-			<property name="minimum_wp_version" value="6.4"/>
+			<property name="minimum_wp_version" value="6.5"/>
 		</properties>
 
 		<!-- No need for this sniff as every Yoast travis script includes linting all files. -->


### PR DESCRIPTION
This PR bumps the minimum supported WordPress version to 6.5, since we are also dropping support for 6.5 in all the plugins