### PR TITLE
Composer: remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",
 		"phpcsstandards/phpcsdevtools": "^1.2.2",
-		"phpunit/phpunit": "^8.0 || ^9.0",
-		"roave/security-advisories": "dev-master"
+		"phpunit/phpunit": "^8.0 || ^9.0"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,


### PR DESCRIPTION
The `roave/security-advisories` package was an inventive method to block installation of known insecure versions of other dependencies (via a `conflict` annotation).

As of Composer 2.9, using the `roave/security-advisories` package for this purpose is no longer needed as Composer will now natively block installation of known insecure versions of dependencies.

And while not all contributors to this repo may be using Composer 2.9+ (yet), Composer 2.9+ **_will_** be used in CI and CI failing on Composer blocking an insecure dependency offers the same level of protection as the package previously offered.

Refs:
* https://blog.packagist.com/composer-2-9/
* https://github.com/composer/composer/releases/tag/2.9.0