### PR TITLE
Composer: use PHPCompatibility 10.0.0-alpha

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -64,6 +64,22 @@
 		 polyfilled functionality from not being flagged in this repo. -->
 	<rule ref="PHPCompatibility">
 		<severity>5</severity>
+
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_bad_characterFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_fnFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_attributeFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_matchFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_nullsafe_object_operatorFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_name_fully_qualifiedFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_name_qualifiedFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_name_relativeFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_readonlyFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_enumFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_public_setFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_protected_setFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_private_setFound"/>
+		<exclude name="PHPCompatibility.Constants.RemovedConstants.t_bad_characterFound"/>
 	</rule>
 
 	<!-- Enforce PSR1 compatible namespaces. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+### [3.4.0] - 2026-02-20
+
+#### Changed
+* Composer: Supported version of [PHPCompatibilityWP] has been changed from `^2.1.6` to `^3.0.0@alpha`.
+    This allows for installing the much, much improved PHPCompatibility 10.0.0 (prerelease).
+    To do so, the `composer.json` file of packages requiring this package must have `"minimum-stability": "dev"` or `"alpha"` (or other tweaks which net the same effect).
+
+
 ### [3.3.0] - 2026-02-04
 
 #### Added
@@ -673,6 +681,7 @@ Initial public release as a stand-alone package.
 [PHP Parallel Lint]:             https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases
 [PHP Console Highlighter]:       https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases
 
+[3.4.0]: https://github.com/Yoast/yoastcs/compare/3.3.0...3.4.0
 [3.3.0]: https://github.com/Yoast/yoastcs/compare/3.2.0...3.3.0
 [3.2.0]: https://github.com/Yoast/yoastcs/compare/3.1.0...3.2.0
 [3.1.0]: https://github.com/Yoast/yoastcs/compare/3.0.0...3.1.0

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"automattic/vipwpcs": "^3.0.1",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
-		"phpcompatibility/phpcompatibility-wp": "^2.1.6",
+		"phpcompatibility/phpcompatibility-wp": "^3.0.0@alpha",
 		"phpcsstandards/phpcsextra": "^1.5.0",
 		"phpcsstandards/phpcsutils": "^1.0.12",
 		"sirbrillig/phpcs-variable-analysis": "^2.13.0",
@@ -38,7 +38,7 @@
 		"wp-coding-standards/wpcs": "^3.3.0"
 	},
 	"require-dev": {
-		"phpcompatibility/php-compatibility": "^9.3.5",
+		"phpcompatibility/php-compatibility": "^10.0.0@alpha",
 		"phpcsstandards/phpcsdevtools": "^1.2.3",
 		"phpunit/phpunit": "^8.5.50 || ^9.6.31"
 	},


### PR DESCRIPTION
PHPCompatibility has, at long last, tagged a 10.0 release, even though still in alpha. PHPCompatibility 10.0.0-alpha1 is cross-version compatible with PHPCS 3.x as well as 4.x.

We really should upgrade to benefit from the > 50 new sniffs and other improvements in this version.

The PHPCompatibilityWP package has received a corresponding 3.0.0-alpha1 tag.

Note: for the plugins to be able to install with these dev versions, they need to have `minimum-stability: dev` enabled in their `composer.json`.

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility/wiki/Upgrading-to-PHPCompatibility-10.0
* https://github.com/PHPCompatibility/PHPCompatibilityWP/releases/tag/3.0.0-alpha1
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/10.0.0-alpha1