### PR TITLE
YoastCS: update minimum support PHP version to 7.4

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -166,7 +166,7 @@
 	SNIFF FOR PHP CROSS-VERSION COMPATIBILITY
 	#############################################################################
 	-->
-	<config name="testVersion" value="7.2-"/>
+	<config name="testVersion" value="7.4-"/>
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php$</include-pattern>
 	</rule>


### PR DESCRIPTION
### YoastCS: update minimum support PHP version to 7.4

Part of https://github.com/Yoast/wordpress-seo/issues/21857