### PR TITLE
Sets the minimum supported WordPress version to 6.8

### DIFF
--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -56,7 +56,7 @@
 			 Ref: https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
 		-->
 		<properties>
-			<property name="minimum_wp_version" value="6.7"/>
+			<property name="minimum_wp_version" value="6.8"/>
 		</properties>
 
 		<!-- No need for this sniff as every Yoast travis script includes linting all files. -->


### PR DESCRIPTION
* PHPCS: The default value for the minimum_wp_version property which is used by various WPCS sniffs has been updated to WP 6.8 (was 6.7).