### PR TITLE
Composer: bump various dependencies + minor ruleset updates to match

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -246,12 +246,6 @@
 	<!-- CS/QA: Enforce static closures when a closure doesn't access $this. -->
 	<rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
 
-	<!-- CS/QA: Enforce using nowdocs instead of heredocs when there is no interpolation/expressions. -->
-	<rule ref="Generic.Strings.UnnecessaryHeredoc"/>
-
-	<!-- CS/QA: Enforce no space between the lt-chars and the heredoc/nowdoc identifier. -->
-	<rule ref="Generic.WhiteSpace.HereNowdocIdentifierSpacing"/>
-
 
 	<!--
 	#############################################################################

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -246,6 +246,12 @@
 	<!-- CS/QA: Enforce static closures when a closure doesn't access $this. -->
 	<rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
 
+	<!-- CS/QA: Forbid referencing true/false/null in fully qualified form. -->
+	<rule ref="Universal.PHP.NoFQNTrueFalseNull"/>
+
+	<!-- Demand a trailing comma for multi-line, multi-attribute attribute blocks, forbid otherwise. -->
+	<rule ref="Universal.Attributes.TrailingComma"/>
+
 
 	<!--
 	#############################################################################

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.6",
-		"phpcsstandards/phpcsextra": "^1.2.1",
+		"phpcsstandards/phpcsextra": "^1.5.0",
 		"phpcsstandards/phpcsutils": "^1.0.12",
 		"sirbrillig/phpcs-variable-analysis": "^2.13.0",
 		"slevomat/coding-standard": "^8.15.0",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"sirbrillig/phpcs-variable-analysis": "^2.13.0",
 		"slevomat/coding-standard": "^8.15.0",
 		"squizlabs/php_codesniffer": "^3.12.0",
-		"wp-coding-standards/wpcs": "^3.1.0"
+		"wp-coding-standards/wpcs": "^3.3.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"phpcompatibility/phpcompatibility-wp": "^2.1.6",
 		"phpcsstandards/phpcsextra": "^1.2.1",
 		"phpcsstandards/phpcsutils": "^1.0.12",
-		"sirbrillig/phpcs-variable-analysis": "^2.12.0",
+		"sirbrillig/phpcs-variable-analysis": "^2.13.0",
 		"slevomat/coding-standard": "^8.15.0",
 		"squizlabs/php_codesniffer": "^3.12.0",
 		"wp-coding-standards/wpcs": "^3.1.0"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",
-		"phpcsstandards/phpcsdevtools": "^1.2.2",
+		"phpcsstandards/phpcsdevtools": "^1.2.3",
 		"phpunit/phpunit": "^8.5.50 || ^9.6.31"
 	},
 	"minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.3.5",
 		"phpcsstandards/phpcsdevtools": "^1.2.2",
-		"phpunit/phpunit": "^8.0 || ^9.0"
+		"phpunit/phpunit": "^8.5.50 || ^9.6.31"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,


### PR DESCRIPTION
### Composer: bump PHPUnit 

... to versions compatible with the latest PHP releases.

### Composer: bump PHPCSDevTools 

... to a version which is cross-version compatible with PHPCS 3.x as well as 4.x.

Ref:
* https://github.com/PHPCSStandards/PHPCSDevTools/releases/tag/1.2.3

### Composer: bump VariableAnalysis 

... to a version which is cross-version compatible with PHPCS 3.x as well as 4.x.

Ref:
* https://github.com/sirbrillig/phpcs-variable-analysis/releases/tag/v2.13.0

### Composer: bump WordPressCS 

WordPressCS is not yet compatible with PHPCS 4.x, but has released two new versions which we should still take advantage of.

Includes removing two sniffs from the YoastCS ruleset, which YoastCS will now "inherit" from WordPressCS, which now also includes these sniffs.

Ref:
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.2.0
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.3.0

### Composer: use PHPExtra 1.5.0 

PHPCSExtra has had several releases and is currently compatible with both PHPCS 3.x as well as 4.x.

Aside from this cross-version compatibility, bumping PHPCSExtra to the 1.5.0 release will also give us access to a number of new sniffs, some of which we should probably start using.

This commit adds two of the new sniffs to YoastCS.
Two additional new sniffs from PHPCSExtra 1.5.0 have gone into WordPressCS 3.3.0 and will be inherited from WPCS.

Refs:
* https://github.com/PHPCSStandards/PHPCSExtra/releases/