### PR TITLE
GH Actions: update PHP ini configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,9 +115,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.cs_dependencies }}" != "dev" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, display_startup_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
+            echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install PHP


### PR DESCRIPTION
Follow up on #406, which missed updating one ini setting toggle.

Add `display_startup_errors=On` as per the current recommendation from PHPUnit.

Ref:
* https://github.com/sebastianbergmann/phpunit-documentation-english/commit/b3b159cbe9bd7eb5656dd381fc6f028549601dce
* https://docs.phpunit.de/en/12.5/installation.html#configuring-php-for-development