### PR TITLE
Release 3.4.1

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -10,13 +10,14 @@ Release checklist
     - [ ] Move anything that is still open in the current milestone to the new `Next release` milestone.
 - [ ] Verify that any PR merged since the last release has a milestone attached to it.
 - [ ] Create a changelog based on everything in the milestone, pull the changelog changes & merge the PR.
-  Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
+    Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
 - [ ] Double-check that nothing was merged into the `main` branch.
     - If there are unreleased commits in `main`, merge `main` into `develop` or cherrypick the commits from main into the `develop` branch.
 
 ## Release
 
 - [ ] Open a PR to merge the `develop` branch to `main`.
+    - Pro-tip: use this release checklist as the PR description to document that this release checklist has been followed.
 - [ ] Merge that PR once all CI checks have passed.
 - [ ] Create a release on GitHub, also creating a new tag (targeting `main`) in the process, and copy & paste the changelog to it.
     - Add/edit the relevant links to the bottom of the changelog to make sure all texts between `[]` in changelog entries become links.
@@ -27,8 +28,8 @@ Release checklist
 
 ## Announce
 
-- [ ] Add a message to the `#yoastcs` Slack channel on the [Yoast Slack](https://yoast.slack.com/) to announce the new release:
-```
-We just released YoastCS x.y.z
-Changelog: https://github.com/Yoast/yoastcs/releases/tag/x.y.z
-```
+- [ ] Post a message in the `#yoastcs` Slack channel on the [Yoast Slack](https://yoast.slack.com/) to announce the new release:
+    ```
+    We just released YoastCS x.y.z
+    Changelog: https://github.com/Yoast/yoastcs/releases/tag/x.y.z
+    ```

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -1,0 +1,65 @@
+Release checklist
+===========================================================
+
+## Pre-release
+
+- [ ] If no upcoming versioned milestone exists:
+    - [ ] Determine what the version number should be for the release and rename the `Next release` milestone to that version number.
+        This project uses [semantic versioning](https://semver.org/) to determine the version of the next release.
+    - [ ] Move anything that is still open in the `Next release` milestone to a new `Next release` milestone.
+
+## Release
+
+- [ ] Checkout `develop`:
+    ```bash
+    git checkout develop
+    ```
+- [ ] Make sure the branch is up to date with `main`:
+    ```bash
+    git merge origin/main
+    ```
+- [ ] Update version, date and add changelog entries in `CHANGELOG.md`.
+    - Guidelines: [Keep a CHANGELOG](https://keepachangelog.com/).
+    - Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
+- [ ] Push branch to origin:
+    ```bash
+    git push origin develop
+    ```
+- [ ] Make sure all CI builds are green.
+- [ ] Check out the `main` branch:
+    ```bash
+    git checkout main
+    ```
+- [ ] Merge `develop` into `main`:
+    ```bash
+    git merge --no-ff develop
+    ```
+- [ ] Create a new tag:
+    ```bash
+    git tag -a [new-version]
+    ```
+- [ ] Push the commit and tag to the remote:
+    ```bash
+    git push origin main --tags
+    ```
+- [ ] Create a new release on GitHub and add the changelog entry to it.
+    - Add the relevant links to the bottom of the changelog to make sure all texts between `[]` in changelog entries become links. 
+      - For example: `[PHP_CodeSniffer]` only becomes a link when `[PHP_CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer/releases` is present as well.
+- [ ] Merge `main` into `develop`:
+    ```bash
+    git checkout develop
+    git merge origin/main
+    git push origin develop
+    ```
+- [ ] Close the milestone.
+- [ ] Create a new `Next release` milestone if it does not yet exist.
+- [ ] If any open PRs/issues that were milestoned for the release did not make it into the release, update their milestone.
+
+## Announce
+
+- [ ] Celebrate the new release 🎉
+- [ ] Add a message to the `#yoastcs` Slack channel on the [Yoast Slack](https://yoast.slack.com/) to announce the new release:
+```
+We just released YoastCS x.y.z
+Changelog: https://github.com/Yoast/yoastcs/releases/tag/x.y.z
+```

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -6,22 +6,23 @@ Release checklist
 - [ ] If no upcoming versioned milestone exists, and there are merged PRs in the `Next release` milestone:
     - [ ] Determine what the version number should be for the release and rename the `Next release` milestone to that version number.
       This project uses [semantic versioning](https://semver.org/) to determine the version of the next release.
-    - [ ] Move anything that is still open in the `Next release` milestone to a new `Next release` milestone.
+    - [ ] Create a new "Next release" milestone for the release _after_ this one.
+    - [ ] Move anything that is still open in the current milestone to the new `Next release` milestone.
 - [ ] Verify that any PR merged since the last release has a milestone attached to it.
 - [ ] Create a changelog based on everything in the milestone, pull the changelog changes & merge the PR.
   Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
-- [ ] Make sure that `develop` is ahead of `main`.
-  - If not, merge `main` into `develop` or fast-forward `develop` to be equal to `main`.
+- [ ] Double-check that nothing was merged into the `main` branch.
+    - If there are unreleased commits in `main`, merge `main` into `develop` or cherrypick the commits from main into the `develop` branch.
 
 ## Release
 
 - [ ] Open a PR to merge the `develop` branch to `main`.
 - [ ] Merge that PR once all CI checks have passed.
-- [ ] Create a release on GitHub, also creating a new tab (targeting `main`) in the process, and copy & paste the changelog to it.
-  - Add/edit the relevant links to the bottom of the changelog to make sure all texts between `[]` in changelog entries become links.
+- [ ] Create a release on GitHub, also creating a new tag (targeting `main`) in the process, and copy & paste the changelog to it.
+    - Add/edit the relevant links to the bottom of the changelog to make sure all texts between `[]` in changelog entries become links.
     - For example: `[PHP_CodeSniffer]` only becomes a link when `[PHP_CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer/releases` is present as well.
 - [ ] Publish the release.
-- [ ] Merge the `main` branch into `develop`.
+- [ ] Fast-forward `develop` to `main`.
 - [ ] Close the milestone.
 - [ ] Open a new milestone for the next release.
 - [ ] If any open PRs/issues which were milestoned for the release did not make it into the release, update their milestone.

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -3,61 +3,31 @@ Release checklist
 
 ## Pre-release
 
-- [ ] If no upcoming versioned milestone exists:
+- [ ] If no upcoming versioned milestone exists, and there are merged PRs in the `Next release` milestone:
     - [ ] Determine what the version number should be for the release and rename the `Next release` milestone to that version number.
-        This project uses [semantic versioning](https://semver.org/) to determine the version of the next release.
+      This project uses [semantic versioning](https://semver.org/) to determine the version of the next release.
     - [ ] Move anything that is still open in the `Next release` milestone to a new `Next release` milestone.
+- [ ] Verify that any PR merged since the last release has a milestone attached to it.
+- [ ] Create a changelog based on everything in the milestone, pull the changelog changes & merge the PR.
+  Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
+- [ ] Make sure that `develop` is ahead of `main`.
+  - If not, merge `main` into `develop` or fast-forward `develop` to be equal to `main`.
 
 ## Release
 
-- [ ] Checkout `develop`:
-    ```bash
-    git checkout develop
-    ```
-- [ ] Make sure the branch is up to date with `main`:
-    ```bash
-    git merge origin/main
-    ```
-- [ ] Update version, date and add changelog entries in `CHANGELOG.md`.
-    - Guidelines: [Keep a CHANGELOG](https://keepachangelog.com/).
-    - Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
-- [ ] Push branch to origin:
-    ```bash
-    git push origin develop
-    ```
-- [ ] Make sure all CI builds are green.
-- [ ] Check out the `main` branch:
-    ```bash
-    git checkout main
-    ```
-- [ ] Merge `develop` into `main`:
-    ```bash
-    git merge --no-ff develop
-    ```
-- [ ] Create a new tag:
-    ```bash
-    git tag -a [new-version]
-    ```
-- [ ] Push the commit and tag to the remote:
-    ```bash
-    git push origin main --tags
-    ```
-- [ ] Create a new release on GitHub and add the changelog entry to it.
-    - Add the relevant links to the bottom of the changelog to make sure all texts between `[]` in changelog entries become links. 
-      - For example: `[PHP_CodeSniffer]` only becomes a link when `[PHP_CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer/releases` is present as well.
-- [ ] Merge `main` into `develop`:
-    ```bash
-    git checkout develop
-    git merge origin/main
-    git push origin develop
-    ```
+- [ ] Open a PR to merge the `develop` branch to `main`.
+- [ ] Merge that PR once all CI checks have passed.
+- [ ] Create a release on GitHub, also creating a new tab (targeting `main`) in the process, and copy & paste the changelog to it.
+  - Add/edit the relevant links to the bottom of the changelog to make sure all texts between `[]` in changelog entries become links.
+    - For example: `[PHP_CodeSniffer]` only becomes a link when `[PHP_CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer/releases` is present as well.
+- [ ] Publish the release.
+- [ ] Merge the `main` branch into `develop`.
 - [ ] Close the milestone.
-- [ ] Create a new `Next release` milestone if it does not yet exist.
-- [ ] If any open PRs/issues that were milestoned for the release did not make it into the release, update their milestone.
+- [ ] Open a new milestone for the next release.
+- [ ] If any open PRs/issues which were milestoned for the release did not make it into the release, update their milestone.
 
 ## Announce
 
-- [ ] Celebrate the new release 🎉
 - [ ] Add a message to the `#yoastcs` Slack channel on the [Yoast Slack](https://yoast.slack.com/) to announce the new release:
 ```
 We just released YoastCS x.y.z

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -24,8 +24,6 @@ Release checklist
 - [ ] Publish the release.
 - [ ] Fast-forward `develop` to `main`.
 - [ ] Close the milestone.
-- [ ] Open a new milestone for the next release.
-- [ ] If any open PRs/issues which were milestoned for the release did not make it into the release, update their milestone.
 
 ## Announce
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+### [3.4.1] - 2026-03-03
+
+#### Fixed
+* PHPCS: a PHPCS run with the SlevomatCodingStandard locked at a version below 8.17.0 would error out on a "ERROR: Property "checkIfConditions" does not exist" error.
+
 ### [3.4.0] - 2026-02-20
 
 #### Changed
@@ -681,6 +686,7 @@ Initial public release as a stand-alone package.
 [PHP Parallel Lint]:             https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases
 [PHP Console Highlighter]:       https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases
 
+[3.4.1]: https://github.com/Yoast/yoastcs/compare/3.4.0...3.4.1
 [3.4.0]: https://github.com/Yoast/yoastcs/compare/3.3.0...3.4.0
 [3.3.0]: https://github.com/Yoast/yoastcs/compare/3.2.0...3.3.0
 [3.2.0]: https://github.com/Yoast/yoastcs/compare/3.1.0...3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -669,15 +669,15 @@ Initial public release as a stand-alone package.
 
 [PHP_CodeSniffer]:               https://github.com/PHPCSStandards/PHP_CodeSniffer/releases
 [Composer PHPCS plugin]:         https://github.com/PHPCSStandards/composer-installer/releases
-[PHPCompatibilityWP]:            https://github.com/PHPCompatibility/PHPCompatibilityWP#changelog
-[PHPCompatibility]:              https://github.com/PHPCompatibility/PHPCompatibility/blob/master/CHANGELOG.md
+[PHPCompatibilityWP]:            https://github.com/PHPCompatibility/PHPCompatibilityWP/releases
+[PHPCompatibility]:              https://github.com/PHPCompatibility/PHPCompatibility/releases
 [PHPCSUtils]:                    https://github.com/PHPCSStandards/PHPCSUtils/releases
 [PHPCSExtra]:                    https://github.com/PHPCSStandards/PHPCSExtra/releases
 [SlevomatCodingStandard]:        https://github.com/slevomat/coding-standard/releases
 [VariableAnalysis]:              https://github.com/sirbrillig/phpcs-variable-analysis/releases
-[WordPressCS]:                   https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/CHANGELOG.md
+[WordPressCS]:                   https://github.com/WordPress/WordPress-Coding-Standards/releases
 [WordPressVIP Coding Standards]: https://github.com/Automattic/VIP-Coding-Standards/releases
-[PHP Mess Detector]:             https://github.com/phpmd/phpmd/blob/master/CHANGELOG
+[PHP Mess Detector]:             https://github.com/phpmd/phpmd/releases
 [PHP Parallel Lint]:             https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases
 [PHP Console Highlighter]:       https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases
 

--- a/Yoast/ruleset.xml
+++ b/Yoast/ruleset.xml
@@ -471,11 +471,7 @@
 
 	<!-- Modernize: Enforce the use of the null coalesce operator (PHP 7.0+) and null coalesce equals (PHP 7.4+) in select circumstances. -->
 	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
-	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator">
-		<properties>
-			<property name="checkIfConditions" value="true"/>
-		</properties>
-	</rule>
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
 
 	<!-- Modernize: Enforce a trailing comma after the last parameter in a multi-line function call (PHP 7.3+). -->
 	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>


### PR DESCRIPTION
## Pre-release

- [x] If no upcoming versioned milestone exists, and there are merged PRs in the `Next release` milestone:
    - [x] Determine what the version number should be for the release and rename the `Next release` milestone to that version number.
      This project uses [semantic versioning](https://semver.org/) to determine the version of the next release.
    - [x] Create a new "Next release" milestone for the release _after_ this one.
    - [x] Move anything that is still open in the current milestone to the new `Next release` milestone.
- [x] Verify that any PR merged since the last release has a milestone attached to it.
- [x] Create a changelog based on everything in the milestone, pull the changelog changes & merge the PR. - PR #428
    Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
- [x] Double-check that nothing was merged into the `main` branch.
    - If there are unreleased commits in `main`, merge `main` into `develop` or cherrypick the commits from main into the `develop` branch.

## Release

- [x] Open a PR to merge the `develop` branch to `main`.
    - Pro-tip: use this release checklist as the PR description to document that this release checklist has been followed.
- [x] Merge that PR once all CI checks have passed.
- [x] Create a release on GitHub, also creating a new tag (targeting `main`) in the process, and copy & paste the changelog to it.
    - Add/edit the relevant links to the bottom of the changelog to make sure all texts between `[]` in changelog entries become links.
    - For example: `[PHP_CodeSniffer]` only becomes a link when `[PHP_CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer/releases` is present as well.
- [x] Publish the release.
- [x] Fast-forward `develop` to `main`.
- [x] Close the milestone.

## Announce

- [x] Post a message in the `#yoastcs` Slack channel on the [Yoast Slack](https://yoast.slack.com/) to announce the new release:
    ```
    We just released YoastCS x.y.z
    Changelog: https://github.com/Yoast/yoastcs/releases/tag/x.y.z
    ```