### PR TITLE
Various sniffs: simplify skipping the rest of the file

### DIFF
--- a/Yoast/Sniffs/Commenting/FileCommentSniff.php
+++ b/Yoast/Sniffs/Commenting/FileCommentSniff.php
@@ -93,7 +93,7 @@ final class FileCommentSniff extends Squiz_FileCommentSniff {
 
 		if ( $comment_start === false || $tokens[ $comment_start ]['code'] !== \T_DOC_COMMENT_OPEN_TAG ) {
 			// No file comment found, we're good.
-			return ( $phpcsFile->numTokens + 1 );
+			return $phpcsFile->numTokens;
 		}
 
 		// Respect phpcs:disable comments in the file docblock.
@@ -110,7 +110,7 @@ final class FileCommentSniff extends Squiz_FileCommentSniff {
 					|| isset( $tokens[ $i ]['sniffCodes']['Yoast.Commenting.FileComment.Unnecessary'] ) === true
 				) {
 					// Applicable disable annotation found.
-					return ( $phpcsFile->numTokens + 1 );
+					return $phpcsFile->numTokens;
 				}
 			}
 		}
@@ -136,6 +136,6 @@ final class FileCommentSniff extends Squiz_FileCommentSniff {
 			'Unnecessary'
 		);
 
-		return ( $phpcsFile->numTokens + 1 );
+		return $phpcsFile->numTokens;
 	}
 }

--- a/Yoast/Sniffs/Files/FileNameSniff.php
+++ b/Yoast/Sniffs/Files/FileNameSniff.php
@@ -144,7 +144,7 @@ final class FileNameSniff implements Sniff {
 		$file = TextStrings::stripQuotes( $phpcsFile->getFileName() );
 
 		if ( $file === 'STDIN' ) {
-			return ( $phpcsFile->numTokens + 1 ); // @codeCoverageIgnore
+			return $phpcsFile->numTokens; // @codeCoverageIgnore
 		}
 
 		// Respect phpcs:disable comments as long as they are not accompanied by an enable.
@@ -167,7 +167,7 @@ final class FileNameSniff implements Sniff {
 
 				if ( $i === false ) {
 					// The entire (rest of the) file is disabled.
-					return ( $phpcsFile->numTokens + 1 );
+					return $phpcsFile->numTokens;
 				}
 			}
 		}
@@ -278,7 +278,7 @@ final class FileNameSniff implements Sniff {
 		}
 
 		// Only run this sniff once per file, no need to run it again.
-		return ( $phpcsFile->numTokens + 1 );
+		return $phpcsFile->numTokens;
 	}
 
 	/**

--- a/Yoast/Sniffs/Files/TestDoublesSniff.php
+++ b/Yoast/Sniffs/Files/TestDoublesSniff.php
@@ -71,7 +71,7 @@ final class TestDoublesSniff implements Sniff {
 		$file = TextStrings::stripQuotes( $phpcsFile->getFileName() );
 
 		if ( $file === 'STDIN' ) {
-			return; // @codeCoverageIgnore
+			return $phpcsFile->numTokens; // @codeCoverageIgnore
 		}
 
 		if ( ! isset( $phpcsFile->config->basepath ) ) {
@@ -81,7 +81,7 @@ final class TestDoublesSniff implements Sniff {
 				'MissingBasePath'
 			);
 
-			return ( $phpcsFile->numTokens + 1 );
+			return $phpcsFile->numTokens;
 		}
 
 		if ( empty( $this->doubles_path ) ) {
@@ -92,7 +92,7 @@ final class TestDoublesSniff implements Sniff {
 				'NoDoublesPathProperty'
 			);
 
-			return ( $phpcsFile->numTokens + 1 );
+			return $phpcsFile->numTokens;
 		}
 
 		if ( ! isset( $this->target_paths ) || \defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {


### PR DESCRIPTION
This commit updates various sniffs to use `return $phpcsFile->numTokens` instead of `return ($phpcsFile->numTokens + 1)`.

If a sniff file contains 50 tokens, the last `$stackPtr` will be 49, so returning `50` will already get us passed the end of the token stack and the `+ 1` is redundant.

Includes changing a plain `return` statements to `return $phpcsFile->numTokens` for efficiency.