### PR TITLE
GH Actions: pin re-usable workflows too

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   actionlint:
     name: 'Lint GH Action workflows'
-    uses: Yoast/.github/.github/workflows/reusable-actionlint.yml@main
+    uses: Yoast/.github/.github/workflows/reusable-actionlint.yml@c14f66005ab514663a48d00712db67617c98728c # v1.0.0
 
   checkcs:
     name: 'Basic CS and QA checks'

--- a/.github/workflows/merge-conflict-check.yml
+++ b/.github/workflows/merge-conflict-check.yml
@@ -18,4 +18,4 @@ jobs:
     if: github.repository_owner == 'Yoast'
 
     name: Check PRs for merge conflicts
-    uses: Yoast/.github/.github/workflows/reusable-merge-conflict-check.yml@main
+    uses: Yoast/.github/.github/workflows/reusable-merge-conflict-check.yml@c14f66005ab514663a48d00712db67617c98728c # v1.0.0


### PR DESCRIPTION
Follow up on #409, which added commit hash pinning to all externally managed action runners, this commit now also adds this to the re-usable workflows managed in the `Yoast/.github` repository.