### PR TITLE
GH Actions: update for PHPCS branch rename

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -47,7 +47,7 @@ jobs:
       - name: 'Composer: adjust dependencies - use dev versions of CS dependencies'
         run: >
           composer require --no-update --no-scripts --no-interaction
-          squizlabs/php_codesniffer:"dev-master"
+          squizlabs/php_codesniffer:"3.x-dev"
           phpcsstandards/phpcsutils:"dev-develop"
           phpcsstandards/phpcsextra:"dev-develop"
           wp-coding-standards/wpcs:"dev-develop as 3.99" # Alias needed to prevent composer conflict with VIPCS.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -60,7 +60,7 @@ jobs:
         if: ${{ matrix.cs_dependencies == 'dev' }}
         run: >
           composer require --no-update --no-scripts --no-interaction
-          squizlabs/php_codesniffer:"dev-master"
+          squizlabs/php_codesniffer:"3.x-dev"
           phpcsstandards/phpcsutils:"dev-develop"
           wp-coding-standards/wpcs:"dev-develop as 3.99" # Alias needed to prevent composer conflict with VIPCS.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PHPCS_HIGHEST: 'dev-master'
+  PHPCS_HIGHEST: '3.x-dev'
   UTILS_HIGHEST: 'dev-develop'
   WPCS_HIGHEST: 'dev-develop as 3.99' # Alias needed to prevent composer conflict with VIPCS.
 


### PR DESCRIPTION
The "main" branch for the PHPCS repo is currently `4.x`, with the branch for the previous major being called `3.x`.
The `master` branch has been removed.