### PR TITLE
PHPStan: minor tweaks

### DIFF
--- a/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
+++ b/Yoast/Sniffs/NamingConventions/NamespaceNameSniff.php
@@ -424,7 +424,7 @@ final class NamespaceNameSniff implements Sniff {
 		$this->validated_src_directory = [];
 
 		// Note: the check whether a basepath is available is done in the main `process()` routine.
-		$base_path = PathHelper::normalize_absolute_path( $phpcsFile->config->basepath );
+		$base_path = PathHelper::normalize_absolute_path( $phpcsFile->config->basepath ); // @phpstan-ignore argument.type
 
 		// Add any src directories.
 		$absolute_paths = PathValidationHelper::relative_to_absolute( $phpcsFile, $this->src_directory );

--- a/Yoast/Tests/Utils/PSR4PathsTraitTest.php
+++ b/Yoast/Tests/Utils/PSR4PathsTraitTest.php
@@ -311,7 +311,7 @@ final class PSR4PathsTraitTest extends NonSniffTestCase {
 		$this->assertSame( $input['expected'], $this->validated_psr4_paths, 'Validated paths has not been set correctly' );
 
 		// Now make sure that the missing basepath resets the validated paths.
-		$phpcsFile->config->basepath = null; // @phpstan-ignore assign.propertyType (Issue with the PHPCS docs. Can't be helped.)
+		$phpcsFile->config->basepath = null;
 
 		$this->validate_psr4_paths( $phpcsFile );
 


### PR DESCRIPTION
Like is often the case, new PHPStan versions fix some false positives and may add some others.

These tweaks should allow the build to pass again with the current PHPStan version.