### PR TITLE
GH Actions: fail "setup-php" if requested tooling could not be installed

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -39,6 +39,8 @@ jobs:
           php-version: 'latest'
           coverage: none
           tools: cs2pr
+        env:
+          fail-fast: true
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate
@@ -158,6 +160,8 @@ jobs:
           php-version: 'latest'
           coverage: none
           tools: phpstan:2.x
+        env:
+          fail-fast: true
 
       # Install dependencies and handle caching in one go.
       # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -57,6 +57,8 @@ jobs:
           php-version: ${{ matrix.php_version }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
+        env:
+          fail-fast: true
 
       - name: "Composer: set PHPCS dependencies for tests (dev)"
         if: ${{ matrix.cs_dependencies == 'dev' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,8 @@ jobs:
           ini-file: 'development'
           coverage: none
           tools: cs2pr
+        env:
+          fail-fast: true
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
@@ -126,6 +128,8 @@ jobs:
           php-version: ${{ matrix.php_version }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
+        env:
+          fail-fast: true
 
       - name: "Composer: set PHPCS dependencies for tests (dev)"
         if: ${{ matrix.cs_dependencies == 'dev' }}
@@ -208,6 +212,8 @@ jobs:
           php-version: ${{ matrix.php_version }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
+        env:
+          fail-fast: true
 
       - name: "Composer: set PHPCS dependencies for tests (dev)"
         if: ${{ matrix.cs_dependencies == 'dev' }}


### PR DESCRIPTION
Setup-PHP will normally "gracefully" show a warning and not the build when an extension or tool failed to install.

This is not particularly useful as that means that either there will be a failure later on in the build due to the extension or tool missing, or the build will not be representative of what is supposed to be tested.

This commit changes this behaviour to fail the build at the `setup-php` step, which also makes debugging these type of build failures much more straight-forward.

Ref: https://github.com/shivammathur/setup-php?tab=readme-ov-file#fail-fast-optional