### PR TITLE
Update CS dependencies + add two new sniffs

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -246,6 +246,12 @@
 	<!-- CS/QA: Enforce static closures when a closure doesn't access $this. -->
 	<rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
 
+	<!-- CS/QA: Enforce using nowdocs instead of heredocs when there is no interpolation/expressions. -->
+	<rule ref="Generic.Strings.UnnecessaryHeredoc"/>
+
+	<!-- CS/QA: Enforce no space between the lt-chars and the heredoc/nowdoc identifier. -->
+	<rule ref="Generic.WhiteSpace.HereNowdocIdentifierSpacing"/>
+
 
 	<!--
 	#############################################################################

--- a/composer.json
+++ b/composer.json
@@ -26,20 +26,20 @@
 	"require": {
 		"php": ">=7.2",
 		"ext-tokenizer": "*",
-		"automattic/vipwpcs": "^3.0.0",
+		"automattic/vipwpcs": "^3.0.1",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
-		"phpcompatibility/phpcompatibility-wp": "^2.1.4",
+		"phpcompatibility/phpcompatibility-wp": "^2.1.6",
 		"phpcsstandards/phpcsextra": "^1.2.1",
-		"phpcsstandards/phpcsutils": "^1.0.10",
-		"sirbrillig/phpcs-variable-analysis": "^2.11.17",
+		"phpcsstandards/phpcsutils": "^1.0.12",
+		"sirbrillig/phpcs-variable-analysis": "^2.12.0",
 		"slevomat/coding-standard": "^8.15.0",
-		"squizlabs/php_codesniffer": "^3.9.1",
+		"squizlabs/php_codesniffer": "^3.12.0",
 		"wp-coding-standards/wpcs": "^3.1.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",
-		"phpcsstandards/phpcsdevtools": "^1.2.1",
+		"phpcsstandards/phpcsdevtools": "^1.2.2",
 		"phpunit/phpunit": "^8.0 || ^9.0",
 		"roave/security-advisories": "dev-master"
 	},


### PR DESCRIPTION
### Composer: update minimum version for CS dependencies 

This updates the minimum version of various CS dependencies to ensure the latest version will be used by users of this package.

Refs:
* https://github.com/phpcsStandards/PHP_CodeSniffer/releases
* https://github.com/phpcsStandards/phpcsutils/releases
* https://github.com/PHPCompatibility/PHPCompatibilityWP/releases
* https://github.com/automattic/VIP-Coding-Standards/releases
* https://github.com/sirbrillig/phpcs-variable-analysis/releases
* https://github.com/phpcsStandards/phpcsdevTools/releases

### YoastCS: add two new sniffs related to heredoc/nowdocs 

These two new sniffs were introduced in PHPCS 3.11.0.

* The `Generic.Strings.UnnecessaryHeredoc` sniff recommends using nowdoc syntax for heredocs which don't contain interpolation or expressions.
* The `Generic.WhiteSpace.HereNowdocIdentifierSpacing` sniff required that there is no space between the `<<<` and the heredoc/nowdoc identifier.

Both seem like useful additions to me.