### PR TITLE
PHPCS: bug fix - prevent error for property which is not always available (incl changelog 3.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+### [3.4.1] - 2026-03-03
+
+#### Fixed
+* PHPCS: a PHPCS run with the SlevomatCodingStandard locked at a version below 8.17.0 would error out on a "ERROR: Property "checkIfConditions" does not exist" error.
+
 ### [3.4.0] - 2026-02-20
 
 #### Changed
@@ -681,6 +686,7 @@ Initial public release as a stand-alone package.
 [PHP Parallel Lint]:             https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases
 [PHP Console Highlighter]:       https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases
 
+[3.4.1]: https://github.com/Yoast/yoastcs/compare/3.4.0...3.4.1
 [3.4.0]: https://github.com/Yoast/yoastcs/compare/3.3.0...3.4.0
 [3.3.0]: https://github.com/Yoast/yoastcs/compare/3.2.0...3.3.0
 [3.2.0]: https://github.com/Yoast/yoastcs/compare/3.1.0...3.2.0

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -471,11 +471,7 @@
 
 	<!-- Modernize: Enforce the use of the null coalesce operator (PHP 7.0+) and null coalesce equals (PHP 7.4+) in select circumstances. -->
 	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
-	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator">
-		<properties>
-			<property name="checkIfConditions" value="true"/>
-		</properties>
-	</rule>
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
 
 	<!-- Modernize: Enforce a trailing comma after the last parameter in a multi-line function call (PHP 7.3+). -->
 	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>


### PR DESCRIPTION
Turns out the `checkIfConditions` property for the `SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator` sniff is only available as of Slevomat 8.17.0.

As Slevomat raised their minimum PHP version to PHP 7.4 in v 8.16.0 and this package still supports a minimum of PHP 7.2, the version constraint for the Slevomat dependency cannot be changed for the time being.

If we set the property directly on the sniff (like originally done), PHPCS will error out with the following error message when run with Slevomat < 8.17.0:
```
ERROR: Property "checkIfConditions" does not exist on sniff SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator.
```

So, even though the property is useful for those Yoast packages which can run with a higher Slevomat version (i.e. all packages which have a PHP 7.4 minimum and no conflicting dependencies), we unfortunately cannot (yet) set it by default.

Ref:
* slevomat/coding-standard@2031373
* https://github.com/slevomat/coding-standard/releases/tag/8.17.0