### PR TITLE
GH Actions/test: anticipate PHP 8.4 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,30 +37,30 @@ jobs:
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php_version: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         cs_dependencies: ['lowest', 'stable']
 
         include:
           # Make the matrix complete (when combined with the code coverage builds).
           - php_version: '7.2'
             cs_dependencies: 'stable'
-          - php_version: '8.3'
+          - php_version: '8.4'
             cs_dependencies: 'stable'
 
           # Test against dev versions of all CS dependencies with select PHP versions for early detection of issues.
-          - php_version: '7.4'
+          - php_version: '8.0'
             cs_dependencies: 'dev'
-          - php_version: '8.1'
+          - php_version: '8.2'
             cs_dependencies: 'dev'
 
           # Experimental build(s). These are allowed to fail.
           # PHP nightly
-          - php_version: '8.4'
+          - php_version: '8.5'
             cs_dependencies: 'dev'
 
     name: "Test${{ matrix.cs_dependencies == 'stable' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - CS Deps ${{ matrix.cs_dependencies }}"
 
-    continue-on-error: ${{ matrix.php_version == '8.4' }}
+    continue-on-error: ${{ matrix.php_version == '8.5' }}
 
     steps:
       - name: Checkout code
@@ -142,7 +142,7 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['7.2', '8.3']
+        php_version: ['7.2', '8.4']
         cs_dependencies: ['lowest', 'dev']
 
     name: "Coverage${{ matrix.cs_dependencies == 'stable' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - CS Deps ${{ matrix.cs_dependencies }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,12 +55,12 @@ jobs:
 
           # Experimental build(s). These are allowed to fail.
           # PHP nightly
-          - php_version: '8.5'
+          - php_version: 'nightly'
             cs_dependencies: 'dev'
 
     name: "Test${{ matrix.cs_dependencies == 'stable' && ' + Lint' || '' }}: PHP ${{ matrix.php_version }} - CS Deps ${{ matrix.cs_dependencies }}"
 
-    continue-on-error: ${{ matrix.php_version == '8.5' }}
+    continue-on-error: ${{ matrix.php_version == 'nightly' }}
 
     steps:
       - name: Checkout code
@@ -122,7 +122,7 @@ jobs:
       # The results of the linting will be shown inline in the PR via the CS2PR tool.
       # @link https://github.com/staabm/annotate-pull-request-from-checkstyle/
       - name: Lint against parse errors
-        if: ${{ matrix.cs_dependencies == 'stable' }}
+        if: ${{ matrix.cs_dependencies == 'stable' || matrix.php_version == 'nightly' }}
         run: composer lint -- --checkstyle | cs2pr
 
       - name: Run the unit tests


### PR DESCRIPTION
### GH Actions/test: anticipate PHP 8.4 release

* Builds against PHP 8.4 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.4).
* Add _allowed to fail_ build against PHP 8.5.

### GH Actions: use "nightly" alias and lint against nightly

Setup-PHP offers the `'nightly'` alias for the "next" PHP version (PHP source "master" branch).

Using that alias will reduce the manual changes needed to the workflow each year.

We'll still need to expand the list of PHP versions to test against once a year, but we won't need to update the version number for the _next_ PHP version anymore.

Additionally, this commit enables running the PHP linting against the _next_ PHP version. This wasn't previously enabled, though it should have been.