### PR TITLE
Sets the minimum supported WordPress version to 6.7

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -56,7 +56,7 @@
 			 Ref: https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
 		-->
 		<properties>
-			<property name="minimum_wp_version" value="6.6"/>
+			<property name="minimum_wp_version" value="6.7"/>
 		</properties>
 
 		<!-- No need for this sniff as every Yoast travis script includes linting all files. -->


### PR DESCRIPTION
Adapted changelog from the last bump:
* PHPCS: The default value for the `minimum_wp_version` property which is used by various WPCS sniffs has been updated to WP `6.7` (was `6.6`).

Fixes https://github.com/Yoast/reserved-tasks/issues/704