### PR TITLE
GH Actions: minor tweak

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,8 @@ jobs:
       - name: Install Composer dependencies - normal
         uses: ramsey/composer-install@v3
         with:
+          # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
+          composer-options: ${{ matrix.php_version == 'nightly' && '--ignore-platform-req=php+' || '' }}
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 


### PR DESCRIPTION
Prevent builds failing on upcoming PHP versions due to dependencies not allowing for a new PHP version (yet).