### PR TITLE
Composer: prevent a lock file from being created

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -64,6 +64,10 @@ jobs:
           phpcsstandards/phpcsutils:"dev-develop"
           wp-coding-standards/wpcs:"dev-develop as 3.99" # Alias needed to prevent composer conflict with VIPCS.
 
+      - name: Enable creation of `composer.lock` file
+        if: ${{ matrix.cs_dependencies == 'lowest' }}
+        run: composer config --unset lock
+
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,10 @@ jobs:
           phpcsstandards/phpcsutils:"${{ env.UTILS_HIGHEST }}"
           wp-coding-standards/wpcs:"${{ env.WPCS_HIGHEST }}"
 
+      - name: Enable creation of `composer.lock` file
+        if: ${{ matrix.cs_dependencies == 'lowest' }}
+        run: composer config --unset lock
+
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
@@ -173,6 +177,10 @@ jobs:
           squizlabs/php_codesniffer:"${{ env.PHPCS_HIGHEST }}"
           phpcsstandards/phpcsutils:"${{ env.UTILS_HIGHEST }}"
           wp-coding-standards/wpcs:"${{ env.WPCS_HIGHEST }}"
+
+      - name: Enable creation of `composer.lock` file
+        if: ${{ matrix.cs_dependencies == 'lowest' }}
+        run: composer config --unset lock
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
+		},
+		"lock": false
 	},
 	"scripts": {
 		"lint": [


### PR DESCRIPTION
Composer 1.10.0 introduced a `lock` config option, which, when set to `false` will prevent a `composer.lock` file from being created and will ignore it when one exists.

This is a useful option for libraries such as this where the `lock` file has no meaning.

It also makes life easier for contributors as they don't have to remember that for this repo they should use `composer update` instead of `composer install`. Both will now work the same.

Refs:
https://getcomposer.org/doc/06-config.md#lock