### PR TITLE
PHPStan 2.0: update configuration

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -151,7 +151,7 @@ jobs:
         with:
           php-version: 'latest'
           coverage: none
-          tools: phpstan:1.x
+          tools: phpstan:2.x
 
       # Install dependencies and handle caching in one go.
       # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.

--- a/Yoast/Sniffs/Commenting/CoversTagSniff.php
+++ b/Yoast/Sniffs/Commenting/CoversTagSniff.php
@@ -357,6 +357,7 @@ final class CoversTagSniff implements Sniff {
 			$tokens      = $phpcsFile->getTokens();
 			$annotation  = $tokens[ $stackPtr ]['content'];
 			$annotations = \explode( $separator, $annotation );
+			// @phpstan-ignore argument.type (explode will never return `false` as it is never given an empty string separator.)
 			$annotations = \array_map( 'trim', $annotations );
 			$annotations = \array_filter( $annotations ); // Remove empties.
 

--- a/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -213,7 +213,7 @@ final class ValidHookNameSniff extends WPCS_ValidHookNameSniff {
 	 * @return void
 	 */
 	private function verify_yoast_hook_name( $stackPtr, $hook_name_param ) {
-
+		// @phpstan-ignore binaryOp.invalid, argument.type (The passed value will only ever be an integer, PHPStan just doesn't know the shape of the array.)
 		$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $hook_name_param['start'], ( $hook_name_param['end'] + 1 ), true );
 		if ( $first_non_empty === false ) {
 			// Shouldn't be possible as we've checked this before.
@@ -281,6 +281,7 @@ final class ValidHookNameSniff extends WPCS_ValidHookNameSniff {
 		$allow  = [ \T_CONSTANT_ENCAPSED_STRING ];
 		$allow += Tokens::$emptyTokens;
 
+		// @phpstan-ignore binaryOp.invalid, argument.type (The passed value will only ever be an integer, PHPStan just doesn't know the shape of the array.)
 		$has_non_string = $this->phpcsFile->findNext( $allow, $hook_name_param['start'], ( $hook_name_param['end'] + 1 ), true );
 		if ( $has_non_string !== false ) {
 			/*

--- a/Yoast/Sniffs/Tools/BrainMonkeyRaceConditionSniff.php
+++ b/Yoast/Sniffs/Tools/BrainMonkeyRaceConditionSniff.php
@@ -79,11 +79,13 @@ final class BrainMonkeyRaceConditionSniff implements Sniff {
 		$expected   = Tokens::$emptyTokens;
 		$expected[] = \T_CONSTANT_ENCAPSED_STRING;
 
+		// @phpstan-ignore binaryOp.invalid, argument.type (The passed value will only ever be an integer, PHPStan just doesn't know the shape of the array.)
 		$hasUnexpected = $phpcsFile->findNext( $expected, $param['start'], ( $param['end'] + 1 ), true );
 		if ( $hasUnexpected !== false ) {
 			return;
 		}
 
+		// @phpstan-ignore binaryOp.invalid, argument.type (The passed value will only ever be an integer, PHPStan just doesn't know the shape of the array.)
 		$text        = $phpcsFile->findNext( Tokens::$emptyTokens, $param['start'], ( $param['end'] + 1 ), true );
 		$textContent = TextStrings::stripQuotes( $tokens[ $text ]['content'] );
 		if ( $textContent !== 'apply_filters' && $textContent !== 'do_action' ) {

--- a/Yoast/Sniffs/Yoast/JsonEncodeAlternativeSniff.php
+++ b/Yoast/Sniffs/Yoast/JsonEncodeAlternativeSniff.php
@@ -116,6 +116,7 @@ final class JsonEncodeAlternativeSniff extends AbstractFunctionRestrictionsSniff
 		 */
 		$value_param = PassedParameters::getParameterFromStack( $params, 1, self::PARAM_INFO[ $matched_content ] );
 		if ( \is_array( $value_param ) && \count( $params ) === 1 ) {
+			// @phpstan-ignore binaryOp.invalid, argument.type (The passed value will only ever be an integer, PHPStan just doesn't know the shape of the array.)
 			$first_token = $this->phpcsFile->findNext( Tokens::$emptyTokens, $value_param['start'], ( $value_param['end'] + 1 ), true );
 			if ( $first_token === false || $this->tokens[ $first_token ]['code'] !== \T_ELLIPSIS ) {
 				/*
@@ -171,6 +172,8 @@ final class JsonEncodeAlternativeSniff extends AbstractFunctionRestrictionsSniff
 		if ( \is_array( $value_param ) && isset( $value_param['name_token'] ) ) {
 			// Update the parameter name when the function call uses named parameters.
 			// `$data` is the parameter name used in the WPSEO_Utils::format_json_encode() function.
+
+			// @phpstan-ignore argument.type (The passed value will only ever be an integer, PHPStan just doesn't know the shape of the array.)
 			$this->phpcsFile->fixer->replaceToken( $value_param['name_token'], 'data' );
 		}
 

--- a/Yoast/Tests/Utils/PSR4PathsTraitTest.php
+++ b/Yoast/Tests/Utils/PSR4PathsTraitTest.php
@@ -311,7 +311,7 @@ final class PSR4PathsTraitTest extends NonSniffTestCase {
 		$this->assertSame( $input['expected'], $this->validated_psr4_paths, 'Validated paths has not been set correctly' );
 
 		// Now make sure that the missing basepath resets the validated paths.
-		$phpcsFile->config->basepath = null;
+		$phpcsFile->config->basepath = null; // @phpstan-ignore assign.propertyType (Issue with the PHPCS docs. Can't be helped.)
 
 		$this->validate_psr4_paths( $phpcsFile );
 
@@ -331,7 +331,7 @@ final class PSR4PathsTraitTest extends NonSniffTestCase {
 		$phpcsFile->config->basepath = self::CLEAN_BASEPATH;
 
 		// PSR-4 paths contains the same path for two different prefixes.
-		$this->psr4_paths = [
+		$this->psr4_paths = [ // @phpstan-ignore assign.propertyType (This is exactly what we're testing)
 			'src',
 			'tests',
 		];

--- a/Yoast/Tests/Utils/PathHelperTest.php
+++ b/Yoast/Tests/Utils/PathHelperTest.php
@@ -238,6 +238,7 @@ final class PathHelperTest extends TestCase {
 	 * @return void
 	 */
 	public function test_trailingslashit( $input, $expected ) {
+		// @phpstan-ignore argument.type (This is exactly what we're testing.)
 		$this->assertSame( $expected, PathHelper::trailingslashit( $input ) );
 	}
 

--- a/Yoast/Utils/PSR4PathsTrait.php
+++ b/Yoast/Utils/PSR4PathsTrait.php
@@ -140,6 +140,7 @@ trait PSR4PathsTrait {
 		$validated_paths = [];
 
 		foreach ( $this->psr4_paths as $prefix => $paths ) {
+			// @phpstan-ignore function.alreadyNarrowedType, identical.alwaysFalse (Defensive coding as the property value is user provided via the ruleset.)
 			if ( \is_string( $prefix ) === false || $prefix === '' ) {
 				throw new RuntimeException(
 					'Invalid value passed for `psr4_paths`. Path "' . $paths . '" is not associated with a namespace prefix'

--- a/Yoast/Utils/PathHelper.php
+++ b/Yoast/Utils/PathHelper.php
@@ -74,6 +74,7 @@ final class PathHelper {
 	 * @return string
 	 */
 	public static function trailingslashit( $path ) {
+		// @phpstan-ignore function.alreadyNarrowedType (Defensive coding as the application is not type safe.)
 		if ( ! \is_string( $path ) || $path === '' ) {
 			return '';
 		}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,93 +10,29 @@ parameters:
 #	treatPhpDocTypesAsCertain: false
 #	reportUnmatchedIgnoredErrors: false
 	dynamicConstantNames:
+		- PHP_CODESNIFFER_VERBOSITY
 		- YOASTCS_ABOVE_THRESHOLD
 
 	ignoreErrors:
-		# Level 3
-		-
-			# This is an issue with the PHPCS docs. Can't be helped.
-			message: '`^Property PHP_CodeSniffer\\Config::\$basepath \(string\) does not accept null\.$`'
-			path: Yoast/Tests/Utils/PSR4PathsTraitTest.php
-			count: 1
-		-
-			# This is a test specifically checking the handling when an invalid value is passed, so this is okay.
-			message: '`^Property YoastCS\\Yoast\\Tests\\Utils\\PSR4PathsTraitTest::\$psr4_paths \(array\<string, string\>\) does not accept array\<int, string\>\.$`'
-			path: Yoast/Tests/Utils/PSR4PathsTraitTest.php
-			count: 1
-
 		# Level 4
 		-
 			# Bug in PHPStan: PHPStan doesn't seem to like uninitialized properties...
+			# https://github.com/phpstan/phpstan/issues/10305
 			message: '`^Property \S+Sniff::\$target_paths \(array<string, string>\) in isset\(\) is not nullable\.$`'
 			path: Yoast/Sniffs/Files/TestDoublesSniff.php
 			count: 1
-		-
-			# Defensive coding in the PSR4PathsTrait as the property value is user provided via the ruleset. This is okay.
-			message: '`^Strict comparison using === between true and false will always evaluate to false\.$`'
-			paths:
-				- Yoast/Sniffs/Files/FileNameSniff.php
-				- Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
-				- Yoast/Tests/Utils/PSR4PathsTraitTest.php
 
 		# Level 5
 		# We're not using strict types, so this will be juggled without any issues.
 		- '#^Parameter \#3 \$value of method \S+File::recordMetric\(\) expects string, \(?(float|int|bool)(<[^>]+>)?(\|(float|int|bool)(<[^>]+>)?)*\)? given\.$#'
 
-		# Level 7
+		# Level 8
+		# PHPStan (x2) being overzealous: preg_replace() will only return null if an error occured.
 		-
-			# False positive: the explode will never return `false` as it is never given an empty string separator.
-			message: '`^Parameter #2 \$array of function array_map expects array, array<int, string>\|false given\.$`'
-			path: Yoast/Sniffs/Commenting/CoversTagSniff.php
-			count: 1
-		-
-			# False positive: the preg_replace will never return `null` as the regex is valid.
 			message: '`^Parameter #1 \$str of function strtolower expects string, string\|null given\.$`'
 			path: Yoast/Sniffs/Files/FileNameSniff.php
 			count: 1
 		-
-			# False positive: the preg_replace will never return `null` as the regex is valid.
 			message: '`^Parameter #2 \$str of function explode expects string, string\|null given\.$`'
 			path: Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
 			count: 1
-		-
-			# False positive: the passed value will only ever be an integer, PHPStan just doesn't know the shape of the array.
-			message: '`^Binary operation "\+" between int\|string and 1 results in an error\.$`'
-			count: 2
-			path: Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
-		-
-			# False positive: the passed value will only ever be an integer, PHPStan just doesn't know the shape of the array.
-			message: '`^Parameter #2 \$start of method PHP_CodeSniffer\\Files\\File::findNext\(\) expects int, int\|string given\.$`'
-			count: 2
-			path: Yoast/Sniffs/NamingConventions/ValidHookNameSniff.php
-		-
-			# False positive: the passed value will only ever be an integer, PHPStan just doesn't know the shape of the array.
-			message: '`^Parameter #1 \$stackPtr of method PHP_CodeSniffer\\Fixer::replaceToken\(\) expects int, int\|string given\.$`'
-			path: Yoast/Sniffs/Yoast/JsonEncodeAlternativeSniff.php
-			count: 1
-		-
-			# This is a test specifically checking type handling, so this is okay.
-			message: '`^Parameter #1 \$path of static method YoastCS\\Yoast\\Utils\\PathHelper::trailingslashit\(\) expects string, bool\|string given\.$`'
-			path: Yoast/Tests/Utils/PathHelperTest.php
-			count: 1
-
-		# Not a real issue (x 4), PHPstan just doesn't know the format of the array well enough.
-		-
-			message: '`^Binary operation "\+" between int\|string and 1 results in an error\.$`'
-			count: 2
-			path: Yoast/Sniffs/Tools/BrainMonkeyRaceConditionSniff.php
-
-		-
-			message: '`^Parameter #2 \$start of method PHP_CodeSniffer\\Files\\File::findNext\(\) expects int, int\|string given\.$`'
-			count: 2
-			path: Yoast/Sniffs/Tools/BrainMonkeyRaceConditionSniff.php
-
-		-
-			message: '`^Binary operation "\+" between int\|string and 1 results in an error\.$`'
-			count: 1
-			path: Yoast/Sniffs/Yoast/JsonEncodeAlternativeSniff.php
-
-		-
-			message: '`^Parameter #2 \$start of method PHP_CodeSniffer\\Files\\File::findNext\(\) expects int, int\|string given\.$`'
-			count: 1
-			path: Yoast/Sniffs/Yoast/JsonEncodeAlternativeSniff.php


### PR DESCRIPTION
PHPStan 2.0 has been released.

This commit updates the PHPStan configuration file for use with PHPStan 2.0, moves a number of ignore rules over to inline ignores and switches the workflow to start using PHPStan 2.0.

Refs:
* https://phpstan.org/blog/phpstan-2-0-released-level-10-elephpants
* https://github.com/phpstan/phpstan/blob/2.0.x/UPGRADING.md
* https://github.com/phpstan/phpstan/releases/tag/2.0.0